### PR TITLE
Improve performance reassembling fragmented packets

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -125,8 +125,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
     def _callback_packet(self, type_: int, data: Union[bytes, bytearray]) -> None:
         """Complete reading a packet from the buffer."""
-        del self._buffer[: self._pos]
-        self._buffer_len -= self._pos
+        end_of_frame_pos = self._pos
+        del self._buffer[: end_of_frame_pos]
+        self._buffer_len -= end_of_frame_pos
         self._on_pkt(type_, data)
 
     def write_packet(self, type_: int, data: bytes) -> None:
@@ -366,8 +367,9 @@ class APINoiseFrameHelper(APIFrameHelper):
             except Exception as err:  # pylint: disable=broad-except
                 self._handle_error_and_close(err)
             finally:
-                del self._buffer[: self._pos]
-                self._buffer_len -= self._pos
+                end_of_frame_pos = self._pos
+                del self._buffer[: end_of_frame_pos]
+                self._buffer_len -= end_of_frame_pos
 
     def _send_hello(self) -> None:
         """Send a ClientHello to the server."""

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -489,18 +489,8 @@ class APINoiseFrameHelper(APIFrameHelper):
                 ProtocolAPIError(f"Bad encryption frame: {ex!r}")
             )
             return
-        msg_len = len(msg)
-        if msg_len < 4:
-            self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg!r}"))
-            return
-        msg_type_high, msg_type_low, data_len_high, data_len_low = msg[:4]
+        msg_type_high, msg_type_low = msg[:2]
         msg_type = (msg_type_high << 8) | msg_type_low
-        data_len = (data_len_high << 8) | data_len_low
-        if data_len + 4 != msg_len:
-            self._handle_error_and_close(
-                ProtocolAPIError(f"Bad data len: {data_len} vs {msg_len}")
-            )
-            return
         self._on_pkt(msg_type, msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -348,7 +348,8 @@ class APINoiseFrameHelper(APIFrameHelper):
                     ProtocolAPIError(f"Marker byte invalid: {header[0]}")
                 )
                 return
-            frame = self._read_exactly((msg_size_high << 8) | msg_size_low)
+            frame_len = (msg_size_high << 8) | msg_size_low
+            frame = self._read_exactly(frame_len)
             # The complete frame is not yet available, wait for more data
             # to arrive before continuing, since callback_packet has not
             # been called yet the buffer will not be cleared and the next
@@ -358,7 +359,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 return
 
             try:
-                self.STATE_TO_CALLABLE[self._state](self, frame)
+                self.STATE_TO_CALLABLE[self._state](self, frame, frame_len)
             except Exception as err:  # pylint: disable=broad-except
                 self._handle_error_and_close(err)
             finally:
@@ -370,7 +371,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Send a ClientHello to the server."""
         self._write_frame(b"")  # ClientHello
 
-    def _handle_hello(self, server_hello: bytearray) -> None:
+    def _handle_hello(self, server_hello: bytearray, msg_len: int) -> None:
         """Perform the handshake with the server, the caller is responsible for having the lock."""
         if not server_hello:
             self._handle_error_and_close(HandshakeAPIError("ServerHello is empty"))
@@ -420,7 +421,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Send the handshake message."""
         self._write_frame(b"\x00" + self._proto.write_message())
 
-    def _handle_handshake(self, msg: bytearray) -> None:
+    def _handle_handshake(self, msg: bytearray, msg_len: int) -> None:
         _LOGGER.debug("Starting handshake...")
         if msg[0] != 0:
             explanation = msg[1:].decode()
@@ -478,7 +479,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             )
         )
 
-    def _handle_frame(self, frame: bytearray) -> None:
+    def _handle_frame(self, frame: bytearray, msg_len: int) -> None:
         """Handle an incoming frame."""
         if TYPE_CHECKING:
             assert self._decrypt is not None, "Handshake should be complete"
@@ -489,7 +490,6 @@ class APINoiseFrameHelper(APIFrameHelper):
                 ProtocolAPIError(f"Bad encryption frame: {ex!r}")
             )
             return
-        msg_len = len(msg)
         if msg_len < 4:
             self._handle_error_and_close(ProtocolAPIError(f"Bad packet frame: {msg!r}"))
             return
@@ -504,7 +504,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._on_pkt(msg_type, msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument
-        self, frame: bytearray
+        self, frame: bytearray, msg_len: int
     ) -> None:
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError("Connection closed"))

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -165,7 +165,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             init_bytes = self._init_read(3)
             if init_bytes is None:
                 # No need to reset self._pos since
-                # it was not changed by _init_read                
+                # it was not changed by _init_read
                 return
             msg_type_int: Optional[int] = None
             length_int: Optional[int] = None

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -469,9 +469,9 @@ class APINoiseFrameHelper(APIFrameHelper):
                 bytes(
                     [
                         (type_ >> 8) & 0xFF,
-                        (type_ >> 0) & 0xFF,
+                        type_ & 0xFF,
                         (data_len >> 8) & 0xFF,
-                        (data_len >> 0) & 0xFF,
+                        data_len & 0xFF,
                     ]
                 )
                 + data

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -4,7 +4,7 @@ import logging
 from abc import abstractmethod
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -77,11 +77,6 @@ class APIFrameHelper(asyncio.Protocol):
         self._buffer_len = 0
         self._pos = 0
 
