### PR TITLE
Fix write_packet error not re-raised

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -546,6 +546,7 @@ class APIConnection:
             # If writing packet fails, we don't know what state the frames
             # are in anymore and we have to close the connection
             await self._report_fatal_error(err)
+            raise
 
     async def send_message_callback_response(
         self, send_msg: message.Message, on_message: Callable[[Any], None]


### PR DESCRIPTION
Small thing I missed in https://github.com/esphome/aioesphomeapi/pull/108

(Not found during testing because `_report_fatal_error` will set the error when reading the response, but still better to raise directly)