### PR TITLE
Catch error when task is stopped

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -531,7 +531,10 @@ class APIConnection:
                 # Socket closed but task isn't cancelled yet
                 break
 
-            msg = await self._to_process.get()
+            try:
+                msg = await self._to_process.get()
+            except RuntimeError:
+                break
 
             for handler in self._message_handlers[:]:
                 handler(msg)


### PR DESCRIPTION
```
Task was destroyed but it is pending!
task: <Task pending name='Task-57' coro=<APIConnection._process_loop() running at /workspaces/aioesphomeapi/aioesphomeapi/connection.py:534> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Exception ignored in: <coroutine object APIConnection._process_loop at 0x7f784a916110>
Traceback (most recent call last):
  File "/workspaces/aioesphomeapi/aioesphomeapi/connection.py", line 534, in _process_loop
    msg = await self._to_process.get()
  File "/usr/local/lib/python3.10/asyncio/queues.py", line 161, in get
    getter.cancel()  # Just in case getter is not done yet.
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 753, in call_soon
    self._check_closed()
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```