### PR TITLE
Catch conn reset

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -66,7 +66,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 _LOGGER.debug("Sending plaintext frame %s", data.hex())
                 self._writer.write(data)
                 await self._writer.drain()
-        except OSError as err:
+        except (ConnectionResetError, OSError) as err:
             raise SocketAPIError(f"Error while writing data: {err}") from err
 
     async def read_packet(self) -> Packet:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -336,7 +336,7 @@ class APIConnection:
                     data=encoded,
                 )
             )
-        except Exception as err:  # pylint: disable=broad-except
+        except SocketAPIError as err:  # pylint: disable=broad-except
             # If writing packet fails, we don't know what state the frames
             # are in anymore and we have to close the connection
             await self._report_fatal_error(err)


### PR DESCRIPTION
Small changes to exception handling to try and address an error seen a few times recently. Unable to do much beyond basic tests due complexity of reproducing :-( Error reproduced below.

Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/_frame_helper.py", line 68, in write_packet
    await self._writer.drain()
  File "/usr/local/lib/python3.9/asyncio/streams.py", line 387, in drain
    await self._protocol._drain_helper()
  File "/usr/local/lib/python3.9/asyncio/streams.py", line 190, in _drain_helper
    raise ConnectionResetError('Connection lost')
ConnectionResetError: Connection lost

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/reconnect_logic.py", line 121, in _try_connect
    await self._cli.connect(on_stop=self._on_disconnect, login=True)
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/client.py", line 176, in connect
    await self._connection.connect(login=login)
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/connection.py", line 262, in connect
    await self._connect_hello()
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/connection.py", line 189, in _connect_hello
    resp = await self.send_message_await_response(hello, HelloResponse)
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/connection.py", line 411, in send_message_await_response
    res = await self.send_message_await_response_complex(
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/connection.py", line 389, in send_message_await_response_complex
    await self.send_message(send_msg)
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/connection.py", line 333, in send_message
    await self._frame_helper.write_packet(
  File "/usr/local/lib/python3.9/site-packages/aioesphomeapi/_frame_helper.py", line 70, in write_packet
    raise SocketAPIError(f"Error while writing data: {err}") from err
aioesphomeapi.core.SocketAPIError: Error while writing data: Connection lost