-    def _init_read(self, length: int) -> Optional[bytearray]:
-        """Start reading a packet from the buffer."""
-        self._pos = 0
-        return self._read_exactly(length)
-
     def _read_exactly(self, length: int) -> Optional[bytearray]:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""
         original_pos = self._pos
@@ -161,7 +156,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Read preamble, which should always 0x00
             # Also try to get the length and msg type
             # to avoid multiple calls to _read_exactly
-            init_bytes = self._init_read(3)
+            self._pos = 0
+            init_bytes = self._read_exactly(3)
             if init_bytes is None:
                 return
             msg_type_int: Optional[int] = None
@@ -346,7 +342,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._buffer += data
         self._buffer_len += len(data)
         while self._buffer:
-            header = self._init_read(3)
+            self._pos = 0
+            header = self._read_exactly(3)
             if header is None:
                 return
             preamble, msg_size_high, msg_size_low = header

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -202,7 +202,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     if add_length is None:
                         # The complete length is not yet available, wait for more data
                         # and reset the buffer to the start of the frame
-                        frame_start_pos = self._pos
+                        self._pos = frame_start_pos
                         return
                     length += add_length
                 length_int = bytes_to_varuint(length)
@@ -219,7 +219,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     if add_msg_type is None:
                         # The complete length is not yet available, wait for more data
                         # and reset the buffer to the start of the frame
-                        frame_start_pos = self._pos
+                        self._pos = frame_start_pos
                         return
                     msg_type += add_msg_type
                 msg_type_int = bytes_to_varuint(msg_type)
@@ -242,7 +242,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if packet_data is None:
                 # The complete length is not yet available, wait for more data
                 # and reset the buffer to the start of the frame
-                frame_start_pos = self._pos
+                self._pos = frame_start_pos
                 return
 
             self._callback_packet(msg_type_int, bytes(packet_data))
@@ -377,7 +377,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             # call to data_received will continue processing the packet
             # at the start of the frame.
             if frame is None:
-                frame_start_pos = self._pos
+                self._pos = frame_start_pos
                 return
 
             try:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -161,7 +161,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Read preamble, which should always 0x00
             # Also try to get the length and msg type
             # to avoid multiple calls to _read_exactly
-            frame_start_pos = self._pos
             init_bytes = self._init_read(3)
             if init_bytes is None:
                 return

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -489,8 +489,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 ProtocolAPIError(f"Bad encryption frame: {ex!r}")
             )
             return
-        msg_type_high, msg_type_low = msg[:2]
-        self._on_pkt((msg_type_high << 8) | msg_type_low, msg[4:])
+        self._on_pkt((msg[0] << 8) | msg[1], msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument
         self, frame: bytearray

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -164,6 +164,8 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             frame_start_pos = self._pos
             init_bytes = self._init_read(3)
             if init_bytes is None:
+                # No need to reset self._pos since
+                # it was not changed by _init_read                
                 return
             msg_type_int: Optional[int] = None
             length_int: Optional[int] = None
@@ -359,6 +361,8 @@ class APINoiseFrameHelper(APIFrameHelper):
             frame_start_pos = self._pos
             header = self._init_read(3)
             if header is None:
+                # No need to reset self._pos since
+                # it was not changed by _init_read
                 return
             preamble, msg_size_high, msg_size_low = header
             if preamble != 0x01:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -126,7 +126,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
     def _callback_packet(self, type_: int, data: Union[bytes, bytearray]) -> None:
         """Complete reading a packet from the buffer."""
         end_of_frame_pos = self._pos
-        del self._buffer[: end_of_frame_pos]
+        del self._buffer[:end_of_frame_pos]
         self._buffer_len -= end_of_frame_pos
         self._on_pkt(type_, data)
 
@@ -368,7 +368,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 self._handle_error_and_close(err)
             finally:
                 end_of_frame_pos = self._pos
-                del self._buffer[: end_of_frame_pos]
+                del self._buffer[:end_of_frame_pos]
                 self._buffer_len -= end_of_frame_pos
 
     def _send_hello(self) -> None:

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -490,8 +490,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             )
             return
         msg_type_high, msg_type_low = msg[:2]
-        msg_type = (msg_type_high << 8) | msg_type_low
-        self._on_pkt(msg_type, msg[4:])
+        self._on_pkt((msg_type_high << 8) | msg_type_low, msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument
         self, frame: bytearray

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -489,6 +489,10 @@ class APINoiseFrameHelper(APIFrameHelper):
                 ProtocolAPIError(f"Bad encryption frame: {ex!r}")
             )
             return
+        # Message layout is
+        # 2 bytes: message type
+        # 2 bytes: message length
+        # N bytes: message data
         self._on_pkt((msg[0] << 8) | msg[1], msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument


### PR DESCRIPTION
The camera packets tend to get fragmented because of the size and I was looking for a bug in the reassembly but it turns out the camera was just overheating.

I thought there was a bug here but there isn't after I wrote the tests it shows it works as expected. However the new design is faster so I'll clean it up and move it forward

- Avoid checking `len()` each read call
- Remove some unreachable checks since the decryption will fail if the data is invalid
- Remove a useless shift
- Avoid the extra stack depth of `_callback_packet` since it was only called from one function