### PR TITLE
Emit different Exception types to differentiate between connection errors

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -1,6 +1,16 @@
 # flake8: noqa
 from .client import APIClient
 from .connection import APIConnection, ConnectionParams
-from .core import MESSAGE_TYPE_TO_PROTO, APIConnectionError
+from .core import (
+    MESSAGE_TYPE_TO_PROTO,
+    APIConnectionError,
+    HandshakeAPIError,
+    InvalidAuthAPIError,
+    InvalidEncryptionKeyAPIError,
+    ProtocolAPIError,
+    RequiresEncryptionAPIError,
+    ResolveAPIError,
+    SocketAPIError,
+)
 from .model import *
 from .reconnect_logic import ReconnectLogic

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -139,7 +139,8 @@ class APIClient:
             client_info=client_info,
             keepalive=keepalive,
             zeroconf_instance=zeroconf_instance,
-            noise_psk=noise_psk,
+            # treat empty psk string as missing (like password)
+            noise_psk=noise_psk or None,
         )
         self._connection: Optional[APIConnection] = None
         self._cached_name: Optional[str] = None

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -63,6 +63,34 @@ class APIConnectionError(Exception):
     pass
 
 
+class InvalidAuthAPIError(APIConnectionError):
+    pass
+
+
+class ResolveAPIError(APIConnectionError):
+    pass
+
+
+class ProtocolAPIError(APIConnectionError):
+    pass
+
+
+class RequiresEncryptionAPIError(ProtocolAPIError):
+    pass
+
+
+class SocketAPIError(APIConnectionError):
+    pass
+
+
+class HandshakeAPIError(APIConnectionError):
+    pass
+
+
+class InvalidEncryptionKeyAPIError(HandshakeAPIError):
+    pass
+
+
 MESSAGE_TYPE_TO_PROTO = {
     1: HelloRequest,
     2: HelloResponse,

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     ZC_ASYNCIO = False
 
-from .core import APIConnectionError
+from .core import APIConnectionError, ResolveAPIError
 
 ZeroconfInstanceType = Union[zeroconf.Zeroconf, "zeroconf.asyncio.AsyncZeroconf", None]
 
@@ -56,7 +56,7 @@ def _sync_zeroconf_get_service_info(
         try:
             zc = zeroconf.Zeroconf()
         except Exception:
-            raise APIConnectionError(
+            raise ResolveAPIError(
                 "Cannot start mDNS sockets, is this a docker container without "
                 "host network mode?"
             )
@@ -72,7 +72,7 @@ def _sync_zeroconf_get_service_info(
     try:
         info = zc.get_service_info(service_type, service_name, int(timeout * 1000))
     except Exception as exc:
-        raise APIConnectionError(
+        raise ResolveAPIError(
             f"Error resolving mDNS {service_name} via mDNS: {exc}"
         ) from exc
     finally:
@@ -105,7 +105,7 @@ async def _async_zeroconf_get_service_info(
         try:
             zc = zeroconf.asyncio.AsyncZeroconf()
         except Exception:
-            raise APIConnectionError(
+            raise ResolveAPIError(
                 "Cannot start mDNS sockets, is this a docker container without "
                 "host network mode?"
             )
@@ -126,7 +126,7 @@ async def _async_zeroconf_get_service_info(
             service_type, service_name, int(timeout * 1000)
         )
     except Exception as exc:
-        raise APIConnectionError(
+        raise ResolveAPIError(
             f"Error resolving mDNS {service_name} via mDNS: {exc}"
         ) from exc
     finally:
@@ -240,9 +240,7 @@ async def async_resolve_host(
         if zc_error:
             # Only show ZC error if getaddrinfo also didn't work
             raise zc_error
-        raise APIConnectionError(
-            f"Could not resolve host {host} - got no results from OS"
-        )
+        raise ResolveAPIError(f"Could not resolve host {host} - got no results from OS")
 
     # Use first matching result
     # Future: return all matches and use first working one


### PR DESCRIPTION
For the HA implementation of transport encryption I needed to differentiate between different connection error types (couldn't resolve address, requires encryption, etc). Previously this was checked by comparing the stringified error, but we needed a better solution.

Additionally add `_read_exception_handlers` so that exception that are thrown in the read loop are directly communicated to tasks waiting for a response (previously they would just wait until they time out, then notice the disconnect)