### PR TITLE
Improve data throughput

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -349,8 +349,8 @@ class APINoiseFrameHelper(APIFrameHelper):
                 (
                     bytes(
                         [
-                            (type >> 8) & 0xFF,
-                            (type >> 0) & 0xFF,
+                            (type_ >> 8) & 0xFF,
+                            (type_ >> 0) & 0xFF,
                             (len(data) >> 8) & 0xFF,
                             (len(data) >> 0) & 0xFF,
                         ]

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import logging
 from abc import abstractmethod
-from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Optional, Union, cast
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -17,7 +17,6 @@ from ._frame_helper import (
     APIFrameHelper,
     APINoiseFrameHelper,
     APIPlaintextFrameHelper,
-    Packet,
 )
 from .api_pb2 import (  # type: ignore
     ConnectRequest,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -13,11 +13,7 @@ from google.protobuf import message
 
 import aioesphomeapi.host_resolver as hr
 
-from ._frame_helper import (
-    APIFrameHelper,
-    APINoiseFrameHelper,
-    APIPlaintextFrameHelper,
-)
+from ._frame_helper import APIFrameHelper, APINoiseFrameHelper, APIPlaintextFrameHelper
 from .api_pb2 import (  # type: ignore
     ConnectRequest,
     ConnectResponse,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -498,12 +498,7 @@ class APIConnection:
         _LOGGER.debug("%s: Sending %s: %s", self._params.address, type(msg), str(msg))
 
         try:
-            frame_helper.write_packet(
-                Packet(
-                    type=message_type,
-                    data=encoded,
-                )
-            )
+            frame_helper.write_packet(message_type, encoded)
         except SocketAPIError as err:  # pylint: disable=broad-except
             # If writing packet fails, we don't know what state the frames
             # are in anymore and we have to close the connection
@@ -646,9 +641,8 @@ class APIConnection:
         self._read_exception_handlers.clear()
         self._cleanup()
 
-    def _process_packet(self, pkt: Packet) -> None:
+    def _process_packet(self, msg_type_proto: int, data: bytes) -> None:
         """Process a packet from the socket."""
-        msg_type_proto = pkt.type
         if msg_type_proto not in MESSAGE_TYPE_TO_PROTO:
             _LOGGER.debug("%s: Skipping message type %s", self.log_name, msg_type_proto)
             return
@@ -658,19 +652,19 @@ class APIConnection:
             # MergeFromString instead of ParseFromString since
             # ParseFromString will clear the message first and
             # the msg is already empty.
-            msg.MergeFromString(pkt.data)
+            msg.MergeFromString(data)
         except Exception as e:
             _LOGGER.info(
                 "%s: Invalid protobuf message: type=%s data=%s: %s",
                 self.log_name,
-                pkt.type,
-                pkt.data,
+                msg_type_proto,
+                data,
                 e,
                 exc_info=True,
             )
             self._report_fatal_error(
                 ProtocolAPIError(
-                    f"Invalid protobuf message: type={pkt.type} data={pkt.data!r}: {e}"
+                    f"Invalid protobuf message: type={msg_type_proto} data={data!r}: {e}"
                 )
             )
             raise

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, Packet
+from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
 from aioesphomeapi.util import varuint_to_bytes
 
 PREAMBLE = b"\x00"
@@ -48,8 +48,8 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
     for _ in range(5):
         packets = []
 
-        def _packet(pkt: Packet):
-            packets.append(pkt)
+        def _packet(type_: int, data: bytes):
+            packets.append((type_, data))
 
         def _on_error(exc: Exception):
             raise exc
@@ -59,6 +59,7 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
         helper.data_received(in_bytes)
 
         pkt = packets.pop()
+        type_, data = pkt
 
-        assert pkt.type == pkt_type
-        assert pkt.data == pkt_data
+        assert type_ == pkt_type
+        assert data == pkt_data


### PR DESCRIPTION
Wrapping everything up in a simple dataclass and than unwrapping it per packet when processing 10000 per minute added a lot of run time and complexity.

As previous refactoring made the data simpler the wrapper for the raw bytes, which was only used internally, added some unneeded complexity.