### PR TITLE
Simplify connection flow with an asyncio.Protocol

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -197,19 +197,22 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     return
                 msg_type += add_msg_type
 
-            length_int = bytes_to_varuint(length)
+            length_int = bytes_to_varuint(bytes(length))
             assert length_int is not None
-            msg_type_int = bytes_to_varuint(msg_type)
+            msg_type_int = bytes_to_varuint(bytes(msg_type))
             assert msg_type_int is not None
 
             if length_int == 0:
                 self._callback_packet(Packet(type=msg_type_int, data=b""))
-                return
+                # If we have more data, continue processing
+                continue
 
             data = self._read_exactly(length_int)
             if data is None:
                 return
+
             self._callback_packet(Packet(type=msg_type_int, data=data))
+            # If we have more data, continue processing
 
 
 def _decode_noise_psk(psk: str) -> bytes:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -361,15 +361,14 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._write_frame(b"\x00" + self._proto.write_message())
 
     def _handle_handshake(self, msg: bytearray) -> None:
-        _LOGGER.debug("Starting handshake...msg=%s", msg)
+        _LOGGER.debug("Starting handshake...")
         if msg[0] != 0:
             explanation = msg[1:].decode()
             if explanation == "Handshake MAC failure":
                 raise InvalidEncryptionKeyAPIError("Invalid encryption key")
             raise HandshakeAPIError(f"Handshake failure: {explanation}")
-        _LOGGER.debug("Reading message...: %s", msg[1:])
-        result = self._proto.read_message(msg[1:])
-        _LOGGER.debug("Handshake complete: %s!", result)
+        self._proto.read_message(msg[1:])
+        _LOGGER.debug("Handshake complete")
         self._state = NoiseConnectionState.READY
         self._ready_event.set()
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -32,7 +32,7 @@ SOCKET_ERRORS = (
 @dataclass
 class Packet:
     type: int
-    data: bytes | bytearray
+    data: Union[bytes, bytearray]
 
 
 class APIFrameHelper(asyncio.Protocol):

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -112,7 +112,8 @@ class APIFrameHelper(asyncio.Protocol):
     def close(self) -> None:
         """Close the connection."""
         self._closed_event.set()
-        self._transport.close()
+        if self._transport:
+            self._transport.close()
 
 
 class APIPlaintextFrameHelper(APIFrameHelper):

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -111,11 +111,11 @@ class APIFrameHelper(asyncio.Protocol):
         self._on_error(exc)
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
-        self._handle_error(exc)
+        self._handle_error(exc or SocketClosedAPIError("Connection lost"))
         return super().connection_lost(exc)
 
     def eof_received(self) -> bool | None:
-        self._handle_error(SocketClosedAPIError("Connection closed"))
+        self._handle_error(SocketClosedAPIError("EOF received"))
         return super().eof_received()
 
     async def close(self) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -271,6 +271,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         to avoid locking.
         """
         _LOGGER.debug("Sending frame %s", frame.hex())
+        assert self._transport is not None, "Transport is not set"
 
         try:
             header = bytes(

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -127,6 +127,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         The entire packet must be written in a single call to write
         to avoid locking.
         """
+        assert self._transport is not None, "Transport should be set"
         data = (
             b"\0"
             + varuint_to_bytes(len(packet.data))
@@ -372,7 +373,6 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def write_packet(self, packet: Packet) -> None:
         """Write a packet to the socket."""
-        padding = 0
         self._write_frame(
             self._proto.encrypt(
                 (
@@ -385,7 +385,6 @@ class APINoiseFrameHelper(APIFrameHelper):
                         ]
                     )
                     + packet.data
-                    + b"\x00" * padding
                 )
             )
         )

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -101,7 +101,7 @@ class APIFrameHelper(asyncio.Protocol):
         self._handle_error(exc)
         self.close()
 
