### PR TITLE
Dataclasses better legacy UserService compat

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -485,9 +485,11 @@ class UserServiceArg(APIModelBase):
         ret = []
         for x in value:
             if isinstance(x, dict):
-                ret.append(UserServiceArg(x["name"], x["type"]))
+                if "type_" in x and "type" not in x:
+                    x = {**x, "type": x["type_"]}
+                ret.append(UserServiceArg.from_dict(x))
             else:
-                ret.append(UserServiceArg(x.name, x.type))
+                ret.append(UserServiceArg.from_pb(x))
         return ret
 
 


### PR DESCRIPTION
In https://github.com/esphome/aioesphomeapi/pull/36 I renamed `type_` in UserServiceArg to `type` (to match what's in the protobuf definition).

Unfortunately, this rename meant that HA upgrades would have trouble restoring the services (assuming `bool` as the arg type), until the device reconnects; that's a minor annoyance at best, but we can still improve it easily.