### PR TITLE
Improve error reporting for authenticated vs non-authenticated requests

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -316,24 +316,27 @@ class APIClient:
         else:
             await self._connection.disconnect()
 
-    def _check_connected(self) -> None:
-        if self._connection is None:
+    def _check_authenticated(self) -> None:
+        connection = self._connection
+        if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
-        if not self._connection.is_connected:
+        if not connection.is_connected:
             raise APIConnectionError(
-                f"Connection not done for {self._log_name}; "
+                f"Authenticated connection not ready yet for {self._log_name}; "
                 f"current state is {self._connection.connection_state}!"
             )
-
-    def _check_authenticated(self) -> None:
-        self._check_connected()
-        assert self._connection is not None
-        if not self._connection.is_authenticated:
+        if not connection.is_authenticated:
             raise APIConnectionError(f"Not authenticated for {self._log_name}!")
 
     async def device_info(self) -> DeviceInfo:
-        self._check_connected()
-        assert self._connection is not None
+        connection = self._connection
+        if not connection:
+            raise APIConnectionError(f"Not connected to {self._log_name}!")
+        if not connection or not connection.is_connected:
+            raise APIConnectionError(
+                f"Connection not ready yet for {self._log_name}; "
+                f"current state is {self._connection.connection_state}!"
+            )
         resp = await self._connection.send_message_await_response(
             DeviceInfoRequest(), DeviceInfoResponse
         )

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -320,12 +320,10 @@ class APIClient:
         connection = self._connection
         if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
-        if TYPE_CHECKING:
-            assert connection is not None
         if not connection.is_connected:
             raise APIConnectionError(
                 f"Authenticated connection not ready yet for {self._log_name}; "
-                f"current state is {self._connection.connection_state}!"
+                f"current state is {connection.connection_state}!"
             )
         if not connection.is_authenticated:
             raise APIConnectionError(f"Not authenticated for {self._log_name}!")
@@ -334,19 +332,17 @@ class APIClient:
         connection = self._connection
         if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
-        if TYPE_CHECKING:
-            assert connection is not None
         if not connection or not connection.is_connected:
             raise APIConnectionError(
                 f"Connection not ready yet for {self._log_name}; "
-                f"current state is {self._connection.connection_state}!"
+                f"current state is {connection.connection_state}!"
             )
-        resp = await self._connection.send_message_await_response(
+        resp = await connection.send_message_await_response(
             DeviceInfoRequest(), DeviceInfoResponse
         )
         info = DeviceInfo.from_pb(resp)
         self._cached_name = info.name
-        self._connection.set_log_name(self._log_name)
+        connection.set_log_name(self._log_name)
         return info
 
     async def list_entities_services(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -320,6 +320,8 @@ class APIClient:
         connection = self._connection
         if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
+        if TYPE_CHECKING:
+            assert connection is not None
         if not connection.is_connected:
             raise APIConnectionError(
                 f"Authenticated connection not ready yet for {self._log_name}; "
@@ -332,6 +334,8 @@ class APIClient:
         connection = self._connection
         if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
+        if TYPE_CHECKING:
+            assert connection is not None        
         if not connection or not connection.is_connected:
             raise APIConnectionError(
                 f"Connection not ready yet for {self._log_name}; "

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -335,7 +335,7 @@ class APIClient:
         if not connection:
             raise APIConnectionError(f"Not connected to {self._log_name}!")
         if TYPE_CHECKING:
-            assert connection is not None        
+            assert connection is not None
         if not connection or not connection.is_connected:
             raise APIConnectionError(
                 f"Connection not ready yet for {self._log_name}; "


### PR DESCRIPTION
If we failed during getting device info vs another request is was not clear if it was an auth problem or not from the message