### PR TITLE
Fix bluetooth_device_connect returning prematurely from a disconnect

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -497,7 +497,8 @@ class APIClient:
             resp = BluetoothDeviceConnection.from_pb(msg)
             if address == resp.address:
                 on_bluetooth_connection_state(resp.connected, resp.mtu, resp.error)
-                event.set()
+                if resp.connected:
+                    event.set()
 
         assert self._connection is not None
         if has_cache:


### PR DESCRIPTION
fixes an issue when a disconnect is followed by a connect, example:

```python
def connect_cb(connected, ...)
   print("Connected:", connected)
await api.bluetooth_device_disconnect(...)
await api.bluetooth_device_connect(..., connect_cb)
print('Attempt to use connection')
```
yields
```
Connected: False
Attempt to use connection
Connected: True
```
`bluetooth_device_disconnect` resolves as soon as the aioesphomeapi call is done which I think is fine but it is unexpected to have a closed connection after an `await bluetooth_device_connect`.