### PR TITLE
Add esp ble error code mappings

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from .ble_defs import ESP_CONNECTION_ERROR_DESCRIPTION, BLEConnectionError
 from .client import APIClient
 from .connection import APIConnection, ConnectionParams
 from .core import (

--- a/aioesphomeapi/ble_defs.py
+++ b/aioesphomeapi/ble_defs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class BLEConnectionError(IntEnum):
+    """BLE Connection Error."""
+
+    ESP_GATT_CONN_UNKNOWN = 0
+    ESP_GATT_CONN_L2C_FAILURE = 1
+    ESP_GATT_CONN_TIMEOUT = 0x08
+    ESP_GATT_CONN_TERMINATE_PEER_USER = 0x13
+    ESP_GATT_CONN_TERMINATE_LOCAL_HOST = 0x16
+    ESP_GATT_CONN_FAIL_ESTABLISH = 0x3E
+    ESP_GATT_CONN_LMP_TIMEOUT = 0x22
+    ESP_GATT_CONN_CONN_CANCEL = 0x0100
+    ESP_GATT_CONN_NONE = 0x0101
+
+
+ESP_CONNECTION_ERROR_DESCRIPTION = {
+    BLEConnectionError.ESP_GATT_CONN_UNKNOWN: "Connection failed for unknown reason",
+    BLEConnectionError.ESP_GATT_CONN_L2C_FAILURE: "Connection failed due to L2CAP failure",
+    BLEConnectionError.ESP_GATT_CONN_TIMEOUT: "Connection failed due to timeout",
+    BLEConnectionError.ESP_GATT_CONN_TERMINATE_PEER_USER: "Connection terminated by peer user",
+    BLEConnectionError.ESP_GATT_CONN_TERMINATE_LOCAL_HOST: "Connection terminated by local host",
+    BLEConnectionError.ESP_GATT_CONN_FAIL_ESTABLISH: "Connection failed to establish",
+    BLEConnectionError.ESP_GATT_CONN_LMP_TIMEOUT: "Connection failed due to LMP response timeout",
+    BLEConnectionError.ESP_GATT_CONN_CONN_CANCEL: "Connection cancelled",
+    BLEConnectionError.ESP_GATT_CONN_NONE: "No connection to cancel",
+}


### PR DESCRIPTION
Not 100% sure this is the best place to put/format them, but seems better to live here than HA

Ideally we can provide a better error code than

`2022-10-25 09:42:33.737 DEBUG (MainThread) [bleak_retry_connector] VOCOlinc-VS1-185620 [E5:AB:B3:23:65:23] (id=E4:2F:25:E5:71:C5) - E5:AB:B3:23:65:23: Failed to connect: Error while connecting: 62, backing off: 0.1 (attempt: 2, last rssi: -62)`
`2022-10-25 09:42:47.406 DEBUG (MainThread) [bleak_retry_connector]  (D1:FB:3B:74:C8:90) - D1:FB:3B:74:C8:90: Failed to connect: Error while connecting: 19, backing off: 0.1 (attempt: 2, last rssi: -35)`