### PR TITLE
Remove _convert_bluetooth_le_name as it did not need to be its own function

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -842,10 +842,6 @@ def _convert_bluetooth_le_manufacturer_data(
     return {int(v.uuid, 16): bytes(v.legacy_data) for v in value}  # type: ignore
 
 
-def _convert_bluetooth_le_name(value: bytes) -> str:
-    return value.decode("utf-8", errors="replace")
-
-
 @dataclass(frozen=True)
 class BluetoothLEAdvertisement(APIModelBase):
     def __post_init__(self) -> None:
@@ -867,7 +863,7 @@ class BluetoothLEAdvertisement(APIModelBase):
             address=data.address,
             rssi=data.rssi,
             address_type=data.address_type,
-            name=_convert_bluetooth_le_name(data.name),
+            name=data.name.decode("utf-8", errors="replace"),
             service_uuids=_convert_bluetooth_le_service_uuids(data.service_uuids),
             service_data=_convert_bluetooth_le_service_data(data.service_data),
             manufacturer_data=_convert_bluetooth_le_manufacturer_data(


### PR DESCRIPTION
This was only used in one place. I had originally had more code in it but I did not think to collapse it when I removed the code since it turned out to be smaller expected.

I only noticed because I had to turn on active scans to test something else and it was called 30000/min 