### PR TITLE
Apply float fix for all float attributes

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -357,9 +357,7 @@ class SensorInfo(EntityInfo):
 
 @dataclass(frozen=True)
 class SensorState(EntityState):
-    state: float = converter_field(
-        default=0.0, converter=fix_float_single_double_conversion
-    )
+    state: float = 0.0
     missing_state: bool = False
 
 


### PR DESCRIPTION
Noticed another place where we'd need rounding: NumberInfo `min`/`max`, otherwise the input is broken when used a max like `3.3`

Recap: over the wire it gets sent as 32-bit float, but python only has 64-bit floats, so it gets converted. but that conversion rounds to the nearest 64-bit float, not the nearest decimal. That adds a bunch of random digits to the end of the number if representing a decimal value.