### PR TITLE
Reduce protocol overhead

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -149,7 +149,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         """Perform the handshake."""
         await self._connected_event.wait()
 
-    def data_received(self, data: bytes) -> None:
+    def data_received(self, data: bytes) -> None: # pylint: disable=too-many-branches
         self._buffer += data
         while len(self._buffer) >= 3:
             # Read preamble, which should always 0x00

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -149,7 +149,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         """Perform the handshake."""
         await self._connected_event.wait()
 
-    def data_received(self, data: bytes) -> None: # pylint: disable=too-many-branches
+    def data_received(self, data: bytes) -> None:  # pylint: disable=too-many-branches
         self._buffer += data
         while len(self._buffer) >= 3:
             # Read preamble, which should always 0x00

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -479,7 +479,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             msg = self._decrypt(frame)
         except InvalidTag as ex:
             self._handle_error_and_close(
-                ProtocolAPIError(f"Bad encryption frame: {ex}")
+                ProtocolAPIError(f"Bad encryption frame: {ex!r}")
             )
             return
         msg_len = len(msg)

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -156,6 +156,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Also try to get the length and msg type
             # to avoid multiple calls to readexactly
             init_bytes = self._init_read(3)
+            msg_type_int: Optional[int] = None
             if TYPE_CHECKING:
                 assert init_bytes is not None, "Buffer should have at least 3 bytes"
             preamble, length_high, maybe_msg_type = init_bytes
@@ -183,12 +184,11 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     #
                     # Message type is also only 1 byte
                     #
-                    msg_type_int: Optional[int] = maybe_msg_type
+                    msg_type_int = maybe_msg_type
                 else:
                     #
                     # Message type is longer than 1 byte
                     #
-                    msg_type_int = None
                     msg_type = bytes(init_bytes[2:3])
             else:
                 #
@@ -202,7 +202,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                         return
                     length += add_length
                 length_int = bytes_to_varuint(length)
-                msg_type_int = None
                 msg_type = b""
 
             # If the we do not have the message type yet, read it

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -183,12 +183,12 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     #
                     # Message type is also only 1 byte
                     #
-                    msg_type_int = maybe_msg_type
+                    msg_type_int: Optional[int] = maybe_msg_type
                 else:
                     #
                     # Message type is longer than 1 byte
                     #
-                    msg_type_int: Optional[int] = None
+                    msg_type_int = None
                     msg_type = bytes(init_bytes[2:3])
             else:
                 #

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -156,7 +156,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Also try to get the length and msg type
             # to avoid multiple calls to readexactly
             init_bytes = self._init_read(3)
-            msg_type_int = None
+            msg_type_int: Optional[int] = None
             preamble, length_high, maybe_msg_type = init_bytes
             assert init_bytes is not None, "Buffer should have at least 3 bytes"
             if preamble != 0x00:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -157,8 +157,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # to avoid multiple calls to readexactly
             init_bytes = self._init_read(3)
             msg_type_int: Optional[int] = None
+            if TYPE_CHECKING:
+                assert init_bytes is not None, "Buffer should have at least 3 bytes"
             preamble, length_high, maybe_msg_type = init_bytes