-    def _handle_error(self, exc: Optional[Exception]) -> None:
+    def _handle_error(self, exc: Exception) -> None:
         self._closed_event.set()
         self._on_error(exc)
 
@@ -113,7 +113,7 @@ class APIFrameHelper(asyncio.Protocol):
         self._handle_error(SocketClosedAPIError("EOF received"))
         return super().eof_received()
 
-    async def close(self) -> None:
+    def close(self) -> None:
         """Close the connection."""
         self._closed_event.set()
         self._transport.close()

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -310,7 +310,7 @@ class APINoiseFrameHelper(APIFrameHelper):
 
             try:
                 self.STATE_TO_CALLABLE[self._state](self, frame)
-            except APIConnectionError as err:
+            except Exception as err:  # pylint: disable=broad-except
                 self._handle_error_and_close(err)
             finally:
                 del self._buffer[: self._pos]

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -3,7 +3,7 @@ import base64
 import logging
 from abc import abstractmethod, abstractproperty
 from dataclasses import dataclass
-from typing import Callable, Optional, cast, Union
+from typing import Callable, Optional, Union, cast
 
 import async_timeout
 from noise.connection import NoiseConnection  # type: ignore

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -403,9 +403,9 @@ class APINoiseFrameHelper(APIFrameHelper):
         data = msg[4 : 4 + data_len]
         return self._on_pkt(Packet(pkt_type, data))
 
-    def _handle_closed(
+    def _handle_closed(  # pylint: disable=unused-argument
         self, frame: bytearray
-    ) -> None:  # pylint: disable=unused-argument
+    ) -> None:
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError("Connection closed"))
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -77,10 +77,6 @@ class APIFrameHelper(asyncio.Protocol):
         return self._buffer[original_pos:new_pos]
 
     @abstractmethod
-    def close(self) -> None:
-        """Close the connection."""
-
-    @abstractmethod
     def write_packet(self, packet: Packet) -> None:
         """Write a packet to the socket."""
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -240,7 +240,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         on_pkt: Callable[[Packet], None],
         on_error: Callable[[Exception], None],
         noise_psk: str,
-        expected_name: str,
+        expected_name: Optional[str],
     ) -> None:
         """Initialize the API frame helper."""
         super().__init__(on_pkt, on_error)

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -403,7 +403,9 @@ class APINoiseFrameHelper(APIFrameHelper):
         data = msg[4 : 4 + data_len]
         return self._on_pkt(Packet(pkt_type, data))
 
-    def _handle_closed(self, frame: bytearray) -> None:
+    def _handle_closed(
+        self, frame: bytearray
+    ) -> None:  # pylint: disable=unused-argument
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError("Connection closed"))
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -315,14 +315,6 @@ class APINoiseFrameHelper(APIFrameHelper):
             finally:
                 del self._buffer[: self._pos]
 
-    def _setup_proto(self) -> None:
-        """Set up the noise protocol."""
-        self._proto = NoiseConnection.from_name(b"Noise_NNpsk0_25519_ChaChaPoly_SHA256")
-        self._proto.set_as_initiator()
-        self._proto.set_psks(_decode_noise_psk(self._noise_psk))
-        self._proto.set_prologue(b"NoiseAPIInit" + b"\x00\x00")
-        self._proto.start_handshake()
-
     def _send_hello(self) -> None:
         """Send a ClientHello to the server."""
         self._write_frame(b"")  # ClientHello
@@ -355,6 +347,14 @@ class APINoiseFrameHelper(APIFrameHelper):
 
         self._state = NoiseConnectionState.HANDSHAKE
         self._send_handshake()
+
+    def _setup_proto(self) -> None:
+        """Set up the noise protocol."""
+        self._proto = NoiseConnection.from_name(b"Noise_NNpsk0_25519_ChaChaPoly_SHA256")
+        self._proto.set_as_initiator()
+        self._proto.set_psks(_decode_noise_psk(self._noise_psk))
+        self._proto.set_prologue(b"NoiseAPIInit" + b"\x00\x00")
+        self._proto.start_handshake()
 
     def _send_handshake(self) -> None:
         """Send the handshake message."""

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -200,11 +200,11 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 # If we have more data, continue processing
                 continue
 
