### PR TITLE
Use memoryview for camera images

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -417,13 +417,15 @@ class APIClient:
                 msg_key = msg.key
                 data_parts: Optional[List[memoryview]] = image_stream.get(msg_key)
                 if not data_parts:
-                    data_parts: list[memoryview] = []
+                    data_parts = []
                     image_stream[msg_key] = data_parts
 
                 data_parts.append(memoryview(msg.data))
                 if msg.done:
                     # Return CameraState with the merged data
-                    on_state(CameraState(key=msg.key, data=bytes().join(data_parts)))
+                    image_data = bytes().join(data_parts)
+                    del image_stream[msg_key]
+                    on_state(CameraState(key=msg.key, data=image_data))
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -423,7 +423,7 @@ class APIClient:
                 data_parts.append(memoryview(msg.data))
                 if msg.done:
                     # Return CameraState with the merged data
-                    on_state(CameraState(key=msg.key, data=bytes.join(data_parts)))
+                    on_state(CameraState(key=msg.key, data=bytes().join(data_parts)))
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -413,7 +413,7 @@ class APIClient:
             cls = response_types.get(msg_type)
             if cls:
                 on_state(cls.from_pb(msg))
-            elif type(msg) is CameraImageResponse:
+            elif msg_type is CameraImageResponse:
                 msg_key = msg.key
                 data_parts: Optional[List[memoryview]] = image_stream.get(msg_key)
                 if not data_parts:

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -414,6 +415,8 @@ class APIClient:
             if cls:
                 on_state(cls.from_pb(msg))
             elif msg_type is CameraImageResponse:
+                if TYPE_CHECKING:
+                    assert isinstance(msg, CameraImageResponse)
                 msg_key = msg.key
                 data_parts: Optional[List[memoryview]] = image_stream.get(msg_key)
                 if not data_parts:


### PR DESCRIPTION
Save the camera data in a list of memory views and join them all together when we have the final packet. This avoids creating a new bytes object every time the camera sends a partial response