-            assert init_bytes is not None, "Buffer should have at least 3 bytes"
             if preamble != 0x00:
                 if preamble == 0x01:
                     self._handle_error_and_close(

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -470,7 +470,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Handle an incoming frame."""
         assert self._proto is not None
         try:
-            msg = self._proto.decrypt(frame)
+            msg = self._decrypt(frame)
         except InvalidTag as ex:
             self._handle_error_and_close(
                 ProtocolAPIError(f"Bad encryption frame {ex}: {msg}")

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -156,7 +156,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Also try to get the length and msg type
             # to avoid multiple calls to readexactly
             init_bytes = self._init_read(3)
-            msg_type_int: Optional[int] = None
             if TYPE_CHECKING:
                 assert init_bytes is not None, "Buffer should have at least 3 bytes"
             preamble, length_high, maybe_msg_type = init_bytes

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -194,6 +194,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                         return
                     length += add_length
                 length_int = bytes_to_varuint(length)
+                # Since the length is longer than 1 byte we do not have the
+                # message type yet.
                 msg_type = b""
 
             # If the we do not have the message type yet because the message

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -415,7 +415,6 @@ class APINoiseFrameHelper(APIFrameHelper):
     def _send_handshake(self) -> None:
         """Send the handshake message."""
         self._write_frame(b"\x00" + self._proto.write_message())
-        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad # type: ignore[no-member]
 
     def _handle_handshake(self, msg: bytearray) -> None:
         _LOGGER.debug("Starting handshake...")
@@ -443,6 +442,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             return
         _LOGGER.debug("Handshake complete")
         self._state = NoiseConnectionState.READY
+        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad  # type: ignore[no-member]
         self._ready_future.set_result(None)
 
     def write_packet(self, type_: int, data: bytes) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -335,7 +335,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._buffer += data
         while len(self._buffer) >= 3:
             header = self._init_read(3)
-            assert header is not None, "Buffer should have at least 3 bytes"
+            if TYPE_CHECKING:
+                assert header is not None, "Buffer should have at least 3 bytes"
             preamble, msg_size_high, msg_size_low = header
             if preamble != 0x01:
                 self._handle_error_and_close(

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -219,6 +219,11 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 continue
 
             packet_data = self._read_exactly(length_int)
+            # The packet data is not yet available, wait for more data
+            # to arrive before continuing, since callback_packet has not
+            # been called yet the buffer will not be cleared and the next
+            # call to data_received will continue processing the packet
+            # at the start of the frame.
             if packet_data is None:
                 return
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -284,8 +284,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._expected_name = expected_name
         self._state = NoiseConnectionState.HELLO
         self._server_name: Optional[str] = None
-        self._decrypt: Optional[Callable[[Union[bytes, bytearray]], bytes]] = None
-        self._encrypt: Optional[Callable[[Union[bytes, bytearray]], bytes]] = None
+        self._decrypt: Optional[Callable[[bytes], bytes]] = None
+        self._encrypt: Optional[Callable[[bytes], bytes]] = None
         self._setup_proto()
 
     def _set_ready_future_exception(self, exc: Exception) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -3,8 +3,9 @@ import base64
 import logging
 from abc import abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
+
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
@@ -456,17 +457,15 @@ class APINoiseFrameHelper(APIFrameHelper):
         data_len = len(data)
         self._write_frame(
             self._encrypt(
-                (
-                    bytes(
-                        [
-                            (type_ >> 8) & 0xFF,
-                            (type_ >> 0) & 0xFF,
-                            (data_len >> 8) & 0xFF,
-                            (data_len >> 0) & 0xFF,
-                        ]
-                    )
-                    + data
+                bytes(
+                    [
+                        (type_ >> 8) & 0xFF,
+                        (type_ >> 0) & 0xFF,
+                        (data_len >> 8) & 0xFF,
+                        (data_len >> 0) & 0xFF,
+                    ]
                 )
+                + data
             )
         )
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -466,7 +466,7 @@ class APINoiseFrameHelper(APIFrameHelper):
     def _handle_frame(self, frame: bytearray) -> None:
         """Handle an incoming frame."""
         assert self._proto is not None
-        msg = self._proto.decrypt(bytes(frame))
+        msg = self._proto.decrypt(frame)
         msg_len = len(msg)
         if msg_len < 4:
             self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg}"))

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -446,8 +446,12 @@ class APINoiseFrameHelper(APIFrameHelper):
         _LOGGER.debug("Handshake complete")
         self._state = NoiseConnectionState.READY
         noise_protocol = self._proto.noise_protocol
-        self._decrypt = partial(noise_protocol.cipher_state_decrypt.decrypt_with_ad, None)
-        self._encrypt = partial(noise_protocol.cipher_state_encrypt.encrypt_with_ad, None)
+        self._decrypt = partial(
+            noise_protocol.cipher_state_decrypt.decrypt_with_ad, None
+        )
+        self._encrypt = partial(
+            noise_protocol.cipher_state_encrypt.encrypt_with_ad, None
+        )
         self._ready_future.set_result(None)
 
     def write_packet(self, type_: int, data: bytes) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -415,7 +415,7 @@ class APINoiseFrameHelper(APIFrameHelper):
     def _send_handshake(self) -> None:
         """Send the handshake message."""
         self._write_frame(b"\x00" + self._proto.write_message())
-        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad
+        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad # type: ignore[no-member]
 
     def _handle_handshake(self, msg: bytearray) -> None:
         _LOGGER.debug("Starting handshake...")
@@ -473,7 +473,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             msg = self._decrypt(frame)
         except InvalidTag as ex:
             self._handle_error_and_close(
-                ProtocolAPIError(f"Bad encryption frame {ex}: {msg}")
+                ProtocolAPIError(f"Bad encryption frame: {ex}")
             )
             return
         msg_len = len(msg)

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -176,14 +176,14 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 # needing a single byte for length and type which means
                 # we avoid 2 calls to readexactly
                 length_int = length_high
-                if maybe_msg_type & 0x80 != 0x80:
-                    msg_type_int = maybe_msg_type
-                else:
+                if maybe_msg_type & 0x80 == 0x80:
+                    msg_type_int: Optional[int] = None
                     msg_type = init_bytes[2:3]
+                else:
+                    msg_type_int = maybe_msg_type
             else:
                 # Length is longer than 1 byte
                 length = init_bytes[1:3]
-                msg_type = b""
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:
                     add_length = self._read_exactly(1)
@@ -191,6 +191,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                         return
                     length += add_length
                 length_int = bytes_to_varuint(length)
+                msg_type_int = None
+                msg_type = b""
 
             # If the we do not have the message type yet, read it
             if msg_type_int is None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -171,17 +171,29 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 return
 
             if length_high & 0x80 != 0x80:
+                #
+                # Length is only 1 byte
+                #
                 # This is the most common case with 99% of messages
                 # needing a single byte for length and type which means
                 # we avoid 2 calls to readexactly
+                #
                 length_int = length_high
                 if maybe_msg_type & 0x80 != 0x80:
+                    #
+                    # Message type is also only 1 byte
+                    #
                     msg_type_int = maybe_msg_type
                 else:
+                    #
+                    # Message type is longer than 1 byte
+                    #
                     msg_type_int: Optional[int] = None
                     msg_type = bytes(init_bytes[2:3])
             else:
+                #
                 # Length is longer than 1 byte
+                #
                 length = bytes(init_bytes[1:3])
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -411,11 +411,11 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._proto.set_psks(_decode_noise_psk(self._noise_psk, self._server_name))
         self._proto.set_prologue(b"NoiseAPIInit" + b"\x00\x00")
         self._proto.start_handshake()
-        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad
 
     def _send_handshake(self) -> None:
         """Send the handshake message."""
         self._write_frame(b"\x00" + self._proto.write_message())
+        self._decrypt = self._proto.noise_protocol.cipher_state_decrypt.decrypt_with_ad
 
     def _handle_handshake(self, msg: bytearray) -> None:
         _LOGGER.debug("Starting handshake...")
@@ -468,7 +468,7 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def _handle_frame(self, frame: bytearray) -> None:
         """Handle an incoming frame."""
-        assert self._proto is not None
+        assert self._decrypt is not None, "Handshake should be complete"
         try:
             msg = self._decrypt(frame)
         except InvalidTag as ex:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -447,12 +447,12 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NoiseConnectionState.READY
         noise_protocol = self._proto.noise_protocol
         self._decrypt = partial(
-            noise_protocol.cipher_state_decrypt.decrypt_with_ad,
-            None,  # pylint: disable=no-member
+            noise_protocol.cipher_state_decrypt.decrypt_with_ad, # pylint: disable=no-member
+            None,  
         )
         self._encrypt = partial(
-            noise_protocol.cipher_state_encrypt.encrypt_with_ad,
-            None,  # pylint: disable=no-member
+            noise_protocol.cipher_state_encrypt.encrypt_with_ad, # pylint: disable=no-member
+            None,  
         )
         self._ready_future.set_result(None)
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -154,7 +154,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         while len(self._buffer) >= 3:
             # Read preamble, which should always 0x00
             # Also try to get the length and msg type
-            # to avoid multiple calls to readexactly
+            # to avoid multiple calls to _read_exactly
             init_bytes = self._init_read(3)
             msg_type_int: Optional[int] = None
             length_int: Optional[int] = None

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -476,7 +476,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         if TYPE_CHECKING:
             assert self._decrypt is not None, "Handshake should be complete"
         try:
-            msg = self._decrypt(frame)
+            msg = self._decrypt(bytes(frame))
         except InvalidTag as ex:
             self._handle_error_and_close(
                 ProtocolAPIError(f"Bad encryption frame: {ex!r}")

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -488,7 +488,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             return
         msg_len = len(msg)
         if msg_len < 4:
-            self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg}"))
+            self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg!r}"))
             return
         msg_type_high, msg_type_low, data_len_high, data_len_low = msg[:4]
         msg_type = (msg_type_high << 8) | msg_type_low

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -200,7 +200,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
             # If the we do not have the message type yet because the message
             # length was so long it did not fit into the first byte we need
-            # to read the rest of the message type
+            # to read the (rest) of the message type
             if msg_type_int is None:
                 while not msg_type or msg_type[-1] & 0x80 == 0x80:
                     add_msg_type = self._read_exactly(1)

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -345,7 +345,11 @@ class APINoiseFrameHelper(APIFrameHelper):
                 )
                 return
             frame = self._read_exactly((msg_size_high << 8) | msg_size_low)
-
+            # The complete frame is not yet available, wait for more data
+            # to arrive before continuing, since callback_packet has not
+            # been called yet the buffer will not be cleared and the next
+            # call to data_received will continue processing the packet
+            # at the start of the frame.
             if frame is None:
                 return
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -447,10 +447,12 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NoiseConnectionState.READY
         noise_protocol = self._proto.noise_protocol
         self._decrypt = partial(
-            noise_protocol.cipher_state_decrypt.decrypt_with_ad, None
+            noise_protocol.cipher_state_decrypt.decrypt_with_ad,
+            None,  # pylint: disable=no-member
         )
         self._encrypt = partial(
-            noise_protocol.cipher_state_encrypt.encrypt_with_ad, None
+            noise_protocol.cipher_state_encrypt.encrypt_with_ad,
+            None,  # pylint: disable=no-member
         )
         self._ready_future.set_result(None)
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -157,6 +157,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # to avoid multiple calls to readexactly
             init_bytes = self._init_read(3)
             msg_type_int: Optional[int] = None
+            length_int: Optional[int] = None
             if TYPE_CHECKING:
                 assert init_bytes is not None, "Buffer should have at least 3 bytes"
             preamble, length_high, maybe_msg_type = init_bytes

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -191,7 +191,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     length += add_length
                 length_int = bytes_to_varuint(length)
                 msg_type_int = None
-                msg_type = b""
+                msg_type = bytearray()
 
             # If the we do not have the message type yet, read it
             if msg_type_int is None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -173,32 +173,20 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 return
 
             if length_high & 0x80 != 0x80:
-                _LOGGER.warning("Using fast length path")
-                #
                 # Length is only 1 byte
                 #
                 # This is the most common case with 99% of messages
                 # needing a single byte for length and type which means
                 # we avoid 2 calls to readexactly
-                #
                 length_int = length_high
                 if maybe_msg_type & 0x80 != 0x80:
-                    _LOGGER.warning("Using fast msg type path")
-                    #
                     # Message type is also only 1 byte
-                    #
                     msg_type_int = maybe_msg_type
                 else:
-                    _LOGGER.warning("Using slow msg type path")
-                    #
                     # Message type is longer than 1 byte
-                    #
                     msg_type = bytes(init_bytes[2:3])
             else:
-                _LOGGER.warning("Using slow length path")
-                #
                 # Length is longer than 1 byte
-                #
                 length = bytes(init_bytes[1:3])
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:
@@ -211,7 +199,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
             # If the we do not have the message type yet, read it
             if msg_type_int is None:
-                _LOGGER.warning("Using slow msg type path for addl bytes")
                 while not msg_type or msg_type[-1] & 0x80 == 0x80:
                     add_msg_type = self._read_exactly(1)
                     if add_msg_type is None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -447,12 +447,12 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NoiseConnectionState.READY
         noise_protocol = self._proto.noise_protocol
         self._decrypt = partial(
-            noise_protocol.cipher_state_decrypt.decrypt_with_ad, # pylint: disable=no-member
-            None,  
+            noise_protocol.cipher_state_decrypt.decrypt_with_ad,  # pylint: disable=no-member
+            None,
         )
         self._encrypt = partial(
-            noise_protocol.cipher_state_encrypt.encrypt_with_ad, # pylint: disable=no-member
-            None,  
+            noise_protocol.cipher_state_encrypt.encrypt_with_ad,  # pylint: disable=no-member
+            None,
         )
         self._ready_future.set_result(None)
 

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -175,9 +175,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if length_high & 0x80 != 0x80:
                 # Length is only 1 byte
                 #
-                # This is the most common case with 99% of messages
-                # needing a single byte for length and type which means
-                # we avoid 2 calls to readexactly
+                # This is the most common case needing a single byte for
+                # length and type which means we avoid 2 calls to _read_exactly
                 length_int = length_high
                 if maybe_msg_type & 0x80 != 0x80:
                     # Message type is also only 1 byte
@@ -197,7 +196,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 length_int = bytes_to_varuint(length)
                 msg_type = b""
 
-            # If the we do not have the message type yet, read it
+            # If the we do not have the message type yet because the message
+            # length was so long it did not fit into the first byte we need
+            # to read the rest of the message type
             if msg_type_int is None:
                 while not msg_type or msg_type[-1] & 0x80 == 0x80:
                     add_msg_type = self._read_exactly(1)

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -446,7 +446,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NoiseConnectionState.READY
         noise_protocol = self._proto.noise_protocol
         self._decrypt = partial(noise_protocol.cipher_state_decrypt.decrypt_with_ad, None)  # type: ignore[no-member]
-        self._encrypt = partial(noise_protocol.cipher_state_encrypt.encrypt_with_ad, None)  # type: ignore[no-member]     
+        self._encrypt = partial(noise_protocol.cipher_state_encrypt.encrypt_with_ad, None)  # type: ignore[no-member]
         self._ready_future.set_result(None)
 
     def write_packet(self, type_: int, data: bytes) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -175,14 +175,14 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 # needing a single byte for length and type which means
                 # we avoid 2 calls to readexactly
                 length_int = length_high
-                if maybe_msg_type & 0x80 == 0x80:
-                    msg_type_int: Optional[int] = None
-                    msg_type = init_bytes[2:3]
-                else:
+                if maybe_msg_type & 0x80 != 0x80:
                     msg_type_int = maybe_msg_type
+                else:
+                    msg_type_int: Optional[int] = None
+                    msg_type = bytes(init_bytes[2:3])
             else:
                 # Length is longer than 1 byte
-                length = init_bytes[1:3]
+                length = bytes(init_bytes[1:3])
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:
                     add_length = self._read_exactly(1)
@@ -191,7 +191,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     length += add_length
                 length_int = bytes_to_varuint(length)
                 msg_type_int = None
-                msg_type = bytearray()
+                msg_type = b""
 
             # If the we do not have the message type yet, read it
             if msg_type_int is None:

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -1,6 +1,6 @@
 import math
 from functools import lru_cache
-from typing import Optional
+from typing import Optional, Union
 
 
 @lru_cache(maxsize=1024)
@@ -21,7 +21,7 @@ def varuint_to_bytes(value: int) -> bytes:
 
 
 @lru_cache(maxsize=1024)
-def bytes_to_varuint(value: bytes) -> Optional[int]:
+def bytes_to_varuint(value: Union[bytes, bytearray]) -> Optional[int]:
     result = 0
     bitpos = 0
     for val in value:

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -1,6 +1,6 @@
 import math
 from functools import lru_cache
-from typing import Optional, Union
+from typing import Optional
 
 
 @lru_cache(maxsize=1024)
@@ -21,7 +21,7 @@ def varuint_to_bytes(value: int) -> bytes:
 
 
 @lru_cache(maxsize=1024)
-def bytes_to_varuint(value: Union[bytes, bytearray]) -> Optional[int]:
+def bytes_to_varuint(value: bytes) -> Optional[int]:
     result = 0
     bitpos = 0
     for val in value:

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -48,6 +48,14 @@ PREAMBLE = b"\x00"
             b"\x42",
             32768,
         ),
+        (
+            PREAMBLE
+            + varuint_to_bytes(32768)
+            + varuint_to_bytes(32768)
+            + (b"\x42" * 32768),
+            (b"\x42" * 32768),
+            32768,
+        ),
     ],
 )
 async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -43,6 +43,11 @@ PREAMBLE = b"\x00"
             (b"\x42" * 256),
             256,
         ),
+        (
+            PREAMBLE + varuint_to_bytes(1) + varuint_to_bytes(32768) + b"\x42",
+            b"\x42",
+            32768,
+        ),
     ],
 )
 async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):


### PR DESCRIPTION
- Unpack protocol bytes into named values: Easier to see what the data is and uses unpacking sequence which is fast
- For small packets we avoid calling `bytes_to_varuint`
- Avoid a lot of memory copy
- Avoid multiple calls to get length in places it cannot change
- Decryption errors are now raised instead of causing the protocol to fail (its still going to drop but we get the right exception now)

Works out to ~24-38% faster on average