-            data = self._read_exactly(length_int)
-            if data is None:
+            packet_data = self._read_exactly(length_int)
+            if packet_data is None:
                 return
 
-            self._callback_packet(msg_type_int, data)
+            self._callback_packet(msg_type_int, packet_data)
             # If we have more data, continue processing
 
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -157,8 +157,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
     def data_received(self, data: bytes) -> None:
         self._buffer += data
-        while len(self._buffer) >= 3:
-            try:
+        try:
+            while len(self._buffer) >= 3:
                 # Read preamble, which should always 0x00
                 # Also try to get the length and msg type
                 # to avoid multiple calls to readexactly
@@ -201,14 +201,14 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     self._callback_packet(
                         Packet(type=msg_type_int, data=self._read_exactly(length_int))
                     )
-            except MissingBytesAPIError as exc:
-                # Not enough data to read yet, wait for more
-                return
-            except Exception as exc:
-                self._handle_error(exc)
-                if self._transport is not None:
-                    self._transport.close()
-                raise
+        except MissingBytesAPIError as exc:
+            # Not enough data to read yet, wait for more
+            return
+        except Exception as exc:
+            self._handle_error(exc)
+            if self._transport is not None:
+                self._transport.close()
+            raise
 
 
 def _decode_noise_psk(psk: str) -> bytes:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import contextlib
 import logging
 from abc import abstractmethod, abstractproperty
 from dataclasses import dataclass
@@ -110,7 +109,7 @@ class APIFrameHelper(asyncio.Protocol):
         self._handle_error(exc or SocketClosedAPIError("Connection lost"))
         return super().connection_lost(exc)
 
-    def eof_received(self) -> bool | None:
+    def eof_received(self) -> Optional[bool]:
         self._handle_error(SocketClosedAPIError("EOF received"))
         return super().eof_received()
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -581,7 +581,7 @@ class APIClient:
         self._check_authenticated()
 
         assert self._connection is not None
