### PR TITLE
Improve error reporting when encryption is disabled on device but client requests it

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -267,7 +267,6 @@ class APINoiseFrameHelper(APIFrameHelper):
         "_proto",
         "_decrypt",
         "_encrypt",
-        "_client_info",
     )
 
     def __init__(

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -301,6 +301,7 @@ class APIConnection:
                 lambda: APIPlaintextFrameHelper(
                     on_pkt=self._process_packet,
                     on_error=self._report_fatal_error,
+                    client_info=self._params.client_info,
                 ),
                 sock=self._socket,
             )
@@ -311,6 +312,7 @@ class APIConnection:
                     expected_name=self._params.expected_name,
                     on_pkt=self._process_packet,
                     on_error=self._report_fatal_error,
+                    client_info=self._params.client_info,
                 ),
                 sock=self._socket,
             )

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -68,7 +68,9 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
         def _on_error(exc: Exception):
             raise exc
 
-        helper = APIPlaintextFrameHelper(on_pkt=_packet, on_error=_on_error)
+        helper = APIPlaintextFrameHelper(
+            on_pkt=_packet, on_error=_on_error, client_info="my client"
+        )
 
         helper.data_received(in_bytes)
 
@@ -113,6 +115,7 @@ async def test_noise_frame_helper_incorrect_key():
         on_error=_on_error,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
+        client_info="my client",
     )
     helper._transport = MagicMock()
 
@@ -151,6 +154,7 @@ async def test_noise_frame_helper_incorrect_key_fragments():
         on_error=_on_error,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
+        client_info="my client",
     )
     helper._transport = MagicMock()
 
@@ -191,6 +195,7 @@ async def test_noise_incorrect_name():
         on_error=_on_error,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="wrongname",
+        client_info="my client",
     )
     helper._transport = MagicMock()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -54,7 +54,9 @@ def socket_socket():
 
 def _get_mock_protocol(conn: APIConnection):
     protocol = APIPlaintextFrameHelper(
-        on_pkt=conn._process_packet, on_error=conn._report_fatal_error
+        on_pkt=conn._process_packet,
+        on_error=conn._report_fatal_error,
+        client_info="mock",
     )
     protocol._connected_event.set()
     protocol._transport = MagicMock()


### PR DESCRIPTION
Its not clear what is wrong when the device gets re-flashed without encryption but HA is still requesting it.

This PR improves the error reporting