### PR TITLE
Fix BLE writes timing out

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -531,7 +531,7 @@ class APIClient:
             # to avoid race were we run out even though we have a slot.
             await self.bluetooth_device_disconnect(address)
             raise TimeoutAPIError(
-                f"Timeout waiting for connect response while connecting to {to_human_readable_address(address)}"
+                f"Timeout waiting for connect response while connecting to {to_human_readable_address(address)} after {timeout}s"
             ) from err
 
         return unsub
@@ -613,7 +613,7 @@ class APIClient:
         handle: int,
         data: bytes,
         response: bool,
-        timeout: float = 10.0,
+        timeout: float = DEFAULT_BLE_TIMEOUT,
     ) -> None:
         req = BluetoothGATTWriteRequest()
         req.address = address
@@ -656,7 +656,7 @@ class APIClient:
         address: int,
         handle: int,
         data: bytes,
-        timeout: float = 10.0,
+        timeout: float = DEFAULT_BLE_TIMEOUT,
     ) -> None:
         req = BluetoothGATTWriteDescriptorRequest()
         req.address = address

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -469,7 +469,7 @@ class APIConnection:
                 await fut
         except asyncio.TimeoutError as err:
             raise TimeoutAPIError(
-                f"Timeout waiting for response for {type(send_msg)}"
+                f"Timeout waiting for response for {type(send_msg)} after {timeout}s"
             ) from err
         finally:
             with suppress(ValueError):


### PR DESCRIPTION
The GATT writes were not using the DEFAULT_BLE_TIMEOUT. When a HomeKit device pairs it can take a while to respond due to the encryption. We need to wait at least 30s

Also logs how long the timeout was when we raise