### PR TITLE
Fix camera not merging packets

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -274,7 +274,8 @@ class APIClient:
             if isinstance(msg, CameraImageResponse):
                 data = image_stream.pop(msg.key, bytes()) + msg.data
                 if msg.done:
-                    on_state(CameraState.from_pb(msg))
+                    # Return CameraState with the merged data
+                    on_state(CameraState(key=msg.key, data=data))
                 else:
                     image_stream[msg.key] = data
                 return


### PR DESCRIPTION
Bug originally introduced here: https://github.com/esphome/aioesphomeapi/pull/36/files#diff-753f76689d07a39d2daa897bd6416dcb0546b60d15c3a944768fa4b8a75fd869L287

This fix fixed the protobuf->dataclass conversion: https://github.com/esphome/aioesphomeapi/pull/62/files but was incomplete.

For `on_state` we need to return the _merged_ data across the different image responses received.

Related: https://github.com/home-assistant/core/issues/52770