### PR TITLE
Fix bad typing for LogLevel

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1,6 +1,17 @@
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import attr
 import zeroconf
@@ -36,7 +47,6 @@ from aioesphomeapi.api_pb2 import (  # type: ignore
     ListEntitiesServicesResponse,
     ListEntitiesSwitchResponse,
     ListEntitiesTextSensorResponse,
-    LogLevel,
     SensorStateResponse,
     SubscribeHomeassistantServicesRequest,
     SubscribeHomeAssistantStateResponse,
@@ -84,6 +94,9 @@ from aioesphomeapi.model import (
     UserServiceArg,
     UserServiceArgType,
 )
+
+if TYPE_CHECKING:
+    from aioesphomeapi.api_pb2 import LogLevel  # type: ignore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -289,7 +302,7 @@ class APIClient:
     async def subscribe_logs(
         self,
         on_log: Callable[[SubscribeLogsResponse], None],
-        log_level: Optional['LogLevel'] = None,
+        log_level: Optional["LogLevel"] = None,
     ) -> None:
         self._check_authenticated()
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -289,7 +289,7 @@ class APIClient:
     async def subscribe_logs(
         self,
         on_log: Callable[[SubscribeLogsResponse], None],
-        log_level: Optional[LogLevel] = None,
+        log_level: Optional['LogLevel'] = None,
     ) -> None:
         self._check_authenticated()
 


### PR DESCRIPTION
Not sure how this happened, but the `Optional[LogLevel]` is throwing an error because LogLevel is not a type and isn't accepted by `Optional`.

```
  File ".../aioesphomeapi/client.py", line 292, in APIClient
    log_level: Optional[LogLevel] = None,
  File "/usr/lib/python3.9/typing.py", line 268, in inner
    return func(*args, **kwds)
  File "/usr/lib/python3.9/typing.py", line 345, in __getitem__
    return self._getitem(self, parameters)
  File "/usr/lib/python3.9/typing.py", line 468, in Optional
    arg = _type_check(parameters, f"{self} requires a single type.")
  File "/usr/lib/python3.9/typing.py", line 157, in _type_check
    raise TypeError(f"{msg} Got {arg!r:.100}.")
TypeError: typing.Optional requires a single type. Got <google.protobuf.internal.enum_type_wrapper.EnumTypeWrapper object at 0x7f5f545e0940>.
```