### PR TITLE
Speed up formatting the cipher nonce

### DIFF
--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -4,8 +4,9 @@ import logging
 from abc import abstractmethod
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from struct import Struct
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag

--- a/aioesphomeapi/_frame_helper.py
+++ b/aioesphomeapi/_frame_helper.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
-
+from struct import Struct
 import async_timeout
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
@@ -34,11 +34,18 @@ SOCKET_ERRORS = (
     TimeoutError,
 )
 
+PACK_NONCE = partial(Struct("<LQ").pack, 0)
+
 
 class ChaCha20CipherReuseable(ChaCha20Cipher):  # type: ignore[misc]
+    """ChaCha20 cipher that can be reused."""
+
     @property
     def klass(self):  # type: ignore[no-untyped-def]
         return ChaCha20Poly1305Reusable
+
+    def format_nonce(self, n: int) -> bytes:
+        return PACK_NONCE(n)
 
 
 class ESPHomeNoiseBackend(DefaultNoiseBackend):  # type: ignore[misc]


### PR DESCRIPTION
fixes #476

```
 % python3 timer.py
0.045173624996095896
0.07660245802253485

```
```
import timeit
from functools import partial
from struct import Struct

PACK_NONCE = partial(Struct("<LQ").pack, 0)


def call2(n: int):
    return b"\x00\x00\x00\x00" + n.to_bytes(length=8, byteorder="little")


print(timeit.timeit("call(1)", globals={"call": PACK_NONCE}))
print(timeit.timeit("call2(1)", globals={"call2": call2}))
```