### PR TITLE
Allow dispatching the protoc build workflow manually

### DIFF
--- a/.github/workflows/protoc-update.yml
+++ b/.github/workflows/protoc-update.yml
@@ -3,6 +3,7 @@ name: Update protobuf generated files
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   protoc-update:


### PR DESCRIPTION
See failed run: https://github.com/esphome/aioesphomeapi/actions/runs/1079468748

The update workflow cannot run after release-drafter bumps the version