-        await self._connection.send_message(
+        self._connection.send_message(
             BluetoothDeviceRequest(
                 address=address,
                 request_type=BluetoothDeviceRequestType.DISCONNECT,
@@ -661,7 +661,7 @@ class APIClient:
 
         if not response:
             assert self._connection is not None
-            await self._connection.send_message(req)
+            self._connection.send_message(req)
             return
 
         await self._send_bluetooth_message_await_response(
@@ -709,7 +709,7 @@ class APIClient:
 
         if not wait_for_response:
             assert self._connection is not None
-            await self._connection.send_message(req)
+            self._connection.send_message(req)
             return
 
         await self._send_bluetooth_message_await_response(
@@ -762,7 +762,7 @@ class APIClient:
 
             self._check_authenticated()
 
-            await self._connection.send_message(
+            self._connection.send_message(
                 BluetoothGATTNotifyRequest(address=address, handle=handle, enable=False)
             )
 
@@ -789,7 +789,7 @@ class APIClient:
         self._check_authenticated()
 
         assert self._connection is not None
-        await self._connection.send_message(
+        self._connection.send_message(
             HomeAssistantStateResponse(
                 entity_id=entity_id,
                 state=state,
@@ -829,7 +829,7 @@ class APIClient:
                 req.legacy_command = LegacyCoverCommand.CLOSE
                 req.has_legacy_command = True
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def fan_command(
         self,
@@ -860,7 +860,7 @@ class APIClient:
             req.has_direction = True
             req.direction = direction
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def light_command(
         self,
@@ -921,7 +921,7 @@ class APIClient:
             req.has_effect = True
             req.effect = effect
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def switch_command(self, key: int, state: bool) -> None:
         self._check_authenticated()
@@ -930,7 +930,7 @@ class APIClient:
         req.key = key
         req.state = state
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def climate_command(
         self,
@@ -982,7 +982,7 @@ class APIClient:
             req.has_custom_preset = True
             req.custom_preset = custom_preset
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def number_command(self, key: int, state: float) -> None:
         self._check_authenticated()
@@ -991,7 +991,7 @@ class APIClient:
         req.key = key
         req.state = state
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def select_command(self, key: int, state: str) -> None:
         self._check_authenticated()
@@ -1000,7 +1000,7 @@ class APIClient:
         req.key = key
         req.state = state
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def siren_command(
         self,
@@ -1027,7 +1027,7 @@ class APIClient:
             req.duration = duration
             req.has_duration = True
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def button_command(self, key: int) -> None:
         self._check_authenticated()
@@ -1035,7 +1035,7 @@ class APIClient:
         req = ButtonCommandRequest()
         req.key = key
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def lock_command(
         self,
@@ -1051,7 +1051,7 @@ class APIClient:
         if code is not None:
             req.code = code
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def media_player_command(
         self,
@@ -1075,7 +1075,7 @@ class APIClient:
             req.media_url = media_url
             req.has_media_url = True
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def execute_service(
         self, service: UserService, data: ExecuteServiceDataType
@@ -1113,7 +1113,7 @@ class APIClient:
         # pylint: disable=no-member
         req.args.extend(args)
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def _request_image(
         self, *, single: bool = False, stream: bool = False
@@ -1122,7 +1122,7 @@ class APIClient:
         req.single = single
         req.stream = stream
         assert self._connection is not None
-        await self._connection.send_message(req)
+        self._connection.send_message(req)
 
     async def request_single_image(self) -> None:
         await self._request_image(single=True)

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -448,7 +448,7 @@ class APIClient:
         msg_types = (BluetoothLEAdvertisementResponse,)
 
         def on_msg(msg: BluetoothLEAdvertisementResponse) -> None:
-            on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))
+            on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))  # type: ignore[misc]
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -448,7 +448,7 @@ class APIClient:
         msg_types = (BluetoothLEAdvertisementResponse,)
 
         def on_msg(msg: BluetoothLEAdvertisementResponse) -> None:
-            on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))  # type: ignore[misc]
+            on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -373,7 +373,7 @@ class APIClient:
                     image_stream[msg.key] = data
 
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             SubscribeStatesRequest(), on_msg, msg_types
         )
 
@@ -394,7 +394,7 @@ class APIClient:
         if dump_config is not None:
             req.dump_config = dump_config
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             req, on_msg, (SubscribeLogsResponse,)
         )
 
@@ -407,7 +407,7 @@ class APIClient:
             on_service_call(HomeassistantServiceCall.from_pb(msg))
 
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             SubscribeHomeassistantServicesRequest(),
             on_msg,
             (HomeassistantServiceResponse,),
@@ -451,7 +451,7 @@ class APIClient:
             on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))
 
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(), on_msg, msg_types
         )
 
@@ -472,7 +472,7 @@ class APIClient:
             on_bluetooth_connections_free_update(resp.free, resp.limit)
 
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             SubscribeBluetoothConnectionsFreeRequest(), on_msg, msg_types
         )
 
@@ -518,7 +518,7 @@ class APIClient:
             _LOGGER.debug("%s: Using connection version 1", address)
             request_type = BluetoothDeviceRequestType.CONNECT
 
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             BluetoothDeviceRequest(
                 address=address,
                 request_type=request_type,
@@ -777,7 +777,7 @@ class APIClient:
             on_state_sub(msg.entity_id, msg.attribute)
 
         assert self._connection is not None
-        await self._connection.send_message_callback_response(
+        self._connection.send_message_callback_response(
             SubscribeHomeAssistantStatesRequest(),
             on_msg,
             (SubscribeHomeAssistantStateResponse,),

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -277,10 +277,7 @@ class APIConnection:
         """Step 5 in connect process: start the ping loop."""
 
         async def _keep_alive_loop() -> None:
-            while True:
-                if not self._is_socket_open:
-                    return
-
+            while self._is_socket_open:
                 # Wait for keepalive seconds, or ping stop event, whichever happens first
                 try:
                     async with async_timeout.timeout(self._params.keepalive):

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -227,16 +227,16 @@ class APIConnection:
             _, fh = await self.loop.create_connection(
                 lambda: APINoiseFrameHelper(
                     noise_psk=self._params.noise_psk,
+                    expected_name=self._params.expected_name,
                     on_pkt=self._process_packet,
                     on_error=self._handle_fatal_error_and_cleanup,
                 ),
                 sock=self._socket,
             )
-            await fh.perform_handshake(self._params.expected_name)
 
         self._frame_helper = fh
         self._connection_state = ConnectionState.SOCKET_OPENED
-        await fh.wait_for_ready()
+        await fh.perform_handshake()
 
     async def _connect_hello(self) -> None:
         """Step 4 in connect process: send hello and get api version."""

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -224,7 +224,6 @@ class APIConnection:
                 ),
                 sock=self._socket,
             )
-            self._frame_helper = APIPlaintextFrameHelper()
         else:
             _, fh = await self.loop.create_connection(
                 lambda: APINoiseFrameHelper(
@@ -569,7 +568,7 @@ class APIConnection:
         The connection will be closed, all exception handlers notified.
         This method does not log the error, the call site should do so.
         """
-        self._handle_fatal_error()
+        self._handle_fatal_error(err)
         await self._cleanup()
 
     def _process_packet(self, pkt: Packet) -> None:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -140,7 +140,7 @@ class APIConnection:
                 self._to_process.put_nowait(None)
 
                 if self._frame_helper is not None:
-                    await self._frame_helper.close()
+                    self._frame_helper.close()
                     self._frame_helper = None
 
                 if self._socket is not None:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -407,7 +407,6 @@ class APIConnection:
         encoded = msg.SerializeToString()
         _LOGGER.debug("%s: Sending %s: %s", self._params.address, type(msg), str(msg))
 
-        frame_helper = self._frame_helper
         try:
             frame_helper.write_packet(
                 Packet(

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -5,7 +5,7 @@ import socket
 import time
 from contextlib import suppress
 from dataclasses import astuple, dataclass
-from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Type
+from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Type, Union
 
 import async_timeout
 from google.protobuf import message
@@ -215,6 +215,7 @@ class APIConnection:
 
     async def _connect_init_frame_helper(self) -> None:
         """Step 3 in connect process: initialize the frame helper and init read loop."""
+        fh: Union[APIPlaintextFrameHelper, APINoiseFrameHelper]
         if self._params.noise_psk is None:
             _, fh = await self.loop.create_connection(
                 lambda: APIPlaintextFrameHelper(

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -19,8 +19,11 @@ from uuid import UUID
 from .util import fix_float_single_double_conversion
 
 if TYPE_CHECKING:
-    from .api_pb2 import BluetoothServiceData, HomeassistantServiceMap  # type: ignore
-    from .api_pb2 import BluetoothLEAdvertisementResponse
+    from .api_pb2 import (  # type: ignore
+        BluetoothLEAdvertisementResponse,
+        BluetoothServiceData,
+        HomeassistantServiceMap,
+    )
 
 # All fields in here should have defaults set
 # Home Assistant depends on these fields being constructible

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -20,6 +20,7 @@ from .util import fix_float_single_double_conversion
 
 if TYPE_CHECKING:
     from .api_pb2 import BluetoothServiceData, HomeassistantServiceMap  # type: ignore
+    from .api_pb2 import BluetoothLEAdvertisementResponse
 
 # All fields in here should have defaults set
 # Home Assistant depends on these fields being constructible
@@ -821,20 +822,29 @@ def _convert_bluetooth_le_name(value: bytes) -> str:
 
 @dataclass(frozen=True)
 class BluetoothLEAdvertisement(APIModelBase):
-    address: int = 0
-    rssi: int = 0
-    address_type: int = 0
+    address: int
+    rssi: int
+    address_type: int
+    name: str
+    service_uuids: List[str]
+    service_data: Dict[str, bytes]
+    manufacturer_data: Dict[int, bytes]
 
-    name: str = converter_field(default="", converter=_convert_bluetooth_le_name)
-    service_uuids: List[str] = converter_field(
-        default_factory=list, converter=_convert_bluetooth_le_service_uuids
-    )
-    service_data: Dict[str, bytes] = converter_field(
-        default_factory=dict, converter=_convert_bluetooth_le_service_data
-    )
-    manufacturer_data: Dict[int, bytes] = converter_field(
-        default_factory=dict, converter=_convert_bluetooth_le_manufacturer_data
-    )
+    @classmethod
+    def from_pb(
+        cls: "BluetoothLEAdvertisement", data: "BluetoothLEAdvertisementResponse"
+    ) -> "BluetoothLEAdvertisement":
+        return cls(
+            address=data.address,
+            rssi=data.rssi,
+            address_type=data.address_type,
+            name=_convert_bluetooth_le_name(data.name),
+            service_uuids=_convert_bluetooth_le_service_uuids(data.service_uuids),
+            service_data=_convert_bluetooth_le_service_data(data.service_data),
+            manufacturer_data=_convert_bluetooth_le_manufacturer_data(
+                data.manufacturer_data
+            ),
+        )
 
 
 @dataclass(frozen=True)

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -837,9 +837,7 @@ class BluetoothLEAdvertisement(APIModelBase):
     manufacturer_data: Dict[int, bytes]
 
     @classmethod
-    def from_pb(  # type: ignore[misc]
-        cls: "BluetoothLEAdvertisement", data: BluetoothLEAdvertisementResponse
-    ) -> "BluetoothLEAdvertisement":
+    def from_pb(cls: Type[_V], data: Any) -> _V:
         return cls(  # type: ignore[operator, no-any-return]
             address=data.address,
             rssi=data.rssi,

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -837,10 +837,10 @@ class BluetoothLEAdvertisement(APIModelBase):
     manufacturer_data: Dict[int, bytes]
 
     @classmethod
-    def from_pb(
+    def from_pb(  # type: ignore[misc]
         cls: "BluetoothLEAdvertisement", data: "BluetoothLEAdvertisementResponse"
     ) -> "BluetoothLEAdvertisement":
-        return cls(
+        return cls(  # type: ignore[operator, no-any-return]
             address=data.address,
             rssi=data.rssi,
             address_type=data.address_type,

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -838,7 +838,7 @@ class BluetoothLEAdvertisement(APIModelBase):
 
     @classmethod
     def from_pb(  # type: ignore[misc]
-        cls: "BluetoothLEAdvertisement", data: BluetoothLEAdvertisementResponse
+        cls: "BluetoothLEAdvertisement", data: "BluetoothLEAdvertisementResponse"
     ) -> "BluetoothLEAdvertisement":
         return cls(  # type: ignore[operator, no-any-return]
             address=data.address,

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -19,11 +19,7 @@ from uuid import UUID
 from .util import fix_float_single_double_conversion
 
 if TYPE_CHECKING:
-    from .api_pb2 import (  # type: ignore
-        BluetoothLEAdvertisementResponse,
-        BluetoothServiceData,
-        HomeassistantServiceMap,
-    )
+    from .api_pb2 import BluetoothServiceData, HomeassistantServiceMap  # type: ignore
 
 # All fields in here should have defaults set
 # Home Assistant depends on these fields being constructible
@@ -825,32 +821,20 @@ def _convert_bluetooth_le_name(value: bytes) -> str:
 
 @dataclass(frozen=True)
 class BluetoothLEAdvertisement(APIModelBase):
-    def __post_init__(self) -> None:
-        """Post init hook disabled."""
+    address: int = 0
+    rssi: int = 0
+    address_type: int = 0
 
-    address: int
-    rssi: int
-    address_type: int
-    name: str
-    service_uuids: List[str]
-    service_data: Dict[str, bytes]
-    manufacturer_data: Dict[int, bytes]
-
-    @classmethod
-    def from_pb(  # type: ignore[misc]
-        cls: "BluetoothLEAdvertisement", data: "BluetoothLEAdvertisementResponse"
-    ) -> "BluetoothLEAdvertisement":
-        return cls(  # type: ignore[operator, no-any-return]
-            address=data.address,
-            rssi=data.rssi,
-            address_type=data.address_type,
-            name=_convert_bluetooth_le_name(data.name),
-            service_uuids=_convert_bluetooth_le_service_uuids(data.service_uuids),
-            service_data=_convert_bluetooth_le_service_data(data.service_data),
-            manufacturer_data=_convert_bluetooth_le_manufacturer_data(
-                data.manufacturer_data
-            ),
-        )
+    name: str = converter_field(default="", converter=_convert_bluetooth_le_name)
+    service_uuids: List[str] = converter_field(
+        default_factory=list, converter=_convert_bluetooth_le_service_uuids
+    )
+    service_data: Dict[str, bytes] = converter_field(
+        default_factory=dict, converter=_convert_bluetooth_le_service_data
+    )
+    manufacturer_data: Dict[int, bytes] = converter_field(
+        default_factory=dict, converter=_convert_bluetooth_le_manufacturer_data
+    )
 
 
 @dataclass(frozen=True)

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -837,7 +837,9 @@ class BluetoothLEAdvertisement(APIModelBase):
     manufacturer_data: Dict[int, bytes]
 
     @classmethod
-    def from_pb(cls: Type[_V], data: Any) -> _V:
+    def from_pb(  # type: ignore[misc]
+        cls: "BluetoothLEAdvertisement", data: BluetoothLEAdvertisementResponse
+    ) -> "BluetoothLEAdvertisement":
         return cls(  # type: ignore[operator, no-any-return]
             address=data.address,
             rssi=data.rssi,

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -822,6 +822,9 @@ def _convert_bluetooth_le_name(value: bytes) -> str:
 
 @dataclass(frozen=True)
 class BluetoothLEAdvertisement(APIModelBase):
+    def __post_init__(self) -> None:
+        """Post init hook disabled."""
+
     address: int
     rssi: int
     address_type: int

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -838,7 +838,7 @@ class BluetoothLEAdvertisement(APIModelBase):
 
     @classmethod
     def from_pb(  # type: ignore[misc]
-        cls: "BluetoothLEAdvertisement", data: "BluetoothLEAdvertisementResponse"
+        cls: "BluetoothLEAdvertisement", data: BluetoothLEAdvertisementResponse
     ) -> "BluetoothLEAdvertisement":
         return cls(  # type: ignore[operator, no-any-return]
             address=data.address,

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -1,7 +1,9 @@
 import math
 from typing import Optional
+from functools import lru_cache
 
 
+@lru_cache(maxsize=1024)
 def varuint_to_bytes(value: int) -> bytes:
     if value <= 0x7F:
         return bytes([value])
@@ -18,6 +20,7 @@ def varuint_to_bytes(value: int) -> bytes:
     return ret
 
 
+@lru_cache(maxsize=1024)
 def bytes_to_varuint(value: bytes) -> Optional[int]:
     result = 0
     bitpos = 0

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -1,6 +1,6 @@
 import math
-from typing import Optional
 from functools import lru_cache
+from typing import Optional
 
 
 @lru_cache(maxsize=1024)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ def patch_response_complex(client: APIClient, messages):
 def patch_response_callback(client: APIClient):
     on_message = None
 
-    async def patched(req, callback, msg_types):
+    def patched(req, callback, msg_types):
         nonlocal on_message
         on_message = callback
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,11 +4,11 @@ import socket
 import pytest
 from mock import AsyncMock, MagicMock, Mock, patch
 
+from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, Packet
 from aioesphomeapi.api_pb2 import ConnectResponse, HelloResponse
 from aioesphomeapi.connection import APIConnection, ConnectionParams, ConnectionState
 from aioesphomeapi.core import APIConnectionError, RequiresEncryptionAPIError
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
-from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, Packet
 
 
 @pytest.fixture

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,6 +8,7 @@ from aioesphomeapi.api_pb2 import ConnectResponse, HelloResponse
 from aioesphomeapi.connection import APIConnection, ConnectionParams, ConnectionState
 from aioesphomeapi.core import APIConnectionError, RequiresEncryptionAPIError
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
+from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, Packet
 
 
 @pytest.fixture
@@ -50,13 +51,26 @@ def socket_socket():
         yield func
 
 
+def _get_mock_protocol():
+    def _on_packet(pkt: Packet):
+        pass
+
+    def _on_error(exc: Exception):
+        raise exc
+
+    protocol = APIPlaintextFrameHelper(on_pkt=_on_packet, on_error=_on_error)
+    protocol._connected_event.set()
+    protocol._transport = MagicMock()
+    return protocol
+
+
 @pytest.mark.asyncio
 async def test_connect(conn, resolve_host, socket_socket, event_loop):
-    with patch.object(event_loop, "sock_connect"), patch(
-        "asyncio.open_connection", return_value=(None, None)
-    ), patch.object(conn, "_read_loop"), patch.object(
-        conn, "_connect_start_ping"
-    ), patch.object(
+    loop = asyncio.get_event_loop()
+    protocol = _get_mock_protocol()
+    with patch.object(event_loop, "sock_connect"), patch.object(
+        loop, "create_connection", return_value=(MagicMock(), protocol)
+    ), patch.object(conn, "_connect_start_ping"), patch.object(
         conn, "send_message_await_response", return_value=HelloResponse()
     ):
         await conn.connect(login=False)
@@ -66,14 +80,15 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
 
 @pytest.mark.asyncio
 async def test_requires_encryption_propagates(conn):
-    with patch("asyncio.open_connection") as openc:
-        reader = MagicMock()
-        writer = MagicMock()
-        openc.return_value = (reader, writer)
-        writer.drain = AsyncMock()
-        reader.readexactly = AsyncMock()
-        reader.readexactly.return_value = b"\x01"
+    loop = asyncio.get_event_loop()
+    protocol = _get_mock_protocol()
+    with patch.object(loop, "create_connection") as create_connection, patch.object(
+        protocol, "perform_handshake"
+    ):
+        create_connection.return_value = (MagicMock(), protocol)
 
         await conn._connect_init_frame_helper()
+
         with pytest.raises(RequiresEncryptionAPIError):
+            protocol.data_received(b"\x01\x00\x00")
             await conn._connect_hello()


### PR DESCRIPTION
This  removes ~ 20k `call_soon`s per minute which translates to a significant latency improvement (also reduces the run time by ~ 18-24%) with 7 ble proxies.

With this change we can refactor a significant number of coroutines into normal functions.

Eliminates:
- read_loop
- process_loop
- queue

Data now comes in via `data_received` and is called back to the packet processor which was the original `process_loop` and than called back to the consumers of the API (HA) and than to each integration which eliminates the overhead of having to put it into a queue, pull it out of a queue, schedule, fire, etc which was usually more expensive than parsing (when using cpp protobuf) and processing the data itself since almost everything coming from esphome are tiny packets of data (with high frequency with bluetooth active scanning). 