### PR TITLE
Fix more cases where incorrect encryption keys were not detected

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -9,6 +9,7 @@ import async_timeout
 from noise.connection import NoiseConnection  # type: ignore
 
 from .core import (
+    APIConnectionError,
     BadNameAPIError,
     HandshakeAPIError,
     InvalidEncryptionKeyAPIError,
@@ -16,7 +17,6 @@ from .core import (
     RequiresEncryptionAPIError,
     SocketAPIError,
     SocketClosedAPIError,
-    APIConnectionError,
 )
 from .util import bytes_to_varuint, varuint_to_bytes
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -264,8 +264,6 @@ class APINoiseFrameHelper(APIFrameHelper):
                 ]
             )
             self._transport.write(header + frame)
-            if debug:
-                _LOGGER.debug("Sending encrypted frame: [%s]", (header + frame).hex())
         except (RuntimeError, ConnectionResetError, OSError) as err:
             raise SocketAPIError(f"Error while writing data: {err}") from err
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -231,12 +231,14 @@ class APINoiseFrameHelper(APIFrameHelper):
         # Make sure we set the ready event if its not already set
         # so that we don't block forever on the ready event if we
         # are waiting for the handshake to complete.
-        self._ready_future.set_exception(APIConnectionError("Connection closed"))
+        if not self._ready_future.done():
+            self._ready_future.set_exception(APIConnectionError("Connection closed"))
         self._state = NoiseConnectionState.CLOSED
         super().close()
 
     def _handle_error_and_close(self, exc: Exception) -> None:
-        self._ready_future.set_exception(exc)
+        if not self._ready_future.done():
+            self._ready_future.set_exception(exc)
         super()._handle_error_and_close(exc)
 
     def _write_frame(self, frame: bytes) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -291,9 +291,6 @@ class APINoiseFrameHelper(APIFrameHelper):
             msg_size = (header[1] << 8) | header[2]
             frame = self._read_exactly(msg_size)
 
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug("Read frame with header: [%s]", (header + frame).hex())
-
             if frame is None:
                 return
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -280,8 +280,6 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def data_received(self, data: bytes) -> None:
         self._buffer += data
-        import pprint
-        pprint.pprint(['data_received',data])
         while len(self._buffer) >= 3:
             header = self._init_read(3)
             assert header is not None, "Buffer should have at least 3 bytes"
@@ -295,9 +293,6 @@ class APINoiseFrameHelper(APIFrameHelper):
 
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug("Read frame with header: [%s]", (header + frame).hex())
-
-            import pprint
-            pprint.pprint(['frame',frame])
 
             if frame is None:
                 return

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -398,7 +398,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             )
             return
         data = msg[4 : 4 + data_len]
