### PR TITLE
Fix zeroconf listener being removed from zeroconf callback

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -279,6 +279,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 self._log_name,
                 record_update.new,
             )
-            self._stop_zc_listen()
+            # We can't stop the zeroconf listener here because we are in the middle of
+            # a zeroconf callback which is iterating the listeners.
+            #
+            # So we schedule a stop for the next event loop iteration.
+            self.loop.call_soon(self._stop_zc_listen)
             self._schedule_connect(0.0)
             return


### PR DESCRIPTION
fixes #537

before
```
2023-09-05 18:03:34.850 DEBUG (MainThread) [aioesphomeapi.reconnect_logic] disco @ 192.168.211.119: Triggering connect because of received mDNS record record[ptr,in,_esphomelib._tcp.local.]=4500.0/4500,disco._esphomelib._tcp.local.
2023-09-05 18:03:34.851 DEBUG (MainThread) [aioesphomeapi.reconnect_logic] Removing zeroconf listener for disco
2023-09-05 18:03:34.851 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback _SelectorDatagramTransport._read_ready()
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/selector_events.py", line 1169, in _read_ready
    self._protocol.datagram_received(data, addr)
  File "src/zeroconf/_listener.py", line 80, in zeroconf._listener.AsyncListener.datagram_received
  File "src/zeroconf/_listener.py", line 161, in zeroconf._listener.AsyncListener.datagram_received
  File "src/zeroconf/_handlers/record_manager.py", line 134, in zeroconf._handlers.record_manager.RecordManager.async_updates_from_response
  File "src/zeroconf/_handlers/record_manager.py", line 58, in zeroconf._handlers.record_manager.RecordManager.async_updates
RuntimeError: set changed size during iteration
```

after
```
2023-09-05 18:18:58.098 DEBUG (MainThread) [aioesphomeapi.reconnect_logic] Starting zeroconf listener for disco
2023-09-05 18:19:00.245 DEBUG (MainThread) [aioesphomeapi.reconnect_logic] disco @ 192.168.211.119: Triggering connect because of received mDNS record record[ptr,in,_esphomelib._tcp.local.]=4500.0/4500,disco._esphomelib._tcp.local.
2023-09-05 18:19:00.246 DEBUG (MainThread) [aioesphomeapi.reconnect_logic] Removing zeroconf listener for disco
```