### PR TITLE
Add checks for debug logging in the write path

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -139,7 +139,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         """
         assert self._transport is not None, "Transport should be set"
         data = b"\0" + varuint_to_bytes(len(data)) + varuint_to_bytes(type_) + data
-        _LOGGER.debug("Sending plaintext frame %s", data.hex())
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("Sending plaintext frame %s", data.hex())
 
         try:
             self._transport.write(data)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -531,7 +531,9 @@ class APIConnection:
         if not message_type:
             raise ValueError(f"Message type id not found for type {type(msg)}")
         encoded = msg.SerializeToString()
-        _LOGGER.debug("%s: Sending %s: %s", self._params.address, type(msg), str(msg))
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("%s: Sending %s: %s", self._params.address, type(msg), str(msg))
 
         try:
             frame_helper.write_packet(message_type, encoded)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -533,7 +533,9 @@ class APIConnection:
         encoded = msg.SerializeToString()
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug("%s: Sending %s: %s", self._params.address, type(msg), str(msg))
+            _LOGGER.debug(
+                "%s: Sending %s: %s", self._params.address, type(msg), str(msg)
+            )
 
         try:
             frame_helper.write_packet(message_type, encoded)


### PR DESCRIPTION
We want to avoid formatting data for debug when
debug is not enabled since a camera stream will
continually write requests to keep the stream
alive