### PR TITLE
Use slots for APIConnection and APIClient

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -206,6 +206,13 @@ ExecuteServiceDataType = Dict[
 
 # pylint: disable=too-many-public-methods
 class APIClient:
+    __slots__ = (
+        "_params",
+        "_connection",
+        "_cached_name",
+        "_background_tasks",
+    )
+
     def __init__(
         self,
         address: str,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -115,6 +115,28 @@ class APIConnection:
     a new instance should be established.
     """
 
+    __slots__ = (
+        "_params",
+        "on_stop",
+        "_on_stop_task",
+        "_socket",
+        "_frame_helper",
+        "_api_version",
+        "_connection_state",
+        "_is_authenticated",
+        "_connect_complete",
+        "_message_handlers",
+        "log_name",
+        "_read_exception_handlers",
+        "_ping_timer",
+        "_pong_timer",
+        "_keep_alive_interval",
+        "_keep_alive_timeout",
+        "_connect_task",
+        "_fatal_exception",
+        "_expected_disconnect",
+    )
+
     def __init__(
         self,
         params: ConnectionParams,


### PR DESCRIPTION
This is a small performance improvement since we do so many callbacks to access self 

The tests have been refactored to avoid patching the client or connection anymore to get a better end to end test