### PR TITLE
Reduce number of calls to readexactly

### DIFF
--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -23,9 +23,9 @@ def bytes_to_varuint(value: bytes) -> Optional[int]:
     bitpos = 0
     for val in value:
         result |= (val & 0x7F) << bitpos
-        bitpos += 7
         if (val & 0x80) == 0:
             return result
+        bitpos += 7
     return None
 
 


### PR DESCRIPTION
Since each message must be at least 3 bytes we now try to read the the first 3 bytes intead of 1,1,1.  We only do additional reads when the message type or length exceeds 1 byte.

This reduces the number of readexactly calls

Went from 25000 to 9000 per minute so nice improvement