### PR TITLE
Fix bad default values in model

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -100,7 +100,7 @@ class FanInfo(EntityInfo):
     supports_oscillation = attr.ib(type=bool, default=False)
     supports_speed = attr.ib(type=bool, default=False)
     supports_direction = attr.ib(type=bool, default=False)
-    supported_speed_levels = attr.ib(type=int, default=3)
+    supported_speed_levels = attr.ib(type=int, default=0)
 
 
 class FanSpeed(enum.IntEnum):
@@ -284,7 +284,7 @@ class ClimateState(EntityState):
     target_temperature_high = attr.ib(type=float, default=0.0)
     away = attr.ib(type=bool, default=False)
     fan_mode = attr.ib(
-        type=ClimateFanMode, converter=ClimateFanMode, default=ClimateFanMode.AUTO
+        type=ClimateFanMode, converter=ClimateFanMode, default=ClimateFanMode.ON
     )
     swing_mode = attr.ib(
         type=ClimateSwingMode, converter=ClimateSwingMode, default=ClimateSwingMode.OFF


### PR DESCRIPTION
See note at top of file:

```
# All fields in here should have defaults set
# Home Assistant depends on these fields being constructible
# with args from a previous version of Home Assistant.
# The default value should *always* be the Protobuf default value
# for a field (False, 0, empty string, enum with value 0, ...)
```

The `default` arg is really just there for HA to be able to restore `info` items from the json storage.

For protobuf messages it's ignored because protobuf treats lack of a field as 0, and so when the instance is constructed it gets passed 0
