### PR TITLE
fixes connection isssue#87

### DIFF
--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -186,7 +186,9 @@ async def _async_resolve_host_getaddrinfo(
 ) -> List[AddrInfo]:
     try:
         # Limit to TCP IP protocol and SOCK_STREAM
-        res = await eventloop.getaddrinfo(host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP)
+        res = await eventloop.getaddrinfo(
+            host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
+        )     
     except OSError as err:
         raise APIConnectionError("Error resolving IP address: {}".format(err))
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -185,8 +185,8 @@ async def _async_resolve_host_getaddrinfo(
     eventloop: asyncio.events.AbstractEventLoop, host: str, port: int
 ) -> List[AddrInfo]:
     try:
-        # Limit to TCP IP protocol
-        res = await eventloop.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+        # Limit to TCP IP protocol and SOCK_STREAM
+        res = await eventloop.getaddrinfo(host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP)
     except OSError as err:
         raise APIConnectionError("Error resolving IP address: {}".format(err))
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -188,7 +188,7 @@ async def _async_resolve_host_getaddrinfo(
         # Limit to TCP IP protocol and SOCK_STREAM
         res = await eventloop.getaddrinfo(
             host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
-        )     
+        )
     except OSError as err:
         raise APIConnectionError("Error resolving IP address: {}".format(err))
 


### PR DESCRIPTION
Fixes the connection error under Windows : https://github.com/esphome/aioesphomeapi/issues/87
SOCK_STREAM is required anyways so make sure we get only SOCK_STREAM back from getaddrinfo
