### PR TITLE
Avoid a few calls to fetch loop time

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -75,8 +75,10 @@ class APIFrameHelper(asyncio.Protocol):
 
     async def perform_handshake(self, timeout: float) -> None:
         """Perform the handshake with the server."""
-        handshake_handle = self._loop.call_later(
-            timeout, self._set_ready_future_exception, asyncio.TimeoutError()
+        handshake_handle = self._loop.call_at(
+            self._loop.time() + timeout,
+            self._set_ready_future_exception,
+            asyncio.TimeoutError,
         )
         try:
             await self._ready_future

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -649,7 +649,9 @@ class APIClient:
         )
 
         loop = self._loop
-        timeout_handle = loop.call_later(timeout, self._handle_timeout, connect_future)
+        timeout_handle = loop.call_at(
+            loop.time() + timeout, self._handle_timeout, connect_future
+        )
         timeout_expired = False
         connect_ok = False
         try:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -146,7 +146,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         if not delay:
             self._call_connect_once()
             return
-        self._connect_timer = self.loop.call_later(delay, self._call_connect_once)
+        self._connect_timer = self.loop.call_at(
+            self.loop.time() + delay, self._call_connect_once
+        )
 
     def _call_connect_once(self) -> None:
         """Call the connect logic once.


### PR DESCRIPTION
- Only call `loop.time()` once in the ping path (`call_later` has to fetch time under the hood)
- Avoid `call_later` and use `call_at`