### PR TITLE
Fix Dockerfile missing libprotobuf-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         protobuf-compiler=3.12.4-1 \
+        libprotobuf-dev=3.12.4-1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \


### PR DESCRIPTION
Without this some builtin protobuf messages appear not to work

```
google/protobuf/descriptor.proto: File not found.
api_options.proto:2:1: Import "google/protobuf/descriptor.proto" was not found or had errors.
api_options.proto:13:8: "google.protobuf.MethodOptions" is not defined.
api_options.proto: "google.protobuf.MethodOptions" is not defined.
api_options.proto:18:8: "google.protobuf.MessageOptions" is not defined.
api_options.proto: "google.protobuf.MessageOptions" is not defined.
api_options.proto: "google.protobuf.MessageOptions" is not defined.
api_options.proto: "google.protobuf.MessageOptions" is not defined.
api_options.proto: "google.protobuf.MessageOptions" is not defined.
api.proto:3:1: Import "api_options.proto" was not found or had errors.
api.proto:25:52: "void" is not defined.
api.proto:26:58: "void" is not defined.
api.proto:27:54: "void" is not defined.
api.proto:28:89: "void" is not defined.
api.proto:29:86: "void" is not defined.
api.proto:33:56: "void" is not defined.
api.proto:35:52: "void" is not defined.
api.proto:36:48: "void" is not defined.
api.proto:37:52: "void" is not defined.
api.proto:38:54: "void" is not defined.
api.proto:39:50: "void" is not defined.
api.proto:40:56: "void" is not defined.
api.proto:41:54: "void" is not defined.
api.proto:42:54: "void" is not defined.
api.proto:43:52: "void" is not defined.
```