### PR TITLE
Remove cmp=True from APIVersion

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -10,7 +10,7 @@ import attr
 # for a field (False, 0, empty string, enum with value 0, ...)
 
 
-@attr.s(cmp=True)
+@attr.s
 class APIVersion:
     major = attr.ib(type=int, default=0)
     minor = attr.ib(type=int, default=0)


### PR DESCRIPTION
Setting `cmp` has been deprecated and split into `order` and `eq`. Using `cmp=True` prints a warning. Both `order` and `eq` are `True` by default so we don't need to replace the `cmp=True` usage.

See also 19.2.0 changelog http://www.attrs.org/en/19.2.0/changelog.html#deprecations