### PR TITLE
Remove memoryview wrapping for cameras

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -389,7 +389,7 @@ class APIClient:
 
     async def subscribe_states(self, on_state: Callable[[EntityState], None]) -> None:
         self._check_authenticated()
-        image_stream: Dict[int, list[memoryview]] = {}
+        image_stream: Dict[int, list[bytes]] = {}
         response_types: Dict[Any, Type[EntityState]] = {
             BinarySensorStateResponse: BinarySensorState,
             CoverStateResponse: CoverState,
@@ -417,12 +417,12 @@ class APIClient:
                 if TYPE_CHECKING:
                     assert isinstance(msg, CameraImageResponse)
                 msg_key = msg.key
-                data_parts: Optional[List[memoryview]] = image_stream.get(msg_key)
+                data_parts: Optional[List[bytes]] = image_stream.get(msg_key)
                 if not data_parts:
                     data_parts = []
                     image_stream[msg_key] = data_parts
 
-                data_parts.append(memoryview(msg.data))
+                data_parts.append(msg.data)
                 if msg.done:
                     # Return CameraState with the merged data
                     image_data = bytes().join(data_parts)


### PR DESCRIPTION
In #456 these the camera bytes were wrapped in memoryview but since the memory is not contiguous the final string has to copy anyways which makes overhead of wrapping in a memoryview is useless and counterproductive. The real speed up was not building a new bytes string every message and the cost of wrapping the memoryview was so small that I did not notice it was ineffective