### PR TITLE
Increase SO_RCVBUF to 2MiB to reduce chance of ESP32 cam disconnects

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -47,7 +47,7 @@ from .model import APIVersion
 
 _LOGGER = logging.getLogger(__name__)
 
-BUFFER_SIZE = 1024 * 1024 * 2 # Set buffer limit to 2MB
+BUFFER_SIZE = 1024 * 1024 * 2  # Set buffer limit to 2MB
 
 
 INTERNAL_MESSAGE_TYPES = {GetTimeRequest, PingRequest, DisconnectRequest}

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -47,7 +47,7 @@ from .model import APIVersion
 
 _LOGGER = logging.getLogger(__name__)
 
-BUFFER_SIZE = 1024 * 1024  # Set buffer limit to 1MB
+BUFFER_SIZE = 1024 * 1024 * 2 # Set buffer limit to 2MB
 
 
 INTERNAL_MESSAGE_TYPES = {GetTimeRequest, PingRequest, DisconnectRequest}


### PR DESCRIPTION
Increase SO_RCVBUF to 2MiB to reduce chance of ESP32 cam disconnects

```
Logger: aioesphomeapi.connection
Source: runner.py:179
First occurred: 1:56:01 AM (65 occurrences)
Last logged: 8:40:21 AM

cam-utilities-indoor @ 192.168.210.41: Connection error occurred: cam-utilities-indoor @ 192.168.210.41: EOF received
```