### PR TITLE
Include the server name in the exception for invalid encryption key

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -212,7 +212,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # If we have more data, continue processing
 
 
-def _decode_noise_psk(psk: str, server_name: str | None) -> bytes:
+def _decode_noise_psk(psk: str, server_name: Optional[str]) -> bytes:
     """Decode the given noise psk from base64 format to raw bytes."""
     try:
         psk_bytes = base64.b64decode(psk)

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -191,12 +191,14 @@ class BadNameAPIError(APIConnectionError):
     """Raised when a name received from the remote but does not much the expected name."""
 
     def __init__(self, msg: str, received_name: str) -> None:
-        super().__init__(msg)
+        super().__init__(f"{msg}: received_name={received_name}")
         self.received_name = received_name
 
 
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
-    pass
+    def __init__(self, msg: str, received_name: str | None) -> None:
+        super().__init__(f"{msg}: received_name={received_name}")
+        self.received_name = received_name
 
 
 class PingFailedAPIError(APIConnectionError):

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from aioesphomeapi.model import BluetoothGATTError
 
@@ -196,7 +197,7 @@ class BadNameAPIError(APIConnectionError):
 
 
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
-    def __init__(self, msg: str, received_name: str | None) -> None:
+    def __init__(self, msg: str, received_name: Optional[str]) -> None:
         super().__init__(f"{msg}: received_name={received_name}")
         self.received_name = received_name
 

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -197,7 +197,9 @@ class BadNameAPIError(APIConnectionError):
 
 
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
-    def __init__(self, msg: str, received_name: Optional[str]) -> None:
+    def __init__(
+        self, msg: Optional[str] = None, received_name: Optional[str] = None
+    ) -> None:
         super().__init__(f"{msg}: received_name={received_name}")
         self.received_name = received_name
 


### PR DESCRIPTION
HA cannot figure out which device to get from the dashboard without the server name if we only have the IP

The pattern in HA needs to change to

get_device_info ->fails with needs encryption key 
try again with encryption key or empty one
Get device name
get name from dashboard
get key
try again