### PR TITLE
If a field value is None, set the value to default before passing it to a converter

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -69,6 +69,8 @@ class APIModelBase:
             if convert is None:
                 continue
             val = getattr(self, field_.name)
+            if val is None:
+                val = field_.default
             # use this setattr to prevent FrozenInstanceError
             super().__setattr__(field_.name, convert(val))
 


### PR DESCRIPTION
This is related to https://github.com/home-assistant/core/issues/88887

Seems that there is no check for `None` values before calling a field's converter function, so this might fails for some specific use cases. To fix that, in `APIModelBase`'s `__post_init__` I'm setting the value to the field's default value before calling the converter. I'm not familiar with this project so I'm not sure if this was the purpose of `field_.default`, feel free to discard this PR if I misunderstood that.