### PR TITLE
Fix disconnect message not being sent when disconnecting during hello phase

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -645,8 +645,11 @@ class APIConnection:
         await self.send_message_await_response(PingRequest(), PingResponse)
 
     async def disconnect(self) -> None:
-        if self._connection_state != ConnectionState.CONNECTED:
-            # already disconnected
+        if not self._is_socket_open or not self._frame_helper:
+            # We still want to send a disconnect request even
+            # if the hello phase isn't finished to ensure we
+            # the esp will clean up the connection as soon
+            # as possible.
             return
 
         self._expected_disconnect = True


### PR DESCRIPTION
There was a small race window were we would be setting up the connection during the disconnect request that would have prevented the esp from seeing that the client was disconnecting. It would eventually get cleaned up by the keep-alive timeout on the esp side.