### PR TITLE
Avoid sending pings when we have traffic

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -175,7 +175,7 @@ class APIConnection:
         self._fatal_exception: Optional[Exception] = None
         self._expected_disconnect = False
         self._send_pending_ping = False
-        self._loop = asyncio.get_running_loop()
+        self._loop = asyncio.get_event_loop()
 
     @property
     def connection_state(self) -> ConnectionState:


### PR DESCRIPTION
This is the same optimization that the ESPHome side has

https://github.com/esphome/esphome/blob/ddde1ee31ef96476c7a7d1c8b8fe306aa4d2e503/esphome/components/api/api_connection.cpp#L119

The goal is to keep network traffic to a minimum and avoid radio time when not needed