### PR TITLE
Fix old lights with color temperature but no white support

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -254,6 +254,7 @@ class LightInfo(EntityInfo):
                 (True, False, False, True): [LightColorMode.COLOR_TEMPERATURE],
                 (True, True, False, False): [LightColorMode.RGB],
                 (True, True, True, False): [LightColorMode.RGB_WHITE],
+                (True, True, False, True): [LightColorMode.RGB_COLOR_TEMPERATURE],
                 (True, True, True, True): [LightColorMode.RGB_COLOR_TEMPERATURE],
             }
 


### PR DESCRIPTION
ESPHome never supported this, and no built-in lights used this, but apparently it was used by third-party components. Without this fix, those lights would show up as on-off lights in HA. Make them RGBCT lights, which doesn't fit perfectly as they don't expect a white value, but they already had that in pre-2021.8 HA anyway and it's better than being totally broken.