### PR TITLE
Optimize buffering to be zero copy for single packet per read case

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -70,7 +70,6 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = data
             self._buffer_len = len(data)
             return
-        _LOGGER.warning("%s: Add partial packet to buffer", self._log_name)
         # This is the expensive case since we have to create
         # a new immutable bytes object each time, but since
         # its so rare we do not want to optimize for it
@@ -84,7 +83,6 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = None
             self._buffer_len = 0
             return
-        _LOGGER.warning("%s: Removing partial packet from buffer", self._log_name)
         if TYPE_CHECKING:
             assert self._buffer is not None
         # This is the expensive case since we have to create

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -70,6 +70,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = data
             self._buffer_len = len(data)
             return
+        _LOGGER.warning("%s: Add partial packet to buffer", self._log_name)
         # This is the expensive case since we have to create
         # a new immutable bytes object each time, but since
         # its so rare we do not want to optimize for it
@@ -83,6 +84,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = None
             self._buffer_len = 0
             return
+        _LOGGER.warning("%s: Removing partial packet from buffer", self._log_name)
         if TYPE_CHECKING:
             assert self._buffer is not None
         # This is the expensive case since we have to create

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -72,7 +72,7 @@ class APIFrameHelper(asyncio.Protocol):
             return
         # This is the expensive case since we have to create
         # a new immutable bytes object each time, but since
-        # its so rare we do not want to optimize for it        
+        # its so rare we do not want to optimize for it
         self._buffer += data
         self._buffer_len += len(data)
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -76,7 +76,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer += data
         self._buffer_len += len(data)
 
-    def _remove_packet_from_buffer(self):
+    def _remove_packet_from_buffer(self) -> None:
         """Remove the packet from the buffer."""
         buffer_len = self._buffer_len
         end_of_frame_pos = self._pos

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -89,8 +89,9 @@ class APIFrameHelper(asyncio.Protocol):
         if type(self._buffer) is bytearray:
             del self._buffer[:end_of_frame_pos]
         else:
-            # If the buffer is a bytes object we need to create a new bytes object
-            # since bytes objects are immutable
+            # If the buffer is a bytes object we need to convert it to
+            # a bytearray since we know we are going to have to append
+            # to it later
             self._buffer = bytearray(self._buffer[end_of_frame_pos:])
 
     def _read_exactly(self, length: int) -> bytearray | bytes | None:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -70,7 +70,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = data
             self._buffer_len = len(data)
             return
-        if type(self._buffer) is bytes: # pylint: disable=unidiomatic-typecheck
+        if type(self._buffer) is bytes:  # pylint: disable=unidiomatic-typecheck
             self._buffer = bytearray(self._buffer) + data
         else:
             self._buffer += data
@@ -86,7 +86,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer_len = 0
             return
         self._buffer_len -= end_of_frame_pos
-        if type(self._buffer) is bytes: # pylint: disable=unidiomatic-typecheck
+        if type(self._buffer) is bytes:  # pylint: disable=unidiomatic-typecheck
             # If the buffer is a bytes object we need to convert it to
             # a bytearray since we know we are going to have to append
             # to it later

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -73,6 +73,8 @@ class APIFrameHelper(asyncio.Protocol):
         if type(self._buffer) is bytes:  # pylint: disable=unidiomatic-typecheck
             self._buffer = bytearray(self._buffer) + data
         else:
+            if TYPE_CHECKING:
+                assert isinstance(self._buffer, bytearray)
             self._buffer += data
         self._buffer_len += len(data)
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -70,7 +70,7 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = data
             self._buffer_len = len(data)
             return
-        if type(self._buffer) is bytes:
+        if type(self._buffer) is bytes: # pylint: disable=unidiomatic-typecheck
             self._buffer = bytearray(self._buffer) + data
         else:
             self._buffer += data
@@ -86,13 +86,13 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer_len = 0
             return
         self._buffer_len -= end_of_frame_pos
-        if type(self._buffer) is bytearray:
-            del self._buffer[:end_of_frame_pos]
-        else:
+        if type(self._buffer) is bytes: # pylint: disable=unidiomatic-typecheck
             # If the buffer is a bytes object we need to convert it to
             # a bytearray since we know we are going to have to append
             # to it later
             self._buffer = bytearray(self._buffer[end_of_frame_pos:])
+        else:
+            del self._buffer[:end_of_frame_pos]
 
     def _read_exactly(self, length: int) -> bytearray | bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -78,10 +78,8 @@ class APIFrameHelper(asyncio.Protocol):
 
     def _remove_packet_from_buffer(self) -> None:
         """Remove the packet from the buffer."""
-        buffer_len = self._buffer_len
-        end_of_frame_pos = self._pos
         # Best case, the buffer is now emtpy
-        if buffer_len == end_of_frame_pos:
+        if self._buffer_len == self._pos:
             self._buffer = None
             self._buffer_len = 0
             return
@@ -90,6 +88,7 @@ class APIFrameHelper(asyncio.Protocol):
         # This is the expensive case since we have to create
         # a new immutable bytes object each time, but since
         # its so rare we do not want to optimize for it
