### PR TITLE
Fix wrapping native RequiresEncryption error types

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -583,9 +583,10 @@ class APIConnection:
 
         def on_read_exception(exc: Exception) -> None:
             if not fut.done():
-                # Wrap error so that caller gets right stacktrace
-                new_exc = ReadFailedAPIError("Read failed")
-                new_exc.__cause__ = exc
+                new_exc = exc
+                if not isinstance(exc, APIConnectionError):
+                    new_exc = ReadFailedAPIError("Read failed")
+                    new_exc.__cause__ = exc
                 fut.set_exception(new_exc)
 
         self._message_handlers.append(on_message)


### PR DESCRIPTION
A regression in https://github.com/esphome/aioesphomeapi/pull/108 :face_with_head_bandage: 

Some errors in the read task (among others, `RequiresEncryptionAPIError`) should _not_ be wrapped in `ReadFailedError`

Noticed this while looking into https://github.com/home-assistant/core/issues/56915 (note that the issue here is unrelated). The effect is that already _configured_ devices work fine, but setting up new ones doesn't because the appropriate exception isn't propagated to the config flow.

Side note: While we already do have more test coverage for model/client, the connection class does not. When I get time I will add some tests that would have caught this issue (should be easier now with the refactor)