### PR TITLE
Speed up BLE connections

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -585,7 +585,8 @@ class APIClient:
             # Resolve on ANY connection state since we do not want
             # to wait the whole timeout if the device disconnects
             # or we get an error.
-            connect_future.set_result(None)
+            if not connect_future.done():
+                connect_future.set_result(None)
 
     async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches
         self,

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -572,6 +572,7 @@ class APIClient:
         fut.set_exception(asyncio.TimeoutError())
 
     def _on_bluetooth_device_connection_response(
+        self,
         connect_future: asyncio.Future[None],
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -580,7 +580,7 @@ class APIClient:
             return
         fut.set_exception(asyncio.TimeoutError())
 
-    async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches
+    async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         self,
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -587,7 +587,7 @@ class APIClient:
             # or we get an error.
             connect_future.set_result(None)
 
-    async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    async def bluetooth_device_connect(  # pylint: disable=too-many-locals
         self,
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],
@@ -601,12 +601,6 @@ class APIClient:
         msg_types = (BluetoothDeviceConnectionResponse,)
         debug = _LOGGER.isEnabledFor(logging.DEBUG)
         connect_future: asyncio.Future[None] = self._loop.create_future()
-        _on_bluetooth_device_connection_response = partial(
-            self._on_bluetooth_device_connection_response,
-            connect_future,
-            address,
-            on_bluetooth_connection_state,
-        )
 
         assert self._connection is not None
         if has_cache:
@@ -630,7 +624,12 @@ class APIClient:
                 has_address_type=address_type is not None,
                 address_type=address_type or 0,
             ),
-            _on_bluetooth_device_connection_response,
+            partial(
+                self._on_bluetooth_device_connection_response,
+                connect_future,
+                address,
+                on_bluetooth_connection_state,
+            ),
             msg_types,
         )
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -15,7 +15,6 @@ from typing import (
     cast,
 )
 
-import async_timeout
 from google.protobuf import message
 
 from .api_pb2 import (  # type: ignore
@@ -639,7 +638,9 @@ class APIClient:
                     _on_bluetooth_device_connection_response, msg_types
                 )
 
-        timeout_handle = self._loop.call_later(timeout, self._handle_timeout, connect_future)
+        timeout_handle = self._loop.call_later(
+            timeout, self._handle_timeout, connect_future
+        )
         try:
             try:
                 await connect_future

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -580,7 +580,7 @@ class APIClient:
             return
         fut.set_exception(asyncio.TimeoutError())
 
-    async def bluetooth_device_connect(  # pylint: disable=too-many-locals
+    async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches
         self,
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],
@@ -619,7 +619,7 @@ class APIClient:
             request_type = BluetoothDeviceRequestType.CONNECT
 
         if debug:
-            _LOGGER.debug("%s: Using connection version %s", request_type)
+            _LOGGER.debug("%s: Using connection version %s", address, request_type)
 
         self._connection.send_message_callback_response(
             BluetoothDeviceRequest(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -587,7 +587,7 @@ class APIClient:
             # or we get an error.
             connect_future.set_result(None)
 
-    async def bluetooth_device_connect(  # pylint: disable=too-many-locals
+    async def bluetooth_device_connect(  # pylint: disable=too-many-locals, too-many-branches
         self,
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -582,6 +582,7 @@ class APIClient:
 
     def _on_bluetooth_device_connection_response(
         connect_future: asyncio.Future[None],
+        address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],
         msg: BluetoothDeviceConnectionResponse,
     ) -> None:
@@ -610,6 +611,7 @@ class APIClient:
         _on_bluetooth_device_connection_response = partial(
             self._on_bluetooth_device_connection_response,
             connect_future,
+            address,
             on_bluetooth_connection_state,
         )
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -639,7 +639,7 @@ class APIClient:
                     _on_bluetooth_device_connection_response, msg_types
                 )
 
-        self._loop.call_later(timeout, self._handle_timeout, connect_future)
+        timeout_handle = self._loop.call_later(timeout, self._handle_timeout, connect_future)
         try:
             try:
                 await connect_future
@@ -687,7 +687,7 @@ class APIClient:
                 )
             raise
         finally:
-            connect_future.cancel()
+            timeout_handle.cancel()
 
         return unsub
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -15,7 +15,6 @@ from typing import (
     List,
     Optional,
     Set,
-    Tuple,
     Type,
     Union,
 )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Type,
     Union,
 )
@@ -566,9 +567,9 @@ class APIConnection:
         message_handlers = self._message_handlers
         for msg_type in msg_types:
             message_handlers.setdefault(msg_type, set()).add(on_message)
-        return partial(self.remove_message_callback, on_message, msg_types)
+        return partial(self._remove_message_callback, on_message, msg_types)
 
-    def remove_message_callback(
+    def _remove_message_callback(
         self, on_message: Callable[[Any], None], msg_types: Iterable[Type[Any]]
     ) -> None:
         """Remove a message callback."""
@@ -581,7 +582,7 @@ class APIConnection:
         send_msg: message.Message,
         on_message: Callable[[Any], None],
         msg_types: Iterable[Type[Any]],
-    ) -> None:
+    ) -> Callable[[], None]:
         """Send a message to the remote and register the given message handler."""
         self.send_message(send_msg)
         # Since we do not return control to the event loop (no awaits)
@@ -590,6 +591,7 @@ class APIConnection:
         # we register the handler after sending the message
         for msg_type in msg_types:
             self._message_handlers.setdefault(msg_type, set()).add(on_message)
+        return partial(self._remove_message_callback, on_message, msg_types)
 
     def _handle_timeout(self, fut: asyncio.Future[None]) -> None:
         """Handle a timeout."""


### PR DESCRIPTION
- Use a future instead of an Event so we can simplify the timeout procedure
- `remove_message_callback` can now be abstracted away so the client does not ever have to know about it anymore since everything that subscribes now returns a callback to unsubscribe which reduces the risk we will get it wrong and leak subscribers