### PR TITLE
Add method to cancel bluetooth_gatt_start_notify upon ble device disconnect

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -731,7 +731,17 @@ class APIClient:
         address: int,
         handle: int,
         on_bluetooth_gatt_notify: Callable[[int, bytearray], None],
-    ) -> Callable[[], Coroutine[Any, Any, None]]:
+    ) -> Tuple[Callable[[], Coroutine[Any, Any, None]], Callable[[], None]]:
+        """Start a notify session for a GATT characteristic.
+
+        Returns two functions that can be used to stop the notify.
+
+        The first function is a coroutine that can be awaited to stop the notify.
+
+        The second function is a callback that can be called to remove the notify
+        callbacks without stopping the notify session on the remote device, which
+        should be used when the connection is lost.
+        """
 
         await self._send_bluetooth_message_await_response(
             address,
@@ -761,7 +771,7 @@ class APIClient:
                 BluetoothGATTNotifyRequest(address=address, handle=handle, enable=False)
             )
 
-        return stop_notify
+        return stop_notify, remove_callback
 
     async def subscribe_home_assistant_states(
         self, on_state_sub: Callable[[str, Optional[str]], None]


### PR DESCRIPTION
`bluetooth_gatt_start_notify` would leak since there was no way to cancel it when the device disconnected. This lead to a build up of notify callbacks over time. Since all listeners have to reject each callback this made the code slower and slower as each notify listener was built up until the system became sluggish from 1000s of notify callbacks that had to be enumerated and rejected

Needed for https://github.com/home-assistant/core/pull/83106

https://github.com/esphome/aioesphomeapi/pull/328 refactors to prevent the linear searching of callbacks

BREAKING CHANGE: `bluetooth_gatt_start_notify` has changed:

        Returns two functions that can be used to stop the notify.
        The first function is a coroutine that can be awaited to stop the notify.
        The second function is a callback that can be called to remove the notify
        callbacks without stopping the notify session on the remote device, which
        should be used when the connection is lost.