### PR TITLE
Fix plaintext logs unexpected when handled

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -509,7 +509,6 @@ class APIConnection:
         return res[0]
 
     async def _run_once(self) -> None:
-        assert self._frame_helper is not None
         pkt = await self._frame_helper.read_packet()
 
         msg_type = pkt.type
@@ -534,6 +533,9 @@ class APIConnection:
 
     async def run_forever(self) -> None:
         while True:
+            if self._frame_helper is None:
+                # Socket closed
+                break
             try:
                 await self._run_once()
             except APIConnectionError as err:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -511,6 +511,7 @@ class APIConnection:
         return res[0]
 
     async def _run_once(self) -> None:
+        assert self._frame_helper is not None
         pkt = await self._frame_helper.read_packet()
 
         msg_type = pkt.type

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -571,7 +571,7 @@ class APIConnection:
 
     async def ping(self) -> None:
         self._check_connected()
-        await self.send_message_await_response(PingRequest(), PingResponse, timeout=20)
+        await self.send_message_await_response(PingRequest(), PingResponse)
 
     async def _disconnect(self) -> None:
         self._check_connected()

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -220,7 +220,9 @@ class APIFrameHelper:
                 preamble = await self._reader.readexactly(1)
                 if preamble[0] != 0x00:
                     if preamble[0] == 0x01:
-                        raise RequiresEncryptionAPIError("Connection requires encryption")
+                        raise RequiresEncryptionAPIError(
+                            "Connection requires encryption"
+                        )
                     raise ProtocolAPIError(f"Invalid preamble {preamble[0]:02x}")
 
                 length = b""


### PR DESCRIPTION
Looks like I forgot to copy some code over from the noise implementation.

Specifically the try-except block for catching incomplete read errors is missing; it's responsible for catching incomplete read errors and converting it to SocketAPIErrors