### PR TITLE
Cleanups to connect process

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -496,7 +496,7 @@ class APIConnection:
 
     async def login(self, check_connected: bool = True) -> None:
         """Send a login (ConnectRequest) and await the response."""
-        if check_connected and self._connection_state != ConnectionState.CONNECTED:
+        if check_connected and self.is_connected:
             # On first connect, we don't want to check if we're connected
             # because we don't set the connection state until after login
             # is complete

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -284,13 +284,14 @@ class APIConnection:
                 err,
             )
 
-        _LOGGER.debug(
-            "%s: Connecting to %s:%s (%s)",
-            self.log_name,
-            self._params.address,
-            self._params.port,
-            addr,
-        )
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "%s: Connecting to %s:%s (%s)",
+                self.log_name,
+                self._params.address,
+                self._params.port,
+                addr,
+            )
         sockaddr = astuple(addr.sockaddr)
 
         try:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -119,6 +119,7 @@ class ConnectionState(enum.Enum):
     CONNECTED = 2
     CLOSED = 3
 
+
 OPEN_STATES = {ConnectionState.SOCKET_OPENED, ConnectionState.CONNECTED}
 
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -153,7 +153,7 @@ class APIConnection:
         "_send_pending_ping",
         "is_connected",
         "is_authenticated",
-        "_is_socket_open"
+        "_is_socket_open",
     )
 
     def __init__(

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -714,6 +714,7 @@ class APIConnection:
         is_enabled_for = _LOGGER.isEnabledFor
         logging_debug = logging.DEBUG
         message_handlers = self._message_handlers
+        internal_message_types = INTERNAL_MESSAGE_TYPES
 
         def _process_packet(msg_type_proto: int, data: bytes) -> None:
             """Process a packet from the socket."""
@@ -779,7 +780,7 @@ class APIConnection:
 
             # Pre-check the message type to avoid awaiting
             # since most messages are not internal messages
-            if msg_type not in INTERNAL_MESSAGE_TYPES:
+            if msg_type not in internal_message_types:
                 return
 
             if msg_type is DisconnectRequest:


### PR DESCRIPTION
- Make the connect process a bound method to avoid closure construction every time we connect (small imporvement for devices that disconnect/reconnect frequently due to wifi or deep sleep)

- remove api_version property since it does not need to be protected as the class is only used internally

- add OPEN_STATES = {ConnectionState.SOCKET_OPENED, ConnectionState.CONNECTED} constant to collapse some duplicaiton