### PR TITLE
Clear buffer when size reaches zero instead of slicing

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -167,8 +167,11 @@ class APINoiseFrameHelper(APIFrameHelper):
                 self._handle_error_and_close(err)
             finally:
                 end_of_frame_pos = self._pos
-                del self._buffer[:end_of_frame_pos]
                 self._buffer_len -= end_of_frame_pos
+                if not self._buffer_len:
+                    self._buffer.clear()
+                else:
+                    del self._buffer[:end_of_frame_pos]
 
     def _send_hello_handshake(self) -> None:
         """Send a ClientHello to the server."""

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -122,7 +122,10 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 packet_data = bytes(packet_data_bytearray)
 
             end_of_frame_pos = self._pos
-            del self._buffer[:end_of_frame_pos]
             self._buffer_len -= end_of_frame_pos
+            if not self._buffer_len:
+                self._buffer.clear()
+            else:
+                del self._buffer[:end_of_frame_pos]
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing


### PR DESCRIPTION
Most of the time we reach a zero buffer. Its cheaper to resize it to 0 instead of slicing