+        end_of_frame_pos = self._pos
         self._buffer_len -= end_of_frame_pos
         self._buffer = self._buffer[end_of_frame_pos:]
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -71,6 +71,9 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer_len = len(data)
             return
         if type(self._buffer) is bytes:  # pylint: disable=unidiomatic-typecheck
+            _LOGGER.warning(
+                "_append_or_replace_buffer: Worse case scenario, converting bytes to bytearray"
+            )
             self._buffer = bytearray(self._buffer) + data
         else:
             if TYPE_CHECKING:
@@ -92,6 +95,9 @@ class APIFrameHelper(asyncio.Protocol):
             # If the buffer is a bytes object we need to convert it to
             # a bytearray since we know we are going to have to append
             # to it later
+            _LOGGER.warning(
+                "_remove_packet_from_buffer: Worse case scenario, converting bytes to bytearray"
+            )
             self._buffer = bytearray(self._buffer[end_of_frame_pos:])
         else:
             if TYPE_CHECKING:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -76,6 +76,7 @@ class APIFrameHelper(asyncio.Protocol):
             )
             self._buffer = bytearray(self._buffer) + data
         else:
+            _LOGGER.warning("_append_or_replace_buffer: Appending to bytearray")
             if TYPE_CHECKING:
                 assert isinstance(self._buffer, bytearray)
             self._buffer += data
@@ -100,6 +101,7 @@ class APIFrameHelper(asyncio.Protocol):
             )
             self._buffer = bytearray(self._buffer[end_of_frame_pos:])
         else:
+            _LOGGER.warning("_remove_packet_from_buffer: Removing from bytearray")
             if TYPE_CHECKING:
                 assert isinstance(self._buffer, bytearray)
             del self._buffer[:end_of_frame_pos]

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -70,6 +70,9 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = data
             self._buffer_len = len(data)
             return
+        # This is the expensive case since we have to create
+        # a new immutable bytes object each time, but since
+        # its so rare we do not want to optimize for it        
         self._buffer += data
         self._buffer_len += len(data)
 
@@ -82,6 +85,11 @@ class APIFrameHelper(asyncio.Protocol):
             self._buffer = None
             self._buffer_len = 0
             return
+        if TYPE_CHECKING:
+            assert self._buffer is not None
+        # This is the expensive case since we have to create
+        # a new immutable bytes object each time, but since
+        # its so rare we do not want to optimize for it
         self._buffer_len -= end_of_frame_pos
         self._buffer = self._buffer[end_of_frame_pos:]
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, cast
 
 from ..core import HandshakeAPIError, SocketClosedAPIError
 
@@ -105,6 +105,8 @@ class APIFrameHelper(asyncio.Protocol):
         if self._buffer_len < new_pos:
             return None
         self._pos = new_pos
+        if TYPE_CHECKING:
+            assert self._buffer is not None
         return self._buffer[original_pos:new_pos]
 
     async def perform_handshake(self, timeout: float) -> None:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, cast
+from typing import Callable, cast, TYPE_CHECKING
 
 from ..core import HandshakeAPIError, SocketClosedAPIError
 
@@ -92,6 +92,8 @@ class APIFrameHelper(asyncio.Protocol):
             # to it later
             self._buffer = bytearray(self._buffer[end_of_frame_pos:])
         else:
+            if TYPE_CHECKING:
+                assert isinstance(self._buffer, bytearray)
             del self._buffer[:end_of_frame_pos]
 
     def _read_exactly(self, length: int) -> bytearray | bytes | None:

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -137,8 +137,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         await super().perform_handshake(timeout)
 
     def data_received(self, data: bytes) -> None:
-        self._buffer += data
-        self._buffer_len += len(data)
+        self._append_or_replace_buffer(data)
         while self._buffer:
             self._pos = 0
             header = self._read_exactly(3)
@@ -166,9 +165,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             except Exception as err:  # pylint: disable=broad-except
                 self._handle_error_and_close(err)
             finally:
-                end_of_frame_pos = self._pos
-                del self._buffer[:end_of_frame_pos]
-                self._buffer_len -= end_of_frame_pos
+                self._remove_packet_from_buffer()
 
     def _send_hello_handshake(self) -> None:
         """Send a ClientHello to the server."""

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -343,9 +343,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         # N bytes: message data
         self._on_pkt((msg[0] << 8) | msg[1], msg[4:])
 
-    def _handle_closed(  # pylint: disable=unused-argument
-        self, frame: bytes
-    ) -> None:
+    def _handle_closed(self, frame: bytes) -> None:  # pylint: disable=unused-argument
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError(f"{self._log_name}: Connection closed"))
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -191,7 +191,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
 
