### PR TITLE
Add async-timeout to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 protobuf>=3.12.2,<4.0
 zeroconf>=0.36.0,<1.0
 noiseprotocol>=0.3.1,<1.0
+async-timeout>=4.0


### PR DESCRIPTION
Based on the history of commits #243 introduced a dependency on
async-timeout but missed adding it to the requirements.txt,
leading to exceptions when trying to use the module in a fresh
environment.
