### PR TITLE
Adjust ping timeout to prevent premature disconnections

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -164,11 +164,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 5.0
-
-# The keep alive frequency is 60 seconds which aligns with the esphome
-# codebase:
-# https://github.com/esphome/esphome/blob/df3f13ded884682dfbcbba542d79aedb1e100b0a/esphome/components/api/api_connection.cpp#L99
-KEEP_ALIVE_FREQUENCY = 60.0
+KEEP_ALIVE_FREQUENCY = 30.0
 
 ExecuteServiceDataType = Dict[
     str, Union[bool, int, float, str, List[bool], List[int], List[float], List[str]]

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -165,10 +165,15 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 5.0
 
-# We send a ping every 35 seconds, and the timeout ratio is 2.5x the
-# ping interval. This means that if we don't receive a ping for 87.5
+# We send a ping every 20 seconds, and the timeout ratio is 4.5x the
+# ping interval. This means that if we don't receive a ping for 90.0
 # seconds, we'll consider the connection dead and reconnect.
-KEEP_ALIVE_FREQUENCY = 35.0
+#
+# This was chosen because the 20s is around the expected time for a
+# device to reboot and reconnect to wifi, and 90 seconds is the absolute
+# maximum time a device can take to respond when its behind + the WiFi
+# connection is poor.
+KEEP_ALIVE_FREQUENCY = 20.0
 
 ExecuteServiceDataType = Dict[
     str, Union[bool, int, float, str, List[bool], List[int], List[float], List[str]]

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -164,6 +164,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 5.0
+KEEP_ALIVE_FREQUENCY = 30.0
 
 ExecuteServiceDataType = Dict[
     str, Union[bool, int, float, str, List[bool], List[int], List[float], List[str]]
@@ -179,7 +180,7 @@ class APIClient:
         password: Optional[str],
         *,
         client_info: str = "aioesphomeapi",
-        keepalive: float = 20.0,
+        keepalive: float = KEEP_ALIVE_FREQUENCY,
         zeroconf_instance: ZeroconfInstanceType = None,
         noise_psk: Optional[str] = None,
         expected_name: Optional[str] = None,

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -164,7 +164,11 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 5.0
-KEEP_ALIVE_FREQUENCY = 30.0
+
+# We send a ping every 35 seconds, and the timeout ratio is 2.5x the
+# ping interval. This means that if we don't receive a ping for 87.5
+# seconds, we'll consider the connection dead and reconnect.
+KEEP_ALIVE_FREQUENCY = 35.0
 
 ExecuteServiceDataType = Dict[
     str, Union[bool, int, float, str, List[bool], List[int], List[float], List[str]]

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -164,7 +164,11 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 5.0
-KEEP_ALIVE_FREQUENCY = 30.0
+
+# The keep alive frequency is 60 seconds which aligns with the esphome
+# codebase:
+# https://github.com/esphome/esphome/blob/df3f13ded884682dfbcbba542d79aedb1e100b0a/esphome/components/api/api_connection.cpp#L99
+KEEP_ALIVE_FREQUENCY = 60.0
 
 ExecuteServiceDataType = Dict[
     str, Union[bool, int, float, str, List[bool], List[int], List[float], List[str]]

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -179,7 +179,7 @@ class APIClient:
         password: Optional[str],
         *,
         client_info: str = "aioesphomeapi",
-        keepalive: float = 15.0,
+        keepalive: float = 20.0,
         zeroconf_instance: ZeroconfInstanceType = None,
         noise_psk: Optional[str] = None,
         expected_name: Optional[str] = None,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -70,6 +70,7 @@ KEEP_ALIVE_TIMEOUT_RATIO = 4.5
 
 HANDSHAKE_TIMEOUT = 30.0
 RESOLVE_TIMEOUT = 30.0
+CONNECT_REQUEST_TIMEOUT = 30.0
 
 # The connect timeout should be the maximum time we expect the esp to take
 # to reboot and connect to the network/WiFi.
@@ -438,7 +439,9 @@ class APIConnection:
         if self._params.password is not None:
             connect.password = self._params.password
         try:
-            resp = await self.send_message_await_response(connect, ConnectResponse)
+            resp = await self.send_message_await_response(
+                connect, ConnectResponse, timeout=CONNECT_REQUEST_TIMEOUT
+            )
         except TimeoutAPIError as err:
             # After a timeout for connect the connection can no longer be used
             # We don't know what state the device may be in after ConnectRequest

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -365,7 +365,11 @@ class APIConnection:
             self.log_name,
             PING_PONG_TIMEOUT,
         )
-        self._report_fatal_error(PingFailedAPIError())
+        self._report_fatal_error(
+            PingFailedAPIError(
+                f"Ping response not received after {PING_PONG_TIMEOUT} seconds"
+            )
+        )
 
     async def connect(self, *, login: bool) -> None:
         if self._connection_state != ConnectionState.INITIALIZED:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -117,7 +117,6 @@ class APIConnection:
         # Handlers currently subscribed to exceptions in the read task
         self._read_exception_handlers: List[Callable[[Exception], None]] = []
 
-        self._loop = asyncio.get_running_loop()
         self._ping_timer: Optional[asyncio.TimerHandle] = None
         self._pong_timer: Optional[asyncio.TimerHandle] = None
 
@@ -311,7 +310,8 @@ class APIConnection:
 
     def _async_schedule_keep_alive(self) -> None:
         """Start the keep alive task."""
-        self._ping_timer = self._loop.call_later(
+        loop = asyncio.get_running_loop()
+        self._ping_timer = loop.call_later(
             self._params.keepalive, self._async_send_keep_alive
         )
 
@@ -320,7 +320,8 @@ class APIConnection:
         if not self._is_socket_open:
             return
         self.send_message(PingRequest())
-        self._pong_timer = self._loop.call_later(
+        loop = asyncio.get_running_loop()
+        self._pong_timer = loop.call_later(
             PING_PONG_TIMEOUT, self._async_pong_not_received
         )
         self._async_schedule_keep_alive()

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -647,10 +647,6 @@ class APIConnection:
             resp.epoch_seconds = int(time.time())
             self.send_message(resp)
 
-    async def _ping(self) -> None:
-        self._check_connected()
-        await self.send_message_await_response(PingRequest(), PingResponse)
-
     async def disconnect(self) -> None:
         if self._connection_state != ConnectionState.CONNECTED:
             # already disconnected

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -306,11 +306,10 @@ class APIConnection:
 
     async def _connect_start_ping(self) -> None:
         """Step 5 in connect process: start the ping loop."""
-        self._async_schedule_keep_alive()
+        self._async_schedule_keep_alive(asyncio.get_running_loop())
 
-    def _async_schedule_keep_alive(self) -> None:
+    def _async_schedule_keep_alive(self, loop: asyncio.AbstractEventLoop) -> None:
         """Start the keep alive task."""
-        loop = asyncio.get_running_loop()
         self._ping_timer = loop.call_later(
             self._params.keepalive, self._async_send_keep_alive
         )
@@ -324,7 +323,7 @@ class APIConnection:
         self._pong_timer = loop.call_later(
             PING_PONG_TIMEOUT, self._async_pong_not_received
         )
-        self._async_schedule_keep_alive()
+        self._async_schedule_keep_alive(loop)
 
     def _async_cancel_pong_timer(self) -> None:
         """Cancel the pong timer."""

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -58,12 +58,14 @@ PING_RESPONSE_MESSAGE = PingResponse()
 
 PROTO_TO_MESSAGE_TYPE = {v: k for k, v in MESSAGE_TYPE_TO_PROTO.items()}
 
-KEEP_ALIVE_TIMEOUT_RATIO = 2.5
+KEEP_ALIVE_TIMEOUT_RATIO = 4.5
 #
-# We use 2.5x the keepalive time as the timeout for the pong
-# to match the esphome design
-#
-# https://github.com/esphome/esphome/blob/df3f13ded884682dfbcbba542d79aedb1e100b0a/esphome/components/api/api_connection.cpp#L99
+# We use 4.5x the keep-alive time as the timeout for the pong
+# since the default ping interval is 20s which is about the time
+# a device takes to reboot and reconnect to the network making
+# the maximum time it has to respond to a ping at 90s which is
+# enough time to know that the device has truly disconnected
+# from the network.
 #
 
 HANDSHAKE_TIMEOUT = 30.0

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -329,8 +329,8 @@ class APIConnection:
             # so we reschedule the keep alive
             _LOGGER.debug(
                 "%s: PingResponse (pong) was not received "
-                "since last keep alive after %s seconds; ",
-                "rescheduling keep alive"
+                "since last keep alive after %s seconds; "
+                "rescheduling keep alive",
                 self.log_name,
                 self._params.keepalive,
             )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -336,8 +336,9 @@ class APIConnection:
             # so we don't need to send another ping right now
             # so we reschedule the keep alive
             _LOGGER.debug(
-                "%s: PingResponse (pong) was not received"
+                "%s: PingResponse (pong) was not received "
                 "since last keep alive after %s seconds; ",
+                "rescheduling keep alive"
                 self.log_name,
                 self._params.keepalive,
             )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -333,6 +333,13 @@ class APIConnection:
 
     def _async_pong_not_received(self) -> None:
         """Ping not received."""
+        if not self._is_socket_open:
+            return
+        _LOGGER.debug(
+            "%s: Ping response not received after %s seconds",
+            self.log_name,
+            PING_PONG_TIMEOUT,
+        )
         self._report_fatal_error(PingFailedAPIError())
 
     async def connect(self, *, login: bool) -> None:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -54,6 +54,7 @@ BUFFER_SIZE = 1024 * 1024  # Set buffer limit to 1MB
 INTERNAL_MESSAGE_TYPES = {GetTimeRequest, PingRequest, PingResponse, DisconnectRequest}
 
 PING_REQUEST_MESSAGE = PingRequest()
+PING_RESPONSE_MESSAGE = PingResponse()
 
 PROTO_TO_MESSAGE_TYPE = {v: k for k, v in MESSAGE_TYPE_TO_PROTO.items()}
 
@@ -670,7 +671,7 @@ class APIConnection:
             self._expected_disconnect = True
             self._cleanup()
         elif msg_type is PingRequest:
-            self.send_message(PingResponse())
+            self.send_message(PING_RESPONSE_MESSAGE)
         elif msg_type is GetTimeRequest:
             resp = GetTimeResponse()
             resp.epoch_seconds = int(time.time())

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -161,7 +161,7 @@ class APIConnection:
             self._socket = None
 
         self._async_cancel_pong_timer()
-        
+
         if self._ping_timer is not None:
             self._ping_timer.cancel()
             self._ping_timer = None
@@ -311,14 +311,18 @@ class APIConnection:
 
     def _async_schedule_keep_alive(self) -> None:
         """Start the keep alive task."""
-        self._ping_timer = self._loop.call_later(self._params.keepalive, self._async_send_keep_alive)
+        self._ping_timer = self._loop.call_later(
+            self._params.keepalive, self._async_send_keep_alive
+        )
 
     def _async_send_keep_alive(self) -> None:
         """Send a keep alive message."""
         if not self._is_socket_open:
             return
         self.send_message(PingRequest())
-        self._pong_timer = self._loop.call_later(PING_PONG_TIMEOUT, self._async_pong_not_received)
+        self._pong_timer = self._loop.call_later(
+            PING_PONG_TIMEOUT, self._async_pong_not_received
+        )
         self._async_schedule_keep_alive()
 
     def _async_cancel_pong_timer(self) -> None:


### PR DESCRIPTION
Refactor keep alive to avoid coroutines which makes cancelation and disconnect a lot simpler since we don't have to worry about the complexity of canceling a task.

The ping pong timeout was 10s with a send frequency of 15s. This change increases the keep alive frequency to 20.0s and raises the default no response timeout to be 90s (4.5x the keep alive frequency). 20s was chosen because its about the time it takes for the esp device to reboot and reconnect to the network.

 This helps devices that may not have the best connection or are using some type of wifi power management aka `power_save_mode: LIGHT`.

The timeout is slightly more half of the time in the esphome code base, https://github.com/esphome/esphome/blob/df3f13ded884682dfbcbba542d79aedb1e100b0a/esphome/components/api/api_connection.cpp#L99 . In testing we didn't need the full 150s the esphome code is using since after ~90s its relatively clear that the connection has dropped.

We likely have been prematurely disconnecting for some time as we didn't report quite a few unexpected disconnects in the log until recent versions https://github.com/home-assistant/core/issues/89047#issuecomment-1454935372 :

Previous version of `_report_fatal_error` logged nothing
https://github.com/esphome/aioesphomeapi/blob/527420464da223c05fd5d054ec0a9cd891e3bec6/aioesphomeapi/connection.py#L452

Current version
https://github.com/esphome/aioesphomeapi/blob/31b75be915354c524336e6bdaf213b85d1a8038a/aioesphomeapi/connection.py#L575

fixes https://github.com/home-assistant/core/issues/85062
fixes https://github.com/home-assistant/core/issues/88535
fixes https://github.com/home-assistant/core/issues/89047

