### PR TITLE
Reduce overhead to process bluetooth advertisements

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
     Dict,
     Iterable,
     List,
@@ -30,7 +29,6 @@ else:
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore
         BluetoothLEAdvertisementResponse,
-        BluetoothServiceData,
         HomeassistantServiceMap,
     )
 
@@ -818,24 +816,25 @@ class BluetoothLEAdvertisement:
         _uuid_convert = _cached_uuid_converter
 
         if raw_manufacturer_data := data.manufacturer_data:
-            if raw_manufacturer_data[0].data:  # type: ignore
-                manufacturer_data = {int(v.uuid, 16): v.data for v in raw_manufacturer_data}  # type: ignore
+            if raw_manufacturer_data[0].data:
+                manufacturer_data = {
+                    int(v.uuid, 16): v.data for v in raw_manufacturer_data
+                }
             else:
                 # Legacy data
-                manufacturer_data = {int(v.uuid, 16): bytes(v.legacy_data) for v in raw_manufacturer_data}  # type: ignore
+                manufacturer_data = {
+                    int(v.uuid, 16): bytes(v.legacy_data) for v in raw_manufacturer_data
+                }
         else:
             manufacturer_data = {}
 
         if raw_service_data := data.raw_service_data:
-            if raw_service_data.data:  # type: ignore
-                service_data = {
-                    _uuid_convert(v.uuid): v.data  # type: ignore[union-attr]
-                    for v in raw_service_data
-                }
+            if raw_service_data.data:
+                service_data = {_uuid_convert(v.uuid): v.data for v in raw_service_data}
             else:
                 # Legacy data
                 service_data = {
-                    _uuid_convert(v.uuid): bytes(v.legacy_data)  # type: ignore[union-attr]
+                    _uuid_convert(v.uuid): bytes(v.legacy_data)
                     for v in raw_service_data
                 }
         else:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -839,7 +839,7 @@ class BluetoothLEAdvertisement:
                     for v in raw_service_data
                 }
         else:
-            service_data = []
+            service_data = {}
 
         if raw_service_uuids := data.service_uuids:
             service_uuids = [_uuid_convert(v) for v in raw_service_uuids]

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -823,7 +823,7 @@ def _convert_bluetooth_le_service_data(
     # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
     if value[0].data:  # type: ignore
         return {
-            _cached_uuid_converter(v.uuid): bytes(v.data)  # type: ignore[union-attr]
+            _cached_uuid_converter(v.uuid): v.data  # type: ignore[union-attr]
             for v in value
         }
 
@@ -845,7 +845,7 @@ def _convert_bluetooth_le_manufacturer_data(
 
     # v.data if v.data else v.legacy_data is backwards compatible with ESPHome devices before 2022.10.0
     if value[0].data:  # type: ignore
-        return {int(v.uuid, 16): bytes(v.data) for v in value}  # type: ignore
+        return {int(v.uuid, 16): v.data for v in value}  # type: ignore
 
     return {int(v.uuid, 16): bytes(v.legacy_data) for v in value}  # type: ignore
 

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -829,7 +829,7 @@ class BluetoothLEAdvertisement:
             manufacturer_data = {}
 
         if raw_service_data := data.service_data:
-            if raw_service_data.data:
+            if raw_service_data[0].data:
                 service_data = {_uuid_convert(v.uuid): v.data for v in raw_service_data}
             else:
                 # Legacy data

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -828,7 +828,7 @@ class BluetoothLEAdvertisement:
         else:
             manufacturer_data = {}
 
-        if raw_service_data := data.raw_service_data:
+        if raw_service_data := data.service_data:
             if raw_service_data.data:
                 service_data = {_uuid_convert(v.uuid): v.data for v in raw_service_data}
             else:


### PR DESCRIPTION
Since we only ever convert these from protobuf we can reduce the branching and collapse the conversion functions.

The bytes recopy is now avoided in the dict comps.

Will run this on production for a while to be sure

Processing these is still the largest time for all the esphome code.

<img width="1240" alt="Screenshot 2023-05-13 at 4 27 34 PM" src="https://github.com/esphome/aioesphomeapi/assets/663432/d46f7805-742b-4ed0-b3a5-de415b6eaee8">

This works out to ~17% speed up