### PR TITLE
Increase timeout while waiting for ListEntities to be done

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -321,7 +321,7 @@ class APIClient:
 
         assert self._connection is not None
         resp = await self._connection.send_message_await_response_complex(
-            ListEntitiesRequest(), do_append, do_stop, timeout=30
+            ListEntitiesRequest(), do_append, do_stop, timeout=60
         )
         entities: List[EntityInfo] = []
         services: List[UserService] = []


### PR DESCRIPTION
I do not think there is any harm in increasing this timeout. This helps when a single ESPHome device has very many entities. 