### PR TITLE
Avoid a jump to the executor to validate an ip address string

### DIFF
--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -37,6 +37,14 @@ def _bytes_to_varuint(value: bytes) -> Optional[int]:
 
 async def resolve_ip_address_getaddrinfo(eventloop: asyncio.events.AbstractEventLoop,
                                          host: str, port: int) -> Tuple[Any, ...]:
+
+    try:
+        socket.inet_aton(host)
+    except OSError:
+        pass
+    else:
+        return (host, port)
+
     try:
         res = await eventloop.getaddrinfo(host, port, family=socket.AF_INET,
                                           proto=socket.IPPROTO_TCP)


### PR DESCRIPTION
Avoids executor overload on Home Assistant startup

2021-02-13 18:31:38 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.211.201', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.210.102', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.211.180', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.210.100', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.214.225', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.213.240', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.213.168', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.210.29', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.250', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.214.56', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:31:51 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.137', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:32:04 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:32:14 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:32:23 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:32:58 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:33:10 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}
2021-02-13 18:33:19 DEBUG (MainThread) [homeassistant.runner] Calling executor with function: <function getaddrinfo at 0x7f00184c8ca0>, args: ('10.45.209.89', 6053, <AddressFamily.AF_INET: 2>, 0, 6, 0), kwargs: {}