### PR TITLE
Default unit of measurement to None

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -615,7 +615,7 @@ class NumberInfo(EntityInfo):
     step: float = converter_field(
         default=0.0, converter=fix_float_single_double_conversion
     )
-    unit_of_measurement: str = ""
+    unit_of_measurement: Optional[str] = None
     mode: Optional[NumberMode] = converter_field(
         default=NumberMode.AUTO, converter=NumberMode.convert
     )

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -408,7 +408,7 @@ class LastResetType(APIIntEnum):
 @dataclass(frozen=True)
 class SensorInfo(EntityInfo):
     device_class: str = ""
-    unit_of_measurement: str = ""
+    unit_of_measurement: Optional[str] = None
     accuracy_decimals: int = 0
     force_update: bool = False
     state_class: Optional[SensorStateClass] = converter_field(


### PR DESCRIPTION
As reported in https://github.com/home-assistant/core/issues/96543, the device class for AQI should be None instead of an empty string.
