### PR TITLE
Avoid mypy ignore when converting BLE raw advertisement

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -17,8 +17,6 @@ from typing import (
 )
 from uuid import UUID
 
-from google.protobuf.json_format import MessageToDict
-
 from .util import fix_float_single_double_conversion
 
 if sys.version_info[:2] < (3, 10):

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
 )
 from uuid import UUID
+
 from google.protobuf.json_format import MessageToDict
 
 from .util import fix_float_single_double_conversion

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -948,7 +948,7 @@ def make_ble_raw_advertisement_processor(
     ) -> None:
         on_advertisements(
             [
-                BluetoothLERawAdvertisement(zip(*adv.ListFields())[1])
+                BluetoothLERawAdvertisement(tuple(zip(*adv.ListFields()))[1])
                 for adv in data.advertisements
             ]
         )

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
 )
 from uuid import UUID
+from google.protobuf.json_format import MessageToDict
 
 from .util import fix_float_single_double_conversion
 
@@ -945,7 +946,10 @@ def make_ble_raw_advertisement_processor(
         data: "BluetoothLERawAdvertisementsResponse",
     ) -> None:
         on_advertisements(
-            [BluetoothLERawAdvertisement(*adv.values()) for adv in data.advertisements]
+            [
+                BluetoothLERawAdvertisement(*MessageToDict(adv).values())
+                for adv in data.advertisements
+            ]
         )
 
     return _on_ble_raw_advertisement_response

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -948,7 +948,7 @@ def make_ble_raw_advertisement_processor(
     ) -> None:
         on_advertisements(
             [
-                BluetoothLERawAdvertisement(tuple(zip(*adv.ListFields()))[1])
+                BluetoothLERawAdvertisement(*tuple(zip(*adv.ListFields()))[1])
                 for adv in data.advertisements
             ]
         )

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -945,12 +945,7 @@ def make_ble_raw_advertisement_processor(
         data: "BluetoothLERawAdvertisementsResponse",
     ) -> None:
         on_advertisements(
-            [
-                BluetoothLERawAdvertisement(  # type: ignore[call-arg]
-                    adv.address, adv.rssi, adv.address_type, adv.data
-                )
-                for adv in data.advertisements
-            ]
+            [BluetoothLERawAdvertisement(*adv.values()) for adv in data.advertisements]
         )
 
     return _on_ble_raw_advertisement_response

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -948,7 +948,7 @@ def make_ble_raw_advertisement_processor(
     ) -> None:
         on_advertisements(
             [
-                BluetoothLERawAdvertisement(*MessageToDict(adv).values())
+                BluetoothLERawAdvertisement(zip(*adv.ListFields())[1])
                 for adv in data.advertisements
             ]
         )


### PR DESCRIPTION
The protobuf and dataclasses are designed to always match order for round trips so we can use values() instead which avoids the ignore