### PR TITLE
Generate pyi files with protoc-gen-pyi

### DIFF
--- a/script/gen-protoc
+++ b/script/gen-protoc
@@ -8,7 +8,7 @@ root_dir = Path(__file__).absolute().parent.parent
 os.chdir(root_dir)
 
 check_call([
-    "protoc", "--python_out=aioesphomeapi", "-I", "aioesphomeapi",
+    "protoc", "--python_out=aioesphomeapi", "--pyi_out=aioesphomeapi", "-I", "aioesphomeapi",
     "aioesphomeapi/api.proto", "aioesphomeapi/api_options.proto"
 ])
 


### PR DESCRIPTION
All the typing doesn't work with the protobuf defs since we aren't generating the pyi files

This will probably fail because it needs a newer protoc. https://github.com/protocolbuffers/protobuf/issues/10988

