### PR TITLE
Default `Cover.supports_stop` to `True` for backwards compatibility

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -161,7 +161,10 @@ class BinarySensorState(EntityState):
 @dataclass(frozen=True)
 class CoverInfo(EntityInfo):
     assumed_state: bool = False
-    supports_stop: bool = False
+    # "True" by default for backwards compatibility.
+    # Prior to https://github.com/esphome/esphome/pull/3897, all ESPHome covers
+    # were assumed to support stop.
+    supports_stop: bool = True
     supports_position: bool = False
     supports_tilt: bool = False
     device_class: str = ""


### PR DESCRIPTION
Prior to `supports_stop` being sent by ESPHome (introduced in https://github.com/esphome/esphome/pull/3897), all covers were assumed to be support stopping. The whole point of https://github.com/esphome/issues/issues/3059 was to address that.

However, to preserve the correct behaviour for old versions, this PR tweaks `support_stop` (introduced in #276) to default to `True` instead of `False`.

Context: https://github.com/home-assistant/core/pull/80104#discussion_r1106007605