### PR TITLE
Increase ListEntitiesRequest timeout to 30 seconds

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -282,7 +282,7 @@ class APIClient:
 
         assert self._connection is not None
         resp = await self._connection.send_message_await_response_complex(
-            ListEntitiesRequest(), do_append, do_stop, timeout=5
+            ListEntitiesRequest(), do_append, do_stop, timeout=30
         )
         entities: List[EntityInfo] = []
         services: List[UserService] = []


### PR DESCRIPTION
I have device with lots of sensors, I often get timeout error when loading initial data:

```
Error getting initial data for powermon2.local: Timeout waiting for response for <class 'api_pb2.ListEntitiesRequest'>
```

Even with good Wi-Fi signal, 5 seconds certainty not enough for devices with lots of sensors.
Even the `send_message_await_response_complex` function has default timeout of 10 seconds, what is the reasoning of short timeout for ListEntitiesRequest?