### PR TITLE
Reduce uuid conversion overhead

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -804,7 +804,7 @@ def _convert_bluetooth_le_service_uuids(value: Iterable[str]) -> List[str]:
 def _convert_bluetooth_le_service_data(
     value: Union[Dict[str, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[str, bytes]:
-    if isinstance(value, dict):
+    if type(value) is dict:
         return value
 
     if not value:
@@ -826,7 +826,7 @@ def _convert_bluetooth_le_service_data(
 def _convert_bluetooth_le_manufacturer_data(
     value: Union[Dict[int, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[int, bytes]:
-    if isinstance(value, dict):
+    if type(value) is dict:
         return value
 
     if not value:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -781,15 +781,11 @@ def _join_split_uuid(value: List[int]) -> str:
     return str(UUID(int=(value[0] << 64) | value[1]))
 
 
-def _uuid_converter(uuid: str) -> str:
-    return (
-        f"0000{uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"
-        if len(uuid) < 8
-        else uuid.lower()
-    )
-
-
-_cached_uuid_converter = lru_cache(maxsize=1024)(_uuid_converter)
+_cached_uuid_converter = lru_cache(maxsize=128)(
+    lambda uuid: f"0000{uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"
+    if len(uuid) < 8
+    else uuid.lower()
+)
 
 
 # value is likely a google.protobuf.pyext._message.RepeatedScalarContainer

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -804,7 +804,8 @@ def _convert_bluetooth_le_service_uuids(value: Iterable[str]) -> List[str]:
 def _convert_bluetooth_le_service_data(
     value: Union[Dict[str, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[str, bytes]:
-    if type(value) is dict:
+    # We literally mean is a `dict` not any other class
+    if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
         return value
 
     if not value:
@@ -826,7 +827,8 @@ def _convert_bluetooth_le_service_data(
 def _convert_bluetooth_le_manufacturer_data(
     value: Union[Dict[int, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[int, bytes]:
-    if type(value) is dict:
+    # We literally mean is a `dict` not any other class
+    if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
         return value
 
     if not value:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -812,7 +812,7 @@ def _convert_bluetooth_le_service_data(
         return {}
 
     # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
-    if value[0].data:
+    if value[0].data:  # type: ignore
         return {
             _cached_uuid_converter(v.uuid): bytes(v.data)  # type: ignore[union-attr]
             for v in value
@@ -834,7 +834,7 @@ def _convert_bluetooth_le_manufacturer_data(
         return {}
 
     # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
-    if value[0].data:
+    if value[0].data:  # type: ignore
         return {int(v.uuid, 16): bytes(v.data) for v in value}  # type: ignore
 
     return {int(v.uuid, 16): bytes(v.legacy_data) for v in value}  # type: ignore

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -781,11 +781,15 @@ def _join_split_uuid(value: List[int]) -> str:
     return str(UUID(int=(value[0] << 64) | value[1]))
 
 
-_cached_uuid_converter = lru_cache(maxsize=128)(
-    lambda uuid: f"0000{uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"
-    if len(uuid) < 8
-    else uuid.lower()
-)
+def _uuid_converter(uuid: str) -> str:
+    return (
+        f"0000{uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"
+        if len(uuid) < 8
+        else uuid.lower()
+    )
+
+
+_cached_uuid_converter = lru_cache(maxsize=128)(_uuid_converter)
 
 
 # value is likely a google.protobuf.pyext._message.RepeatedScalarContainer

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Collection,
     List,
     Optional,
     Type,
@@ -14,6 +15,7 @@ from typing import (
     Union,
     cast,
 )
+from functools import lru_cache
 from uuid import UUID
 
 from .util import fix_float_single_double_conversion
@@ -780,21 +782,28 @@ def _join_split_uuid(value: List[int]) -> str:
     return str(UUID(int=(value[0] << 64) | value[1]))
 
 
+def _uuid_converter(uuid: str) -> str:
+    return (
+        f"0000{uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"
+        if len(uuid) < 8
+        else uuid.lower()
+    )
+
+
+_cached_uuid_converter = lru_cache(maxsize=1024)(_uuid_converter)
+
+
 # value is likely a google.protobuf.pyext._message.RepeatedScalarContainer
 def _convert_bluetooth_le_service_uuids(value: Iterable[str]) -> List[str]:
     if not value:
         # empty list, don't convert
         return []
 
-    # Long UUID inlined to avoid call stack inside the list comprehension
-    return [
-        f"0000{v[2:].lower()}-0000-1000-8000-00805f9b34fb" if len(v) < 8 else v.lower()
-        for v in value
-    ]
+    return [_cached_uuid_converter(v) for v in value]
 
 
 def _convert_bluetooth_le_service_data(
-    value: Union[Dict[str, bytes], Iterable["BluetoothServiceData"]],
+    value: Union[Dict[str, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[str, bytes]:
     if isinstance(value, dict):
         return value
@@ -802,18 +811,21 @@ def _convert_bluetooth_le_service_data(
     if not value:
         return {}
 
-    # Long UUID inlined to avoid call stack inside the dict comprehension
+    # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
+    if value[0].data:
+        return {
+            _cached_uuid_converter(v.uuid): bytes(v.data)  # type: ignore[union-attr]
+            for v in value
+        }
+
     return {
-        f"0000{v.uuid[2:].lower()}-0000-1000-8000-00805f9b34fb"  # type: ignore[union-attr]
-        if len(v.uuid) < 8  # type: ignore[union-attr]
-        # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
-        else v.uuid.lower(): bytes(v.data if v.data else v.legacy_data)  # type: ignore[union-attr]
+        _cached_uuid_converter(v.uuid): bytes(v.legacy_data)  # type: ignore[union-attr]
         for v in value
     }
 
 
 def _convert_bluetooth_le_manufacturer_data(
-    value: Union[Dict[int, bytes], Iterable["BluetoothServiceData"]],
+    value: Union[Dict[int, bytes], Collection["BluetoothServiceData"]],
 ) -> Dict[int, bytes]:
     if isinstance(value, dict):
         return value
@@ -822,7 +834,10 @@ def _convert_bluetooth_le_manufacturer_data(
         return {}
 
     # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
-    return {int(v.uuid, 16): bytes(v.data if v.data else v.legacy_data) for v in value}  # type: ignore
+    if value[0].data:
+        return {int(v.uuid, 16): bytes(v.data) for v in value}  # type: ignore
+
+    return {int(v.uuid, 16): bytes(v.legacy_data) for v in value}  # type: ignore
 
 
 def _convert_bluetooth_le_name(value: bytes) -> str:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1,13 +1,13 @@
 import enum
 from dataclasses import asdict, dataclass, field, fields
-from functools import cache
+from functools import cache, lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Dict,
     Iterable,
-    Collection,
     List,
     Optional,
     Type,
@@ -15,7 +15,6 @@ from typing import (
     Union,
     cast,
 )
-from functools import lru_cache
 from uuid import UUID
 
 from .util import fix_float_single_double_conversion

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
-VERSION = "13.6.1"
+VERSION = "13.6.0"
 PROJECT_NAME = "aioesphomeapi"
 PROJECT_PACKAGE_NAME = "aioesphomeapi"
 PROJECT_LICENSE = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
-VERSION = "13.6.0"
+VERSION = "13.6.1"
 PROJECT_NAME = "aioesphomeapi"
 PROJECT_PACKAGE_NAME = "aioesphomeapi"
 PROJECT_LICENSE = "MIT"


### PR DESCRIPTION
UUID conversions are a red hot execution path because of the number of BLE advertisements

`_convert_bluetooth_le_service_uuids` and `_convert_bluetooth_le_service_data` drop off the profile with this change

The hit rate on these is stellar since many proxies can mean upwards of 10000-25000 uuids conversions per minute even with only passive scans. With active scans we can reach 50/s per proxy

```
2023-04-04 23:55:51.124 CRITICAL (SyncWorker_5) [homeassistant.components.profiler] Cache stats for lru_cache <function _uuid_converter at 0x7fcd0976d5a0> at /usr/local/lib/python3.10/site-packages/aioesphomeapi/model.py: CacheInfo(hits=4996, misses=13, maxsize=1024, currsize=13)
2023-04-04 23:56:35.448 CRITICAL (SyncWorker_18) [homeassistant.components.profiler] Cache stats for lru_cache <function _uuid_converter at 0x7fcd0976d5a0> at /usr/local/lib/python3.10/site-packages/aioesphomeapi/model.py: CacheInfo(hits=7845, misses=14, maxsize=1024, currsize=14)
```

Even after a few minutes using a passive scanner we only have just a few of the same with 31933 hits!
`2023-04-05 00:02:15.330 CRITICAL (SyncWorker_12) [homeassistant.components.profiler] Cache stats for lru_cache <function _uuid_converter at 0x7fcd0976d5a0> at /usr/local/lib/python3.10/site-packages/aioesphomeapi/model.py: CacheInfo(hits=31933, misses=15, maxsize=1024, currsize=15)`

Even 128 probably is more than is needed but someone will have a device that throws off a lot of uuids:
`2023-04-05 00:11:09.666 CRITICAL (SyncWorker_2) [homeassistant.components.profiler] Cache stats for lru_cache <function _uuid_converter at 0x7f65d013b370> at /usr/local/lib/python3.10/site-packages/aioesphomeapi/model.py: CacheInfo(hits=1409, misses=10, maxsize=128, currsize=10)`
