### PR TITLE
Cache decode of protobuf messages

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -120,7 +120,7 @@ OPEN_STATES = {ConnectionState.SOCKET_OPENED, ConnectionState.CONNECTED}
 # from multiple connections. The Bluetooth advertisements
 # are expected to have a lot of the same messages.
 @lru_cache(maxsize=512)
-def _msg_from_bytes(msg_type_proto: int, data: bytes) -> message.Message:
+def _msg_from_bytes(msg_type_proto: int, data: bytes) -> Any:
     """Create a message from bytes."""
     msg = MESSAGE_TYPE_TO_PROTO[msg_type_proto]()
     # MergeFromString instead of ParseFromString since

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
-VERSION = "15.1.14"
+VERSION = "15.1.13"
 PROJECT_NAME = "aioesphomeapi"
 PROJECT_PACKAGE_NAME = "aioesphomeapi"
 PROJECT_LICENSE = "MIT"


### PR DESCRIPTION
Ideally we can avoid some memory churn if this works since many of the messages are the same