### PR TITLE
Handle socket reset errors while reading

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -21,6 +21,13 @@ from .util import bytes_to_varuint, varuint_to_bytes
 
 _LOGGER = logging.getLogger(__name__)
 
+SOCKET_ERRORS = (
+    ConnectionResetError,
+    asyncio.IncompleteReadError,
+    OSError,
+    TimeoutError,
+)
+
 
 @dataclass
 class Packet:
@@ -143,7 +150,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
             data = await self._reader.readexactly(length_int)
             return Packet(type=msg_type_int, data=data)
-        except (asyncio.IncompleteReadError, OSError, TimeoutError) as err:
+        except SOCKET_ERRORS as err:
             if (
                 isinstance(err, asyncio.IncompleteReadError)
                 and self._closed_event.is_set()
@@ -227,7 +234,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 raise ProtocolAPIError(f"Marker byte invalid: {header[0]}")
             msg_size = (header[1] << 8) | header[2]
             frame = await self._reader.readexactly(msg_size)
-        except (asyncio.IncompleteReadError, OSError, TimeoutError) as err:
+        except SOCKET_ERRORS as err:
             if (
                 isinstance(err, asyncio.IncompleteReadError)
                 and self._closed_event.is_set()


### PR DESCRIPTION
related issue https://github.com/home-assistant/core/issues/83212

If the esp crashes and reconnects we will get a ConnectionResetError since we will still be holding the connection to the esp when it went offline. When it comes back up it will send a RST when we try to talk to it again after it soft reset since we are talking over a connection it thinks is closed.  This only happens if it reboots and comes back up before we timeout from the ping failing 

hopefully the crash that was triggering this is fixed in https://github.com/esphome/esphome/pull/4140