### PR TITLE
Cooldown before reconnecting on expected disconnect

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -233,17 +233,17 @@ class APIClient:
 
     async def connect(
         self,
-        on_stop: Optional[Callable[[], Awaitable[None]]] = None,
+        on_stop: Optional[Callable[[bool], Awaitable[None]]] = None,
         login: bool = False,
     ) -> None:
         if self._connection is not None:
             raise APIConnectionError(f"Already connected to {self._log_name}!")
 
-        async def _on_stop() -> None:
+        async def _on_stop(expected_disconnect: bool) -> None:
             # Hook into on_stop handler to clear connection when stopped
             self._connection = None
             if on_stop is not None:
-                await on_stop()
+                await on_stop(expected_disconnect)
 
         self._connection = APIConnection(
             self._params, _on_stop, log_name=self._log_name

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -27,7 +27,7 @@ def connection_params() -> ConnectionParams:
 
 @pytest.fixture
 def conn(connection_params) -> APIConnection:
-    async def on_stop():
+    async def on_stop(expected_disconnect: bool) -> None:
         pass
 
     return APIConnection(connection_params, on_stop)


### PR DESCRIPTION
If the esp gets an OTA or requests a disconnect because its rebooting, we would reconnect too quickly before the device had shutdown accepting socket connections and end up trying to talk to a device that was moments away from rebooting which would delay reconnecting once the device came back up