### PR TITLE
Switch host resolver to use modern zeroconf APIs

### DIFF
--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -47,7 +47,7 @@ async def _async_zeroconf_get_service_info(
     service_type: str,
     service_name: str,
     timeout: float,
-) -> "zeroconf.ServiceInfo" | None:
+) -> "zeroconf.asyncio.AsyncServiceInfo" | None:
     # Use or create zeroconf instance, ensure it's an AsyncZeroconf
     if zeroconf_instance is None:
         try:
@@ -101,19 +101,19 @@ async def _async_resolve_host_zeroconf(
         return []
 
     addrs: list[AddrInfo] = []
-    for raw in info.addresses_by_version(zeroconf.IPVersion.All):
-        is_ipv6 = len(raw) == 16
+    for ip_address in info.ip_addresses_by_version(zeroconf.IPVersion.All):
+        is_ipv6 = ip_address.version == 6
         sockaddr: Sockaddr
         if is_ipv6:
             sockaddr = IPv6Sockaddr(
-                address=socket.inet_ntop(socket.AF_INET6, raw),
+                address=str(ip_address),
                 port=port,
                 flowinfo=0,
                 scope_id=0,
             )
         else:
             sockaddr = IPv4Sockaddr(
-                address=socket.inet_ntop(socket.AF_INET, raw),
+                address=str(ip_address),
                 port=port,
             )
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -1,6 +1,6 @@
 import socket
-
 from ipaddress import ip_address
+
 import pytest
 from mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -1,6 +1,6 @@
-import asyncio
 import socket
 
+from ipaddress import ip_address
 import pytest
 from mock import AsyncMock, MagicMock, patch
 
@@ -40,9 +40,9 @@ def addr_infos():
 @pytest.mark.asyncio
 async def test_resolve_host_zeroconf(async_zeroconf, addr_infos):
     info = MagicMock()
-    info.addresses_by_version.return_value = [
-        b"\n\x00\x00*",
-        b" \x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4",
+    info.ip_addresses_by_version.return_value = [
+        ip_address(b"\n\x00\x00*"),
+        ip_address(b" \x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4"),
     ]
     async_zeroconf.async_get_service_info = AsyncMock(return_value=info)
     async_zeroconf.async_close = AsyncMock()


### PR DESCRIPTION
replaces `addresses_by_version` with `ip_addresses_by_version` as `addresses_by_version` was deprecated in zeroconf 0.53 and `addresses_by_version` was broken in newer zeroconf until it was recently fixed in zeroconf 0.115.1

related issue https://github.com/home-assistant/core/issues/101039