### PR TITLE
Fix pong timer warning when pending ping is skipped

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -316,6 +316,7 @@ class APIConnection:
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
                     client_info=self._params.client_info,
+                    log_name=self.log_name,
                 ),
                 sock=self._socket,
             )
@@ -327,6 +328,7 @@ class APIConnection:
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
                     client_info=self._params.client_info,
+                    log_name=self.log_name,
                 ),
                 sock=self._socket,
             )
@@ -391,30 +393,29 @@ class APIConnection:
 
         if self._send_pending_ping:
             self.send_message(PING_REQUEST_MESSAGE)
-
-        if self._pong_timer is None:
-            # Do not reset the timer if it's already set
-            # since the only thing we want to reset the timer
-            # is if we receive a pong.
-            self._pong_timer = self._loop.call_later(
-                self._keep_alive_timeout, self._async_pong_not_received
-            )
-        else:
-            #
-            # We haven't reached the ping response (pong) timeout yet
-            # and we haven't seen a response to the last ping
-            #
-            # We send another ping in case the device has
-            # rebooted and dropped the connection without telling
-            # us to force a TCP RST aka connection reset by peer.
-            #
-            _LOGGER.debug(
-                "%s: PingResponse (pong) was not received "
-                "since last keep alive after %s seconds; "
-                "rescheduling keep alive",
-                self.log_name,
-                self._keep_alive_interval,
-            )
+            if self._pong_timer is None:
+                # Do not reset the timer if it's already set
+                # since the only thing we want to reset the timer
+                # is if we receive a pong.
+                self._pong_timer = self._loop.call_later(
+                    self._keep_alive_timeout, self._async_pong_not_received
+                )
+            else:
+                #
+                # We haven't reached the ping response (pong) timeout yet
+                # and we haven't seen a response to the last ping
+                #
+                # We send another ping in case the device has
+                # rebooted and dropped the connection without telling
+                # us to force a TCP RST aka connection reset by peer.
+                #
+                _LOGGER.debug(
+                    "%s: PingResponse (pong) was not received "
+                    "since last keep alive after %s seconds; "
+                    "rescheduling keep alive",
+                    self.log_name,
+                    self._keep_alive_interval,
+                )
 
         self._async_schedule_keep_alive()
 
@@ -540,15 +541,14 @@ class APIConnection:
 
         frame_helper = self._frame_helper
         assert frame_helper is not None
-        message_type = PROTO_TO_MESSAGE_TYPE.get(type(msg))
+        _msg_type = type(msg)
+        message_type = PROTO_TO_MESSAGE_TYPE.get(_msg_type)
         if not message_type:
-            raise ValueError(f"Message type id not found for type {type(msg)}")
+            raise ValueError(f"Message type id not found for type {_msg_type}")
         encoded = msg.SerializeToString()
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug(
-                "%s: Sending %s: %s", self._params.address, type(msg), str(msg)
-            )
+            _LOGGER.debug("%s: Sending %s: %s", self.log_name, _msg_type.__name__, msg)
 
         try:
             frame_helper.write_packet(message_type, encoded)
@@ -730,7 +730,9 @@ class APIConnection:
                 class_ = message_type_to_proto[msg_type_proto]
             except KeyError:
                 _LOGGER.debug(
-                    "%s: Skipping message type %s", self.log_name, msg_type_proto
+                    "%s: Skipping message type %s",
+                    self.log_name,
+                    msg_type_proto.__name__,
                 )
                 return
 
@@ -760,7 +762,10 @@ class APIConnection:
 
             if is_enabled_for(logging_debug):
                 _LOGGER.debug(
-                    "%s: Got message of type %s: %s", self.log_name, msg_type, msg
+                    "%s: Got message of type %s: %s",
+                    self.log_name,
+                    msg_type.__name__,
+                    msg,
                 )
 
             if self._pong_timer:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -732,7 +732,7 @@ class APIConnection:
                 _LOGGER.debug(
                     "%s: Skipping message type %s",
                     self.log_name,
-                    msg_type_proto.__name__,
+                    msg_type_proto,
                 )
                 return
 

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -69,7 +69,7 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
             raise exc
 
         helper = APIPlaintextFrameHelper(
-            on_pkt=_packet, on_error=_on_error, client_info="my client"
+            on_pkt=_packet, on_error=_on_error, client_info="my client", log_name="test"
         )
 
         helper.data_received(in_bytes)
@@ -116,6 +116,7 @@ async def test_noise_frame_helper_incorrect_key():
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
         client_info="my client",
+        log_name="test",
     )
     helper._transport = MagicMock()
 
@@ -155,6 +156,7 @@ async def test_noise_frame_helper_incorrect_key_fragments():
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
         client_info="my client",
+        log_name="test",
     )
     helper._transport = MagicMock()
 
@@ -196,6 +198,7 @@ async def test_noise_incorrect_name():
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="wrongname",
         client_info="my client",
+        log_name="test",
     )
     helper._transport = MagicMock()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -57,6 +57,7 @@ def _get_mock_protocol(conn: APIConnection):
         on_pkt=conn._process_packet_factory(),
         on_error=conn._report_fatal_error,
         client_info="mock",
+        log_name="mock_device",
     )
     protocol._connected_event.set()
     protocol._transport = MagicMock()


### PR DESCRIPTION
If _send_pending_ping was set to False we would still check for pong which was incorrect as it should be skipped until the next time a ping is due

I cleaned up the logging to make sure the name of the device is always logged as I thought this was working correctly but I was getting devices confused