### PR TITLE
Fix race while disconnecting after connect timeout

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -484,10 +484,11 @@ class APIClient:
                 await event.wait()
         except asyncio.TimeoutError as err:
             unsub()
+            # Disconnect before raising the exception to ensure
+            # the slot is recovered before the timeout is raised
+            # to avoid race were we run out even though we have a slot.
+            await self.bluetooth_device_disconnect(address)
             raise TimeoutAPIError("Timeout waiting for connect response") from err
-        finally:
-            if not event.is_set():
-                await self.bluetooth_device_disconnect(address)
 
         return unsub
 


### PR DESCRIPTION
We need to disconnect before raising the TimeoutAPIError to ensure the slot is recovered before the caller gets the exception and tries again