### PR TITLE
Rename image field to data to match the proto field

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -286,7 +286,7 @@ class CameraInfo(EntityInfo):
 
 @dataclass(frozen=True)
 class CameraState(EntityState):
-    image: bytes = field(default_factory=bytes)
+    data: bytes = field(default_factory=bytes)
 
 
 # ==================== CLIMATE ====================


### PR DESCRIPTION
Fixes an issue with the field in proto and dataclass being different for the camera image.

Related: home-assistant/core#52718


Major bump as this is renaming the field