### PR TITLE
Speed up noise by using chacha20poly1305-reuseable

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -8,9 +8,9 @@ from typing import Any, Callable, Optional, Union, cast
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
-from noise.backends.default import DefaultNoiseBackend
-from noise.backends.default.ciphers import ChaCha20Cipher
-from noise.connection import NoiseConnection  # type: ignore
+from noise.backends.default import DefaultNoiseBackend,  # type: ignore[import]
+from noise.backends.default.ciphers import ChaCha20Cipher # type: ignore[import]
+from noise.connection import NoiseConnection  # type: ignore[import]
 
 from .core import (
     APIConnectionError,

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -45,7 +45,7 @@ class ChaCha20CipherReuseable(ChaCha20Cipher):
 class ESPHomeNoiseBackend(DefaultNoiseBackend):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.ciphers["ChaChaPoly"] = ChaCha20CipherReuseable()
+        self.ciphers["ChaChaPoly"] = ChaCha20CipherReuseable
 
 
 ESPHOME_NOISE_BACKEND = ESPHomeNoiseBackend()

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -34,13 +34,13 @@ SOCKET_ERRORS = (
 )
 
 
-class ChaCha20CipherReuseable(ChaCha20Cipher):
+class ChaCha20CipherReuseable(ChaCha20Cipher):  # type: ignore[misc]
     @property
-    def klass(self):
+    def klass(self):  # type: ignore[no-untyped-def]
         return ChaCha20Poly1305Reusable
 
 
-class ESPHomeNoiseBackend(DefaultNoiseBackend):
+class ESPHomeNoiseBackend(DefaultNoiseBackend):  # type: ignore[misc]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.ciphers["ChaChaPoly"] = ChaCha20CipherReuseable

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Optional, Union, cast
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
-from noise.backends.default import DefaultNoiseBackend,  # type: ignore[import]
-from noise.backends.default.ciphers import ChaCha20Cipher # type: ignore[import]
+from noise.backends.default import DefaultNoiseBackend  # type: ignore[import]
+from noise.backends.default.ciphers import ChaCha20Cipher  # type: ignore[import]
 from noise.connection import NoiseConnection  # type: ignore[import]
 
 from .core import (

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -3,7 +3,7 @@ import base64
 import logging
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Callable, Optional, Tuple, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -3,10 +3,13 @@ import base64
 import logging
 from abc import abstractmethod
 from enum import Enum
-from typing import Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Tuple, Union, cast
 
 import async_timeout
+from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
+from noise.backends.default import DefaultNoiseBackend
+from noise.backends.default.ciphers import ChaCha20Cipher
 from noise.connection import NoiseConnection  # type: ignore
 
 from .core import (
@@ -29,11 +32,6 @@ SOCKET_ERRORS = (
     OSError,
     TimeoutError,
 )
-from typing import Any, Optional, Tuple, Union
-
-from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
-from noise.backends.default import DefaultNoiseBackend
-from noise.backends.default.ciphers import ChaCha20Cipher
 
 
 class ChaCha20CipherReuseable(ChaCha20Cipher):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
+chacha20poly1305-reuseable>=0.2.5
 noiseprotocol>=0.3.1,<1.0
 async-timeout>=4.0


### PR DESCRIPTION
Using noise currently incurs a performance penalty (enough that not using it is sometimes a understandable reason). It's a bit uncomfortable being in a position of having to ask users to turn off noise because they have so many esphome devices that it's overwhelming their ha running on raspberry pi (eof errors, connection drops, etc). The goal is to get that penalty closer to zero to eliminate any reason not to use noise (if only eap8266 had just a bit more ram we ... but that's a another issue).

chacha20poly1305-reuseable is a faster drop-in replacement version of chacha20poly1305 which does not use the thread locking that the cryptography base implementation uses since asyncio does not need the ability to encrypt/decrypt in different threads.

Home Assistant currently uses `chacha20poly1305-reuseable` for `HAP-python`, `aiohomekit`, and `pyatv` as they also use long running data streams with similar applications

Wheels are available via ciwheelbuild https://pypi.org/project/chacha20poly1305-reuseable/#files and HA is already building wheels for this library https://wheels.home-assistant.io/musllinux/. The library uses cython to reduce python overhead as well but falls back to pure-python if cython is not available. This allows us to avoid a breaking change in the event for some reason the library can't be compiled with cython (the wheels are more widely available than cryptography so this is unlikely). Additionally, the library is well covered https://app.codecov.io/gh/bdraco/chacha20poly1305-reuseable/blob/main/src%2Fchacha20poly1305_reuseable%2F__init__.py and works on python as old as 3.7
 
In testing bluetooth workloads this was ~68-82% less run time with the cython backend, YMMV with architecture as the savings were on the higher side for x86_64 but on the lower side for armv7