-    def _handle_hello(self, server_hello: bytearray | bytes) -> None:
+    def _handle_hello(self, server_hello: bytes) -> None:
         """Perform the handshake with the server."""
         if not server_hello:
             self._handle_error_and_close(
@@ -262,7 +262,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         proto.start_handshake()
         self._proto = proto
 
-    def _handle_handshake(self, msg: bytearray | bytes) -> None:
+    def _handle_handshake(self, msg: bytes) -> None:
         _LOGGER.debug("Starting handshake...")
         if msg[0] != 0:
             explanation = msg[1:].decode()
@@ -326,12 +326,12 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
 
-    def _handle_frame(self, frame: bytearray | bytes) -> None:
+    def _handle_frame(self, frame: bytes) -> None:
         """Handle an incoming frame."""
         if TYPE_CHECKING:
             assert self._decrypt is not None, "Handshake should be complete"
         try:
-            msg = self._decrypt(bytes(frame))
+            msg = self._decrypt(frame)
         except InvalidTag as ex:
             self._handle_error_and_close(
                 ProtocolAPIError(f"{self._log_name}: Bad encryption frame: {ex!r}")
@@ -344,7 +344,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._on_pkt((msg[0] << 8) | msg[1], msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument
-        self, frame: bytearray | bytes
+        self, frame: bytes
     ) -> None:
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError(f"{self._log_name}: Connection closed"))

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -191,7 +191,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
 
-    def _handle_hello(self, server_hello: bytearray) -> None:
+    def _handle_hello(self, server_hello: bytearray | bytes) -> None:
         """Perform the handshake with the server."""
         if not server_hello:
             self._handle_error_and_close(
@@ -262,7 +262,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         proto.start_handshake()
         self._proto = proto
 
-    def _handle_handshake(self, msg: bytearray) -> None:
+    def _handle_handshake(self, msg: bytearray | bytes) -> None:
         _LOGGER.debug("Starting handshake...")
         if msg[0] != 0:
             explanation = msg[1:].decode()
@@ -326,7 +326,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
 
-    def _handle_frame(self, frame: bytearray) -> None:
+    def _handle_frame(self, frame: bytearray | bytes) -> None:
         """Handle an incoming frame."""
         if TYPE_CHECKING:
             assert self._decrypt is not None, "Handshake should be complete"
@@ -344,7 +344,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._on_pkt((msg[0] << 8) | msg[1], msg[4:])
 
     def _handle_closed(  # pylint: disable=unused-argument
-        self, frame: bytearray
+        self, frame: bytearray | bytes
     ) -> None:
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError(f"{self._log_name}: Connection closed"))

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -110,14 +110,15 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if length_int == 0:
                 packet_data = b""
             else:
-                packet_data = self._read_exactly(length_int)
+                maybe_packet_data = self._read_exactly(length_int)
                 # The packet data is not yet available, wait for more data
                 # to arrive before continuing, since callback_packet has not
                 # been called yet the buffer will not be cleared and the next
                 # call to data_received will continue processing the packet
                 # at the start of the frame.
-                if packet_data is None:
+                if maybe_packet_data is None:
                     return
+                packet_data = maybe_packet_data
 
             self._remove_packet_from_buffer()
             self._on_pkt(msg_type_int, packet_data)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -77,10 +77,10 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     msg_type_int = maybe_msg_type
                 else:
                     # Message type is longer than 1 byte
-                    msg_type = bytes(init_bytes[2:3])
+                    msg_type = init_bytes[2:3]
             else:
                 # Length is longer than 1 byte
-                length = bytes(init_bytes[1:3])
+                length = init_bytes[1:3]
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:
                     add_length = self._read_exactly(1)
@@ -110,16 +110,15 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if length_int == 0:
                 packet_data = b""
             else:
-                packet_data_bytearray = self._read_exactly(length_int)
+                packet_data = self._read_exactly(length_int)
                 # The packet data is not yet available, wait for more data
                 # to arrive before continuing, since callback_packet has not
                 # been called yet the buffer will not be cleared and the next
                 # call to data_received will continue processing the packet
                 # at the start of the frame.
-                if packet_data_bytearray is None:
+                if packet_data is None:
                     return
-                packet_data = bytes(packet_data_bytearray)
-
+                
             self._remove_packet_from_buffer()
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -39,8 +39,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             ) from err
 
     def data_received(self, data: bytes) -> None:  # pylint: disable=too-many-branches
-        self._buffer += data
-        self._buffer_len += len(data)
+        self._append_or_replace_buffer(data)
         while self._buffer:
             # Read preamble, which should always 0x00
             # Also try to get the length and msg type
@@ -121,8 +120,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     return
                 packet_data = bytes(packet_data_bytearray)
 
-            end_of_frame_pos = self._pos
-            del self._buffer[:end_of_frame_pos]
-            self._buffer_len -= end_of_frame_pos
+            self._remove_packet_from_buffer()
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -118,7 +118,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 # at the start of the frame.
                 if packet_data is None:
                     return
-                
+
             self._remove_packet_from_buffer()
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing


### PR DESCRIPTION
Most of the time we get a whole message with the read so we can avoid copying and merging the buffer if this is the case.

this is another attempt at #525 that does not use a deque and instead tries to keep the buffer being a bytes object until we need to actually join it