### PR TITLE
Hold strong references to voice assistant tasks

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -235,7 +235,7 @@ class APIClient:
         )
         self._connection: Optional[APIConnection] = None
         self._cached_name: Optional[str] = None
-        self._background_tasks: set[asyncio.Task] = set()
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
     @property
     def expected_name(self) -> Optional[str]:

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -235,6 +235,7 @@ class APIClient:
         )
         self._connection: Optional[APIConnection] = None
         self._cached_name: Optional[str] = None
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
     @property
     def expected_name(self) -> Optional[str]:
@@ -1280,6 +1281,8 @@ class APIClient:
                 task.add_done_callback(_started)
             else:
                 task = asyncio.create_task(handle_stop())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         assert self._connection is not None
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -235,7 +235,6 @@ class APIClient:
         )
         self._connection: Optional[APIConnection] = None
         self._cached_name: Optional[str] = None
-        self._background_tasks: set[asyncio.Task[Any]] = set()
 
     @property
     def expected_name(self) -> Optional[str]:
@@ -1281,8 +1280,6 @@ class APIClient:
                 task.add_done_callback(_started)
             else:
                 task = asyncio.create_task(handle_stop())
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
 
         assert self._connection is not None
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1281,7 +1281,7 @@ class APIClient:
                 task.add_done_callback(_started)
             else:
                 task = asyncio.create_task(handle_stop())
-            self._background_tasks.add(t)
+            self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
 
         assert self._connection is not None

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1263,7 +1263,7 @@ class APIClient:
         """
         self._check_authenticated()
 
-        t: Optional[asyncio.Task[Optional[int]]] = None
+        task: Optional[asyncio.Task[Optional[int]]] = None
 
         def _started(fut: asyncio.Task[Optional[int]]) -> None:
             if self._connection is not None and not fut.cancelled():
@@ -1299,8 +1299,8 @@ class APIClient:
                     SubscribeVoiceAssistantRequest(subscribe=False)
                 )
 
-            if t is not None and not t.cancelled():
-                t.cancel()
+            if task is not None and not task.cancelled():
+                task.cancel()
 
         return unsub
 


### PR DESCRIPTION
`start_task` has a reference in `unsub` which the caller holds
`stop_task` did not have a strong reference. To prevent it from being garbage collected its now held in background tasks


https://github.com/esphome/aioesphomeapi/pull/412/files#r1162523622