### PR TITLE
Ensure we hold strong references to tasks

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -158,7 +158,7 @@ class APIConnection:
 
         if self.on_stop and self._connect_complete:
 
-            def _remove_on_stop_task(_fut: asyncio.Future) -> None:
+            def _remove_on_stop_task(_fut: asyncio.Future[None]) -> None:
                 """Remove the stop task from the reconnect loop.
 
                 We need to do this because the asyncio does not hold

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -159,7 +159,7 @@ class APIConnection:
         if self.on_stop and self._connect_complete:
 
             def _remove_on_stop_task(_fut: asyncio.Future[None]) -> None:
-                """Remove the stop task from the reconnect loop.
+                """Remove the stop task.
 
                 We need to do this because the asyncio does not hold
                 a strong reference to the task, so it can be garbage

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -118,6 +118,7 @@ class APIConnection:
         self._ping_stop_event = asyncio.Event()
 
         self._connect_task: Optional[asyncio.Task[None]] = None
+        self._keep_alive_task: Optional[asyncio.Task[None]] = None
         self._fatal_exception: Optional[Exception] = None
         self._expected_disconnect = False
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -158,7 +158,7 @@ class APIConnection:
 
         if self.on_stop and self._connect_complete:
 
-            def _remove_on_stop_task():
+            def _remove_on_stop_task(_fut: asyncio.Future) -> None:
                 """Remove the stop task from the reconnect loop.
 
                 We need to do this because the asyncio does not hold

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -96,6 +96,7 @@ class APIConnection:
     ) -> None:
         self._params = params
         self.on_stop: Optional[Callable[[], Coroutine[Any, Any, None]]] = on_stop
+        self._on_stop_task: Optional[asyncio.Task[None]] = None
         self._socket: Optional[socket.socket] = None
         self._frame_helper: Optional[APIFrameHelper] = None
         self._api_version: Optional[APIVersion] = None
@@ -142,6 +143,10 @@ class APIConnection:
             self._connect_task.cancel()
             self._connect_task = None
 
+        if self._keep_alive_task is not None:
+            self._keep_alive_task.cancel()
+            self._keep_alive_task = None
+
         if self._frame_helper is not None:
             self._frame_helper.close()
             self._frame_helper = None
@@ -151,8 +156,19 @@ class APIConnection:
             self._socket = None
 
         if self.on_stop and self._connect_complete:
+
+            def _remove_on_stop_task():
+                """Remove the stop task from the reconnect loop.
+
+                We need to do this because the asyncio does not hold
+                a strong reference to the task, so it can be garbage
+                collected unexpectedly.
+                """
+                self._on_stop_task = None
+
             # Ensure on_stop is called only once
-            asyncio.create_task(self.on_stop())
+            self._on_stop_task = asyncio.create_task(self.on_stop())
+            self._on_stop_task.add_done_callback(_remove_on_stop_task)
             self.on_stop = None
 
         # Note: we don't explicitly cancel the ping/read task here
@@ -318,7 +334,7 @@ class APIConnection:
                     self._report_fatal_error(err)
                     return
 
-        asyncio.create_task(_keep_alive_loop())
+        self._keep_alive_task = asyncio.create_task(_keep_alive_loop())
 
     async def connect(self, *, login: bool) -> None:
         if self._connection_state != ConnectionState.INITIALIZED:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -201,7 +201,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         await self._stop_zc_listen()
 
     def stop_callback(self) -> None:
-        def _remove_stop_task() -> None:
+        def _remove_stop_task(_fut: asyncio.Future) -> None:
             """Remove the stop task from the reconnect loop.
 
             We need to do this because the asyncio does not hold

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -201,7 +201,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         await self._stop_zc_listen()
 
     def stop_callback(self) -> None:
-        def _remove_stop_task(_fut: asyncio.Future) -> None:
+        def _remove_stop_task(_fut: asyncio.Future[None]) -> None:
             """Remove the stop task from the reconnect loop.
 
             We need to do this because the asyncio does not hold

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -59,6 +59,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._wait_task_lock = asyncio.Lock()
         # Event for tracking when logic should stop
         self._stop_event = asyncio.Event()
+        self._stop_task: Optional[asyncio.Task[None]] = None
 
     @property
     def _is_stopped(self) -> bool:


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task

> Important Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection:

see https://github.com/python/cpython/issues/88831