### PR TITLE
Support for old zeroconfs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 protobuf>=3.12.2,<4.0
-zeroconf>=0.32.0,<1.0
+zeroconf>=0.28.0,<1.0

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -1,3 +1,4 @@
+import asyncio
 import socket
 
 import pytest
@@ -45,8 +46,9 @@ async def test_resolve_host_zeroconf(async_zeroconf, addr_infos):
     ]
     async_zeroconf.async_get_service_info = AsyncMock(return_value=info)
     async_zeroconf.async_close = AsyncMock()
+    loop = asyncio.get_event_loop()
 
-    ret = await hr._async_resolve_host_zeroconf("asdf", 6052)
+    ret = await hr._async_resolve_host_zeroconf(loop, "asdf", 6052)
 
     async_zeroconf.async_get_service_info.assert_called_once_with(
         "_esphomelib._tcp.local.", "asdf._esphomelib._tcp.local.", 3000
@@ -60,8 +62,9 @@ async def test_resolve_host_zeroconf(async_zeroconf, addr_infos):
 async def test_resolve_host_zeroconf_empty(async_zeroconf):
     async_zeroconf.async_get_service_info = AsyncMock(return_value=None)
     async_zeroconf.async_close = AsyncMock()
+    loop = asyncio.get_event_loop()
 
-    ret = await hr._async_resolve_host_zeroconf("asdf.local", 6052)
+    ret = await hr._async_resolve_host_zeroconf(loop, "asdf.local", 6052)
     assert ret == []
 
 
@@ -103,9 +106,10 @@ async def test_resolve_host_getaddrinfo_oserror():
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = addr_infos
-    ret = await hr.async_resolve_host(None, "example.local", 6052)
+    loop = asyncio.get_event_loop()
+    ret = await hr.async_resolve_host(loop, "example.local", 6052)
 
-    resolve_zc.assert_called_once_with("example", 6052, zeroconf_instance=None)
+    resolve_zc.assert_called_once_with(loop, "example", 6052, zeroconf_instance=None)
     resolve_addr.assert_not_called()
     assert ret == addr_infos[0]
 
@@ -116,10 +120,11 @@ async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = []
     resolve_addr.return_value = addr_infos
-    ret = await hr.async_resolve_host(None, "example.local", 6052)
+    loop = asyncio.get_event_loop()
+    ret = await hr.async_resolve_host(loop, "example.local", 6052)
 
-    resolve_zc.assert_called_once_with("example", 6052, zeroconf_instance=None)
-    resolve_addr.assert_called_once_with(None, "example.local", 6052)
+    resolve_zc.assert_called_once_with(loop, "example", 6052, zeroconf_instance=None)
+    resolve_addr.assert_called_once_with(loop, "example.local", 6052)
     assert ret == addr_infos[0]
 
 


### PR DESCRIPTION
I want to switch esphome to use aioesphomeapi internally.

Unfortunately, that's currently not possible because aioesphomeapi requires zeroconf>=0.32.0, but esphome has it pinned at `0.28.8` at the moment (https://github.com/platformio/platformio-core/pull/3991)

So until PIO releases an update, we need to support older zeroconfs again