### PR TITLE
Improve performance of converting raw BLE advertisements

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -134,7 +134,6 @@ from .model import (
     BluetoothGATTServices,
     BluetoothLEAdvertisement,
     BluetoothLERawAdvertisement,
-    BluetoothLERawAdvertisements,
     BluetoothProxyFeature,
     BluetoothProxySubscriptionFlag,
     ButtonInfo,

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -182,7 +182,7 @@ from .model import (
     UserServiceArgType,
     VoiceAssistantCommand,
     VoiceAssistantEventType,
-    ble_raw_advertisement_response_to_ble_raw_advertisements,
+    make_ble_raw_advertisement_processor,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -526,15 +526,12 @@ class APIClient:
         self._check_authenticated()
         msg_types = (BluetoothLERawAdvertisementsResponse,)
 
-        def on_msg(msg: BluetoothLERawAdvertisementsResponse) -> None:
-            on_advertisements(ble_raw_advertisement_response_to_ble_raw_advertisements(msg))
-
         assert self._connection is not None
         self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(
                 flags=BluetoothProxySubscriptionFlag.RAW_ADVERTISEMENTS
             ),
-            on_msg,
+            make_ble_raw_advertisement_processor(on_advertisements),
             msg_types,
         )
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -527,7 +527,7 @@ class APIClient:
         msg_types = (BluetoothLERawAdvertisementsResponse,)
 
         def on_msg(msg: BluetoothLERawAdvertisementsResponse) -> None:
-            on_advertisements(ble_raw_advertisement_response_to_ble_raw_advertisements(msg))  # type: ignore[misc]
+            on_advertisements(ble_raw_advertisement_response_to_ble_raw_advertisements(msg))
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -183,6 +183,7 @@ from .model import (
     UserServiceArgType,
     VoiceAssistantCommand,
     VoiceAssistantEventType,
+    ble_raw_advertisement_response_to_ble_raw_advertisements,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -527,7 +528,7 @@ class APIClient:
         msg_types = (BluetoothLERawAdvertisementsResponse,)
 
         def on_msg(msg: BluetoothLERawAdvertisementsResponse) -> None:
-            on_advertisements(BluetoothLERawAdvertisements.from_pb(msg).advertisements)  # type: ignore[misc]
+            on_advertisements(ble_raw_advertisement_response_to_ble_raw_advertisements(msg))  # type: ignore[misc]
 
         assert self._connection is not None
         self._connection.send_message_callback_response(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -527,11 +527,12 @@ class APIClient:
         msg_types = (BluetoothLERawAdvertisementsResponse,)
 
         assert self._connection is not None
+        on_msg = make_ble_raw_advertisement_processor(on_advertisements)
         self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(
                 flags=BluetoothProxySubscriptionFlag.RAW_ADVERTISEMENTS
             ),
-            make_ble_raw_advertisement_processor(on_advertisements),
+            on_msg,
             msg_types,
         )
 

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -940,7 +940,9 @@ def make_ble_raw_advertisement_processor(
 ) -> Callable[["BluetoothLERawAdvertisementsResponse"], None]:
     """Make a processor for BluetoothLERawAdvertisementResponse."""
 
-    def on_msg(data: "BluetoothLERawAdvertisementsResponse") -> None:
+    def _on_ble_raw_advertisement_response(
+        data: "BluetoothLERawAdvertisementsResponse",
+    ) -> None:
         on_advertisements(
             [
                 BluetoothLERawAdvertisement(  # type: ignore[call-arg]
@@ -950,7 +952,7 @@ def make_ble_raw_advertisement_processor(
             ]
         )
 
-    return on_msg
+    return _on_ble_raw_advertisement_response
 
 
 @dataclass(frozen=True)

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -946,22 +946,31 @@ class BluetoothLERawAdvertisements:
     ) -> "BluetoothLERawAdvertisements":
         """Convert BluetoothLERawAdvertisementResponse to BluetoothLERawAdvertisements."""
         return cls(  # type: ignore[operator, no-any-return]
-            advertisements=ble_raw_advertisement_response_to_ble_raw_advertisements(
-                data
-            )
+            advertisements=[
+                BluetoothLERawAdvertisement(  # type: ignore[call-arg]
+                    adv.address, adv.rssi, adv.address_type, adv.data
+                )
+                for adv in data.advertisements
+            ]
         )
 
 
-def ble_raw_advertisement_response_to_ble_raw_advertisements(
-    data: "BluetoothLERawAdvertisementsResponse",
-) -> List[BluetoothLERawAdvertisement]:
-    """Convert BluetoothLERawAdvertisementResponse to a list of BluetoothLERawAdvertisement."""
-    return [
-        BluetoothLERawAdvertisement(  # type: ignore[call-arg]
-            adv.address, adv.rssi, adv.address_type, adv.data
+def make_ble_raw_advertisement_processor(
+    on_advertisements: Callable[[List[BluetoothLERawAdvertisement]], None]
+) -> Callable[["BluetoothLERawAdvertisementsResponse"], None]:
+    """Make a processor for BluetoothLERawAdvertisementResponse."""
+
+    def on_msg(data: BluetoothLERawAdvertisementsResponse) -> None:
+        on_advertisements(
+            [
+                BluetoothLERawAdvertisement(  # type: ignore[call-arg]
+                    adv.address, adv.rssi, adv.address_type, adv.data
+                )
+                for adv in data.advertisements
+            ]
         )
-        for adv in data.advertisements
-    ]
+
+    return on_msg
 
 
 @dataclass(frozen=True)

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -960,7 +960,7 @@ def make_ble_raw_advertisement_processor(
 ) -> Callable[["BluetoothLERawAdvertisementsResponse"], None]:
     """Make a processor for BluetoothLERawAdvertisementResponse."""
 
-    def on_msg(data: BluetoothLERawAdvertisementsResponse) -> None:
+    def on_msg(data: "BluetoothLERawAdvertisementsResponse") -> None:
         on_advertisements(
             [
                 BluetoothLERawAdvertisement(  # type: ignore[call-arg]

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -935,26 +935,6 @@ class BluetoothLERawAdvertisement:
     data: bytes = field(default_factory=bytes)
 
 
-@_dataclass_decorator
-class BluetoothLERawAdvertisements:
-    advertisements: List[BluetoothLERawAdvertisement]
-
-    @classmethod
-    def from_pb(  # type: ignore[misc]
-        cls: "BluetoothLERawAdvertisements",
-        data: "BluetoothLERawAdvertisementsResponse",
-    ) -> "BluetoothLERawAdvertisements":
-        """Convert BluetoothLERawAdvertisementResponse to BluetoothLERawAdvertisements."""
-        return cls(  # type: ignore[operator, no-any-return]
-            advertisements=[
-                BluetoothLERawAdvertisement(  # type: ignore[call-arg]
-                    adv.address, adv.rssi, adv.address_type, adv.data
-                )
-                for adv in data.advertisements
-            ]
-        )
-
-
 def make_ble_raw_advertisement_processor(
     on_advertisements: Callable[[List[BluetoothLERawAdvertisement]], None]
 ) -> Callable[["BluetoothLERawAdvertisementsResponse"], None]:

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -954,7 +954,7 @@ class BluetoothLERawAdvertisements:
 
 def ble_raw_advertisement_response_to_ble_raw_advertisements(
     data: "BluetoothLERawAdvertisementsResponse",
-) -> List[BluetoothLERawAdvertisements]:
+) -> List[BluetoothLERawAdvertisement]:
     """Convert BluetoothLERawAdvertisementResponse to a list of BluetoothLERawAdvertisement."""
     return [
         BluetoothLERawAdvertisement(  # type: ignore[call-arg]

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -944,14 +944,24 @@ class BluetoothLERawAdvertisements:
         cls: "BluetoothLERawAdvertisements",
         data: "BluetoothLERawAdvertisementsResponse",
     ) -> "BluetoothLERawAdvertisements":
+        """Convert BluetoothLERawAdvertisementResponse to BluetoothLERawAdvertisements."""
         return cls(  # type: ignore[operator, no-any-return]
-            advertisements=[
-                BluetoothLERawAdvertisement(  # type: ignore[call-arg]
-                    adv.address, adv.rssi, adv.address_type, adv.data
-                )
-                for adv in data.advertisements
-            ]
+            advertisements=ble_raw_advertisement_response_to_ble_raw_advertisements(
+                data
+            )
         )
+
+
+def ble_raw_advertisement_response_to_ble_raw_advertisements(
+    data: "BluetoothLERawAdvertisementsResponse",
+) -> List[BluetoothLERawAdvertisements]:
+    """Convert BluetoothLERawAdvertisementResponse to a list of BluetoothLERawAdvertisement."""
+    return [
+        BluetoothLERawAdvertisement(  # type: ignore[call-arg]
+            adv.address, adv.rssi, adv.address_type, adv.data
+        )
+        for adv in data.advertisements
+    ]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is part of an effort to reduce latency to see the BTHome buttons since I noticed there was a bit of latency when testing

Avoids making a dataclass of `BluetoothLERawAdvertisements` that is immediately thrown away since the `client` wants a list of `BluetoothLERawAdvertisement` dataclasses and never sees `BluetoothLERawAdvertisements`

Rename everything using `on_msg` to a name that reflects what type of message is being processed to improve trace and profile discoverability