### PR TITLE
Callback messages to listeners by type

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -78,8 +78,7 @@ class APIModelBase:
 
     @classmethod
     def from_pb(cls: Type[_V], data: Any) -> _V:
-        init_args = {f.name: getattr(data, f.name) for f in fields(cls)}
-        return cls(**init_args)
+        return cls(**{f.name: getattr(data, f.name) for f in fields(cls)})
 
 
 def converter_field(*, converter: Callable[[Any], _V], **kwargs: Any) -> _V:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,7 +57,7 @@ def auth_client():
 
 
 def patch_response_complex(client: APIClient, messages):
-    async def patched(req, app, stop, timeout=5.0):
+    async def patched(req, app, stop, msg_types, timeout=5.0):
         resp = []
         for msg in messages:
             if app(msg):
@@ -74,7 +74,7 @@ def patch_response_complex(client: APIClient, messages):
 def patch_response_callback(client: APIClient):
     on_message = None
 
-    async def patched(req, callback):
+    async def patched(req, callback, msg_types):
         nonlocal on_message
         on_message = callback
 


### PR DESCRIPTION
~~Needs https://github.com/esphome/aioesphomeapi/pull/327~~

Previously every listener had to get every bluetooth advertisment message and than reject it.  Refactor subscribing to message types so we only get callbacks for message types we want so every callback does not need to reject messages it doesn't want (ie bluetooth advs)

This was particularly slow when with a lot of gatt notifies setup because it had to callback each one and reject (which later turned out to be even worse because of a leak https://github.com/esphome/aioesphomeapi/pull/329)