### PR TITLE
Use sloted dataclass for BluetoothLEAdvertisement

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1,4 +1,5 @@
 import enum
+import sys
 from dataclasses import asdict, dataclass, field, fields
 from functools import cache, lru_cache
 from typing import (
@@ -18,6 +19,11 @@ from typing import (
 from uuid import UUID
 
 from .util import fix_float_single_double_conversion
+
+if sys.version_info[:2] < (3, 10):
+    _dataclass_decorator = dataclass()
+else:
+    _dataclass_decorator = dataclass(slots=True)
 
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore
@@ -846,11 +852,8 @@ def _convert_bluetooth_le_name(value: bytes) -> str:
     return value.decode("utf-8", errors="replace")
 
 
-@dataclass(frozen=True)
-class BluetoothLEAdvertisement(APIModelBase):
-    def __post_init__(self) -> None:
-        """Post init hook disabled."""
-
+@_dataclass_decorator
+class BluetoothLEAdvertisement:
     address: int
     rssi: int
     address_type: int

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -24,8 +24,8 @@ if sys.version_info[:2] < (3, 10):
     _dataclass_decorator = dataclass()
 else:
     _dataclass_decorator = dataclass(
-        slots=True # pylint: disable=unexpected-keyword-arg
-    )  
+        slots=True  # pylint: disable=unexpected-keyword-arg
+    )
 
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -23,7 +23,9 @@ from .util import fix_float_single_double_conversion
 if sys.version_info[:2] < (3, 10):
     _dataclass_decorator = dataclass()
 else:
-    _dataclass_decorator = dataclass(slots=True)
+    _dataclass_decorator = dataclass(
+        slots=True
+    )  # pylint: disable=unexpected-keyword-arg
 
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -23,8 +23,8 @@ from .util import fix_float_single_double_conversion
 if sys.version_info[:2] < (3, 10):
     _dataclass_decorator = dataclass()
 else:
-    _dataclass_decorator = dataclass(
-        slots=True  # pylint: disable=unexpected-keyword-arg
+    _dataclass_decorator = dataclass(  # pylint: disable=unexpected-keyword-arg
+        slots=True
     )
 
 if TYPE_CHECKING:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -24,8 +24,8 @@ if sys.version_info[:2] < (3, 10):
     _dataclass_decorator = dataclass()
 else:
     _dataclass_decorator = dataclass(
-        slots=True
-    )  # pylint: disable=unexpected-keyword-arg
+        slots=True # pylint: disable=unexpected-keyword-arg
+    )  
 
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
-VERSION = "13.7.0"
+VERSION = "13.7.1"
 PROJECT_NAME = "aioesphomeapi"
 PROJECT_PACKAGE_NAME = "aioesphomeapi"
 PROJECT_LICENSE = "MIT"


### PR DESCRIPTION
The goal is to reduce the memory overhead of these objects since we have a lot of them floating around.  (10k/min on some of my production installs)

I also removed the APIModelBase because nothing is checking for it and we can avoid the `__post_init__` override. Since most of the data is `dict`s/`list`s which can be modified it did not make sense to pay the cost of frozen since it is not actually protecting the data

https://docs.python.org/3.9/library/dataclasses.html#frozen-instances

This is roughly a 15% speed up as well