-        return self._on_pkt(pkt_type, data)
+        self._on_pkt(pkt_type, data)
 
     def _handle_closed(  # pylint: disable=unused-argument
         self, frame: bytearray

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -6,9 +6,9 @@ from enum import Enum
 from typing import Callable, Optional, Union, cast
 
 import async_timeout
+from cryptography.exceptions import InvalidTag
 from noise.connection import NoiseConnection  # type: ignore
 
-from cryptography.exceptions import InvalidTag  
 from .core import (
     APIConnectionError,
     BadNameAPIError,

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -16,6 +16,7 @@ from .core import (
     RequiresEncryptionAPIError,
     SocketAPIError,
     SocketClosedAPIError,
+    APIConnectionError,
 )
 from .util import bytes_to_varuint, varuint_to_bytes
 
@@ -219,7 +220,7 @@ class APINoiseFrameHelper(APIFrameHelper):
     ) -> None:
         """Initialize the API frame helper."""
         super().__init__(on_pkt, on_error)
-        self._ready_event = asyncio.Event()
+        self._ready_future = asyncio.get_event_loop().create_future()
         self._noise_psk = noise_psk
         self._expected_name = expected_name
         self._state = NoiseConnectionState.HELLO
@@ -230,9 +231,13 @@ class APINoiseFrameHelper(APIFrameHelper):
         # Make sure we set the ready event if its not already set
         # so that we don't block forever on the ready event if we
         # are waiting for the handshake to complete.
-        self._ready_event.set()
+        self._ready_future.set_exception(APIConnectionError("Connection closed"))
         self._state = NoiseConnectionState.CLOSED
         super().close()
+
+    def _handle_error_and_close(self, exc: Exception) -> None:
+        self._ready_future.set_exception(exc)
+        super()._handle_error_and_close(exc)
 
     def _write_frame(self, frame: bytes) -> None:
         """Write a packet to the socket, the caller should not have the lock.
@@ -260,7 +265,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._send_hello()
         try:
             async with async_timeout.timeout(60.0):
-                await self._ready_event.wait()
+                await self._ready_future
         except asyncio.TimeoutError as err:
             raise HandshakeAPIError("Timeout during handshake") from err
 
@@ -273,6 +278,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 self._handle_error_and_close(
                     ProtocolAPIError(f"Marker byte invalid: {header[0]}")
                 )
+                return
             msg_size = (header[1] << 8) | header[2]
             frame = self._read_exactly(msg_size)
             if frame is None:
@@ -293,6 +299,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Perform the handshake with the server, the caller is responsible for having the lock."""
         if not server_hello:
             self._handle_error_and_close(HandshakeAPIError("ServerHello is empty"))
+            return
 
         # First byte of server hello is the protocol the server chose
         # for this session. Currently only 0x01 (Noise_NNpsk0_25519_ChaChaPoly_SHA256)
@@ -302,6 +309,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             self._handle_error_and_close(
                 HandshakeAPIError(f"Unknown protocol selected by client {chosen_proto}")
             )
+            return
 
         # Check name matches expected name (for noise sessions, this is done
         # during hello phase before a connection is set up)
@@ -316,6 +324,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                         f"Server sent a different name '{server_name}'", server_name
                     )
                 )
+                return
 
         self._state = NoiseConnectionState.HANDSHAKE
         self._send_handshake()
@@ -340,13 +349,15 @@ class APINoiseFrameHelper(APIFrameHelper):
                 self._handle_error_and_close(
                     InvalidEncryptionKeyAPIError("Invalid encryption key")
                 )
+                return
             self._handle_error_and_close(
                 HandshakeAPIError(f"Handshake failure: {explanation}")
             )
+            return
         self._proto.read_message(msg[1:])
         _LOGGER.debug("Handshake complete")
         self._state = NoiseConnectionState.READY
-        self._ready_event.set()
+        self._ready_future.set_result(None)
 
     def write_packet(self, type_: int, data: bytes) -> None:
         """Write a packet to the socket."""
@@ -374,12 +385,14 @@ class APINoiseFrameHelper(APIFrameHelper):
         msg = self._proto.decrypt(bytes(frame))
         if len(msg) < 4:
             self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg}"))
+            return
         pkt_type = (msg[0] << 8) | msg[1]
         data_len = (msg[2] << 8) | msg[3]
         if data_len + 4 > len(msg):
             self._handle_error_and_close(
                 ProtocolAPIError(f"Bad data len: {data_len} vs {len(msg)}")
             )
+            return
         data = msg[4 : 4 + data_len]
         return self._on_pkt(pkt_type, data)
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -226,19 +226,21 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NoiseConnectionState.HELLO
         self._setup_proto()
 
+    def _set_ready_future_exception(self, exc: Exception) -> None:
+        if not self._ready_future.done():
+            self._ready_future.set_exception(exc)
+
     def close(self) -> None:
         """Close the connection."""
         # Make sure we set the ready event if its not already set
         # so that we don't block forever on the ready event if we
         # are waiting for the handshake to complete.
-        if not self._ready_future.done():
-            self._ready_future.set_exception(APIConnectionError("Connection closed"))
+        self._set_ready_future_exception(APIConnectionError("Connection closed"))
         self._state = NoiseConnectionState.CLOSED
         super().close()
 
     def _handle_error_and_close(self, exc: Exception) -> None:
-        if not self._ready_future.done():
-            self._ready_future.set_exception(exc)
+        self._set_ready_future_exception(exc)
         super()._handle_error_and_close(exc)
 
     def _write_frame(self, frame: bytes) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -250,9 +250,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         The entire packet must be written in a single call to write
         to avoid locking.
         """
-        debug = _LOGGER.isEnabledFor(logging.DEBUG)
         assert self._transport is not None, "Transport is not set"
-        if debug:
+        if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("Sending frame: [%s]", frame.hex())
 
         try:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -29,6 +29,7 @@ from .api_pb2 import (  # type: ignore
 from .core import (
     MESSAGE_TYPE_TO_PROTO,
     APIConnectionError,
+    ConnectionNotEstablishedAPIError,
     BadNameAPIError,
     HandshakeAPIError,
     InvalidAuthAPIError,
@@ -493,7 +494,7 @@ class APIConnection:
     def send_message(self, msg: message.Message) -> None:
         """Send a protobuf message to the remote."""
         if not self._is_socket_open:
-            raise APIConnectionError(
+            raise ConnectionNotEstablishedAPIError(
                 f"Connection isn't established yet ({self._connection_state})"
             )
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -646,7 +646,7 @@ class APIConnection:
                 "%s: Connection error occurred: %s",
                 self.log_name,
                 err or type(err),
-                exc_info=True,  # not str(err),  # Log the full stack on empty error string
+                exc_info=not str(err),  # Log the full stack on empty error string
             )
         self._fatal_exception = err
         self._connection_state = ConnectionState.CLOSED

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -29,8 +29,8 @@ from .api_pb2 import (  # type: ignore
 from .core import (
     MESSAGE_TYPE_TO_PROTO,
     APIConnectionError,
-    ConnectionNotEstablishedAPIError,
     BadNameAPIError,
+    ConnectionNotEstablishedAPIError,
     HandshakeAPIError,
     InvalidAuthAPIError,
     PingFailedAPIError,

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -183,6 +183,10 @@ class HandshakeAPIError(APIConnectionError):
     pass
 
 
+class ConnectionNotEstablishedAPIError(APIConnectionError):
+    pass
+
+
 class BadNameAPIError(APIConnectionError):
     """Raised when a name received from the remote but does not much the expected name."""
 

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -112,7 +112,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 "Can't connect to ESPHome API for %s: %s (%s)",
                 self._log_name,
                 err,
-                type(err),
+                type(err).__name__,
                 # Print stacktrace if unhandled (not APIConnectionError)
                 exc_info=not isinstance(err, APIConnectionError),
             )

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -5,13 +5,12 @@ from typing import Awaitable, Callable, List, Optional
 import zeroconf
 
 from .client import APIClient
-from .core import APIConnectionError
 from .core import (
+    APIConnectionError,
+    InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
     RequiresEncryptionAPIError,
-    InvalidAuthAPIError,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,9 +109,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             level = logging.WARNING if self._tries == 0 else logging.DEBUG
             _LOGGER.log(
                 level,
-                "Can't connect to ESPHome API for %s: %s",
+                "Can't connect to ESPHome API for %s: %s (%s)",
                 self._log_name,
                 err,
+                type(err),
                 # Print stacktrace if unhandled (not APIConnectionError)
                 exc_info=not isinstance(err, APIConnectionError),
             )

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, APINoiseFrameHelper
-from aioesphomeapi.util import varuint_to_bytes
+from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi.core import InvalidEncryptionKeyAPIError
+from aioesphomeapi.util import varuint_to_bytes
+
 PREAMBLE = b"\x00"
 
 
@@ -65,17 +66,16 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
         assert data == pkt_data
 
 
-
 @pytest.mark.asyncio
 async def test_noise_frame_helper_incorrect_key():
     """Test that the noise frame helper can perform a handshake with the ESPHome device."""
     outgoing_packets = [
-        "010000", # hello packet
-        "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4"
+        "010000",  # hello packet
+        "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4",
     ]
     incoming_packets = [
         "01000d01736572766963657465737400",
-        "0100160148616e647368616b65204d4143206661696c757265"
+        "0100160148616e647368616b65204d4143206661696c757265",
     ]
     packets = []
 
@@ -85,14 +85,19 @@ async def test_noise_frame_helper_incorrect_key():
     def _on_error(exc: Exception):
         raise exc
 
-    helper = APINoiseFrameHelper(on_pkt=_packet, on_error=_on_error, noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=", expected_name="servicetest")
+    helper = APINoiseFrameHelper(
+        on_pkt=_packet,
+        on_error=_on_error,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+    )
     helper._transport = MagicMock()
 
     for pkt in outgoing_packets:
         helper._write_frame(bytes.fromhex(pkt))
 
     with pytest.raises(InvalidEncryptionKeyAPIError):
-        for pkt in incoming_packets:    
+        for pkt in incoming_packets:
             helper.data_received(bytes.fromhex(pkt))
 
     with pytest.raises(InvalidEncryptionKeyAPIError):

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
-from aioesphomeapi.core import InvalidEncryptionKeyAPIError, BadNameAPIError
+from aioesphomeapi.core import BadNameAPIError, InvalidEncryptionKeyAPIError
 from aioesphomeapi.util import varuint_to_bytes
 
 PREAMBLE = b"\x00"
@@ -102,7 +102,6 @@ async def test_noise_frame_helper_incorrect_key():
 
     with pytest.raises(InvalidEncryptionKeyAPIError):
         await helper.perform_handshake()
-
 
 
 @pytest.mark.asyncio

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
+from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, APINoiseFrameHelper
 from aioesphomeapi.util import varuint_to_bytes
 
 PREAMBLE = b"\x00"
@@ -63,3 +63,65 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
 
         assert type_ == pkt_type
         assert data == pkt_data
+
+@pytest.mark.asyncio
+async def test_noise_frame_helper_good_handshake():
+    """Test that the noise frame helper can perform a handshake with the ESPHome device."""
+    outgoing_packets = [
+        "010000", # hello packet
+        "010031006e6853c8afd676b53888df3b1ff0e0742c762888855c54b96a5b6e17366c53046ab29bd5f7bb59f48182ea190620a1fd"
+    ]
+    incoming_packets = [
+        "01000d01736572766963657465737400",
+        "01003100900d0da775dfe4744fe4498d32efc666b6ee30664b3047285d84f42a1f8bb16e574317a29f941a605a25b10a32615ac0"
+    ]
+    packets = []
+
+    def _packet(type_: int, data: bytes):
+        packets.append((type_, data))
+
+    def _on_error(exc: Exception):
+        raise exc
+
+    helper = APINoiseFrameHelper(on_pkt=_packet, on_error=_on_error, noise_psk="OIwNWQp2NSwmf7BwfEywyAc9HMijdsef7Kate7b2K14=", expected_name="servicetest")
+    helper._transport = MagicMock()
+
+    for pkt in outgoing_packets:
+        helper._write_frame(bytes.fromhex(pkt))
+
+    for pkt in incoming_packets:    
+        helper.data_received(bytes.fromhex(pkt))
+
+    await helper.perform_handshake()
+
+
+@pytest.mark.asyncio
+async def test_noise_frame_helper_incorrect_key():
+    """Test that the noise frame helper can perform a handshake with the ESPHome device."""
+    outgoing_packets = [
+        "010000", # hello packet
+        "01003100be5444d8e188e893963fea601d94c0aa557a9a5ea628e6405beba115f17a312c07d03c2985bf476b55790ea7e74d617d"
+    ]
+    incoming_packets = [
+        "0148616e647368616b65204d4143206661696c757265",
+    ]
+    packets = []
+
+    def _packet(type_: int, data: bytes):
+        packets.append((type_, data))
+
+    def _on_error(exc: Exception):
+        raise exc
+
+    helper = APINoiseFrameHelper(on_pkt=_packet, on_error=_on_error, noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=", expected_name="servicetest")
+    helper._transport = MagicMock()
+
+    for pkt in outgoing_packets:
+        helper._write_frame(bytes.fromhex(pkt))
+
+    for pkt in incoming_packets:    
+        helper.data_received(bytes.fromhex(pkt))
+
+    import pprint
+    pprint.pprint(['wait for handshake'])
+    await helper.perform_handshake()

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -68,7 +68,7 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
 
 @pytest.mark.asyncio
 async def test_noise_frame_helper_incorrect_key():
-    """Test that the noise frame helper can perform a handshake with the ESPHome device."""
+    """Test that the noise frame helper raises InvalidEncryptionKeyAPIError on bad key."""
     outgoing_packets = [
         "010000",  # hello packet
         "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4",

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -5,7 +5,7 @@ import pytest
 
 from aioesphomeapi._frame_helper import APIPlaintextFrameHelper, APINoiseFrameHelper
 from aioesphomeapi.util import varuint_to_bytes
-
+from aioesphomeapi.core import InvalidEncryptionKeyAPIError
 PREAMBLE = b"\x00"
 
 
@@ -100,10 +100,11 @@ async def test_noise_frame_helper_incorrect_key():
     """Test that the noise frame helper can perform a handshake with the ESPHome device."""
     outgoing_packets = [
         "010000", # hello packet
-        "01003100be5444d8e188e893963fea601d94c0aa557a9a5ea628e6405beba115f17a312c07d03c2985bf476b55790ea7e74d617d"
+        "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4"
     ]
     incoming_packets = [
-        "0148616e647368616b65204d4143206661696c757265",
+        "01000d01736572766963657465737400",
+        "0100160148616e647368616b65204d4143206661696c757265"
     ]
     packets = []
 
@@ -119,9 +120,9 @@ async def test_noise_frame_helper_incorrect_key():
     for pkt in outgoing_packets:
         helper._write_frame(bytes.fromhex(pkt))
 
-    for pkt in incoming_packets:    
-        helper.data_received(bytes.fromhex(pkt))
+    with pytest.raises(InvalidEncryptionKeyAPIError):
+        for pkt in incoming_packets:    
+            helper.data_received(bytes.fromhex(pkt))
 
-    import pprint
-    pprint.pprint(['wait for handshake'])
-    await helper.perform_handshake()
+    with pytest.raises(InvalidEncryptionKeyAPIError):
+        await helper.perform_handshake()

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -64,35 +64,6 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
         assert type_ == pkt_type
         assert data == pkt_data
 
-@pytest.mark.asyncio
-async def test_noise_frame_helper_good_handshake():
-    """Test that the noise frame helper can perform a handshake with the ESPHome device."""
-    outgoing_packets = [
-        "010000", # hello packet
-        "010031006e6853c8afd676b53888df3b1ff0e0742c762888855c54b96a5b6e17366c53046ab29bd5f7bb59f48182ea190620a1fd"
-    ]
-    incoming_packets = [
-        "01000d01736572766963657465737400",
-        "01003100900d0da775dfe4744fe4498d32efc666b6ee30664b3047285d84f42a1f8bb16e574317a29f941a605a25b10a32615ac0"
-    ]
-    packets = []
-
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
-
-    def _on_error(exc: Exception):
-        raise exc
-
-    helper = APINoiseFrameHelper(on_pkt=_packet, on_error=_on_error, noise_psk="OIwNWQp2NSwmf7BwfEywyAc9HMijdsef7Kate7b2K14=", expected_name="servicetest")
-    helper._transport = MagicMock()
-
-    for pkt in outgoing_packets:
-        helper._write_frame(bytes.fromhex(pkt))
-
-    for pkt in incoming_packets:    
-        helper.data_received(bytes.fromhex(pkt))
-
-    await helper.perform_handshake()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
see https://github.com/home-assistant/core/issues/94663

- Fix encryption error being overridden by another exception

- Fix encryption error not being raised because cleanup fails with a different exception which overshadows it

- Ensure that an exception during an asyncio.Protocol callback is reported upward by switching from an event to a future

- Backoff to maximum time on password or encryption error as we do not want to keep hammering the device if the reason we cannot connect is auth
