### PR TITLE
Refactor frame helpers to share more code

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -95,8 +95,6 @@ class APIFrameHelper(asyncio.Protocol):
         """Handle a new connection."""
         self._transport = cast(asyncio.Transport, transport)
         self._writer = self._transport.write
-        if not self._ready_future.done():
-            self._ready_future.set_result(None)
 
     def _handle_error_and_close(self, exc: Exception) -> None:
         self._handle_error(exc)

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -95,7 +95,8 @@ class APIFrameHelper(asyncio.Protocol):
         """Handle a new connection."""
         self._transport = cast(asyncio.Transport, transport)
         self._writer = self._transport.write
-        self._ready_future.set_result(None)
+        if not self._ready_future.done():
+            self._ready_future.set_result(None)
 
     def _handle_error_and_close(self, exc: Exception) -> None:
         self._handle_error(exc)

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from functools import partial
 from typing import Callable, cast
 
-from ..core import SocketClosedAPIError
+from ..core import HandshakeAPIError, SocketClosedAPIError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,11 +24,12 @@ class APIFrameHelper(asyncio.Protocol):
     """Helper class to handle the API frame protocol."""
 
     __slots__ = (
+        "_loop",
         "_on_pkt",
         "_on_error",
         "_transport",
         "_writer",
-        "_connected_event",
+        "_ready_future",
         "_buffer",
         "_buffer_len",
         "_pos",
@@ -45,17 +46,23 @@ class APIFrameHelper(asyncio.Protocol):
         log_name: str,
     ) -> None:
         """Initialize the API frame helper."""
+        loop = asyncio.get_event_loop()
+        self._loop = loop
         self._on_pkt = on_pkt
         self._on_error = on_error
         self._transport: asyncio.Transport | None = None
         self._writer: None | (Callable[[bytes | bytearray | memoryview], None]) = None
-        self._connected_event = asyncio.Event()
+        self._ready_future = self._loop.create_future()
         self._buffer = bytearray()
         self._buffer_len = 0
         self._pos = 0
         self._client_info = client_info
         self._log_name = log_name
         self._debug_enabled = partial(_LOGGER.isEnabledFor, logging.DEBUG)
+
+    def _set_ready_future_exception(self, exc: Exception) -> None:
+        if not self._ready_future.done():
+            self._ready_future.set_exception(exc)
 
     def _read_exactly(self, length: int) -> bytearray | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""
@@ -66,9 +73,19 @@ class APIFrameHelper(asyncio.Protocol):
         self._pos = new_pos
         return self._buffer[original_pos:new_pos]
 
-    @abstractmethod
-    async def perform_handshake(self) -> None:
-        """Perform the handshake."""
+    async def perform_handshake(self, timeout: float) -> None:
+        """Perform the handshake with the server."""
+        handshake_handle = self._loop.call_later(
+            timeout, self._set_ready_future_exception, asyncio.TimeoutError()
+        )
+        try:
+            await self._ready_future
+        except asyncio.TimeoutError as err:
+            raise HandshakeAPIError(
+                f"{self._log_name}: Timeout during handshake"
+            ) from err
+        finally:
+            handshake_handle.cancel()
 
     @abstractmethod
     def write_packet(self, type_: int, data: bytes) -> None:
@@ -78,7 +95,7 @@ class APIFrameHelper(asyncio.Protocol):
         """Handle a new connection."""
         self._transport = cast(asyncio.Transport, transport)
         self._writer = self._transport.write
-        self._connected_event.set()
+        self._ready_future.set_result(None)
 
     def _handle_error_and_close(self, exc: Exception) -> None:
         self._handle_error(exc)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,11 @@ _LOGGER = logging.getLogger(__name__)
 
 class APIPlaintextFrameHelper(APIFrameHelper):
     """Frame helper for plaintext API connections."""
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        """Handle a new connection."""
+        super().connection_made(transport)
+        self._ready_future.set_result(None)
 
     def write_packet(self, type_: int, data: bytes) -> None:
         """Write a packet to the socket.
@@ -31,10 +37,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             raise SocketAPIError(
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
-
-    async def perform_handshake(self) -> None:
-        """Perform the handshake."""
-        await self._connected_event.wait()
 
     def data_received(self, data: bytes) -> None:  # pylint: disable=too-many-branches
         self._buffer += data

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -349,8 +349,7 @@ class APIConnection:
         self._frame_helper = fh
         self._set_connection_state(ConnectionState.SOCKET_OPENED)
         try:
-            async with async_timeout.timeout(HANDSHAKE_TIMEOUT):
-                await fh.perform_handshake()
+            await fh.perform_handshake(HANDSHAKE_TIMEOUT)
         except OSError as err:
             raise HandshakeAPIError(f"Handshake failed: {err}") from err
         except asyncio.TimeoutError as err:

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -149,7 +149,7 @@ async def test_noise_frame_helper_incorrect_key():
             helper.data_received(bytes.fromhex(pkt))
 
     with pytest.raises(InvalidEncryptionKeyAPIError):
-        await helper.perform_handshake()
+        await helper.perform_handshake(30)
 
 
 @pytest.mark.asyncio
@@ -192,7 +192,7 @@ async def test_noise_frame_helper_incorrect_key_fragments():
                 helper.data_received(in_pkt[i : i + 1])
 
     with pytest.raises(InvalidEncryptionKeyAPIError):
-        await helper.perform_handshake()
+        await helper.perform_handshake(30)
 
 
 @pytest.mark.asyncio
@@ -233,4 +233,4 @@ async def test_noise_incorrect_name():
             helper.data_received(bytes.fromhex(pkt))
 
     with pytest.raises(BadNameAPIError):
-        await helper.perform_handshake()
+        await helper.perform_handshake(30)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -59,7 +59,7 @@ def _get_mock_protocol(conn: APIConnection):
         client_info="mock",
         log_name="mock_device",
     )
-    protocol._connected_event.set()
+    protocol._ready_future.set_result(None)
     protocol._transport = MagicMock()
     protocol._writer = MagicMock()
     return protocol
@@ -76,6 +76,7 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
         nonlocal protocol
         protocol = create_func()
         protocol.connection_made(transport)
+        protocol._ready_future.set_result(None)
         connected.set()
         return transport, protocol
 
@@ -138,6 +139,7 @@ async def test_plaintext_connection(conn: APIConnection, resolve_host, socket_so
         nonlocal protocol
         protocol = create_func()
         protocol.connection_made(transport)
+        protocol._ready_future.set_result(None)
         connected.set()
         return transport, protocol
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -59,9 +59,8 @@ def _get_mock_protocol(conn: APIConnection):
         client_info="mock",
         log_name="mock_device",
     )
-    protocol._ready_future.set_result(None)
-    protocol._transport = MagicMock()
-    protocol._writer = MagicMock()
+    transport = MagicMock()
+    protocol.connection_made(transport)
     return protocol
 
 
@@ -76,7 +75,6 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
         nonlocal protocol
         protocol = create_func()
         protocol.connection_made(transport)
-        protocol._ready_future.set_result(None)
         connected.set()
         return transport, protocol
 
@@ -139,7 +137,6 @@ async def test_plaintext_connection(conn: APIConnection, resolve_host, socket_so
         nonlocal protocol
         protocol = create_func()
         protocol.connection_made(transport)
-        protocol._ready_future.set_result(None)
         connected.set()
         return transport, protocol
 


### PR DESCRIPTION
- Remove the need to a connected event and a separate future. The ready future is now used by both noise and plaintext
- Fixes the double timeout with noise and now allows the timeout to be set from the caller

fixes #499