### PR TITLE
Add optional basic cython implementation for frame_helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,25 +16,16 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - id: flake8
-            name: Lint with flake8
-          - id: pylint
-            name: Lint with pylint
-          - id: black
-            name: Check formatting with black
-          - id: isort
-            name: Check import order with isort
-          - id: mypy
-            name: Check typing with mypy
-          - id: pytest
-            name: Run tests with pytest
-          - id: protoc
-            name: Check protobuf files match
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"   
+        os:
+          - ubuntu-latest            
         extension:
           - "skip_cython"
           - "use_cython"            
@@ -44,7 +35,7 @@ jobs:
         uses: actions/setup-python@v4
         id: python
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
 
       - name: Get pip cache dir
         id: pip-cache
@@ -57,14 +48,20 @@ jobs:
           key: pip-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt', 'requirements_test.txt') }}
           restore-keys: |
             pip-${{ steps.python.outputs.python-version }}-
-      - name: Set up Python environment
+      - name: Set up Python environment (no cython)
+        if: ${{ matrix.extension == 'skip_cython' }}
+        env:
+          SKIP_CYTHON: 1
         run: |
           pip3 install -r requirements.txt -r requirements_test.txt
-          if [ "${{ matrix.extension }}" = "skip_cython" ]; then
-            SKIP_CYTHON=1 pip3 install -e .
-          else
-            REQUIRE_CYTHON=1 pip3 install -e .
-          fi
+          pip3 install -e .
+      - name: Set up Python environment (cython)
+        if: ${{ matrix.extension == 'use_cython' }}
+        env:
+          REQUIRE_CYTHON: 1
+        run: |
+          pip3 install -r requirements.txt -r requirements_test.txt
+          pip3 install -e .
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/flake8.json"
@@ -74,17 +71,17 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/pytest.json"
 
       - run: flake8 aioesphomeapi
-        if: ${{ matrix.id == 'flake8' }}
+        name: Lint with flake8
       - run: pylint aioesphomeapi
-        if: ${{ matrix.id == 'pylint' }}
+        name: Lint with pylint
       - run: black --check --diff --color aioesphomeapi tests
-        if: ${{ matrix.id == 'black' }}
+        name: Check formatting with black
       - run: isort --check --diff aioesphomeapi tests
-        if: ${{ matrix.id == 'isort' }}
+        name: Check import order with isort
       - run: mypy aioesphomeapi
-        if: ${{ matrix.id == 'mypy' }}
+        name: Check typing with mypy
       - run: pytest -vv --tb=native tests
-        if: ${{ matrix.id == 'pytest' }}
+        name: Run tests with pytest
       - run: |
           docker run \
             -v "$PWD":/aioesphomeapi \
@@ -95,4 +92,4 @@ jobs:
             echo 'docker run -v "$PWD":/aioesphomeapi ghcr.io/esphome/aioesphomeapi-proto-builder:latest'
             exit 1
           fi
-        if: ${{ matrix.id == 'protoc' }}
+        name: Check protobuf files match

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.name }} py ${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.extension }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,19 @@ jobs:
 
       - run: flake8 aioesphomeapi
         name: Lint with flake8
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
       - run: pylint aioesphomeapi
         name: Lint with pylint
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
       - run: black --check --diff --color aioesphomeapi tests
         name: Check formatting with black
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
       - run: isort --check --diff aioesphomeapi tests
         name: Check import order with isort
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
       - run: mypy aioesphomeapi
         name: Check typing with mypy
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
       - run: pytest -vv --tb=native tests
         name: Run tests with pytest
       - run: |
@@ -99,4 +99,4 @@ jobs:
             exit 1
           fi
         name: Check protobuf files match
-        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,19 @@ jobs:
 
       - run: flake8 aioesphomeapi
         name: Lint with flake8
+        if: ${{ matrix.python-version == '3.11' }}
       - run: pylint aioesphomeapi
         name: Lint with pylint
+        if: ${{ matrix.python-version == '3.11' }}
       - run: black --check --diff --color aioesphomeapi tests
         name: Check formatting with black
+        if: ${{ matrix.python-version == '3.11' }}
       - run: isort --check --diff aioesphomeapi tests
         name: Check import order with isort
+        if: ${{ matrix.python-version == '3.11' }}
       - run: mypy aioesphomeapi
         name: Check typing with mypy
+        if: ${{ matrix.python-version == '3.11' }}
       - run: pytest -vv --tb=native tests
         name: Run tests with pytest
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
             name: Run tests with pytest
           - id: protoc
             name: Check protobuf files match
+        extension:
+          - "skip_cython"
+          - "use_cython"            
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -57,8 +60,11 @@ jobs:
       - name: Set up Python environment
         run: |
           pip3 install -r requirements.txt -r requirements_test.txt
-          pip3 install -e .
-
+          if [ "${{ matrix.extension }}" = "skip_cython" ]; then
+            SKIP_CYTHON=1 pip3 install -e .
+          else
+            REQUIRE_CYTHON=1 pip3 install -e .
+          fi
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/flake8.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Restore PIP cache
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt', 'requirements_test.txt') }}
+          key: pip-${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('requirements.txt', 'requirements_test.txt') }}
           restore-keys: |
-            pip-${{ steps.python.outputs.python-version }}-
+            pip-${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-
       - name: Set up Python environment (no cython)
         if: ${{ matrix.extension == 'skip_cython' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   ci:
     name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,19 @@ jobs:
 
       - run: flake8 aioesphomeapi
         name: Lint with flake8
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
       - run: pylint aioesphomeapi
         name: Lint with pylint
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
       - run: black --check --diff --color aioesphomeapi tests
         name: Check formatting with black
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
       - run: isort --check --diff aioesphomeapi tests
         name: Check import order with isort
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
       - run: mypy aioesphomeapi
         name: Check typing with mypy
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}
       - run: pytest -vv --tb=native tests
         name: Run tests with pytest
       - run: |
@@ -99,3 +99,4 @@ jobs:
             exit 1
           fi
         name: Check protobuf files match
+        if: ${{ matrix.python-version == '3.11' and matrix.extension == 'skip_cython' }}

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ The module is available from the `Python Package Index <https://pypi.python.org/
 
 An optional cython extension is available for better performance, and the module will try to build it automatically.
 
-The extension requires a C compiler and the Python development headers, if they are not available the module will fall back to the pure Python implementation.
+The extension requires a C compiler and Python development headers. The module will fall back to the pure Python implementation if they are unavailable.
 
-Building the extension can be disabled by setting the environment variable ``SKIP_CYTHON`` to ``1``.
+Building the extension can be forcefully disabled by setting the environment variable ``SKIP_CYTHON`` to ``1``.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,12 @@ The module is available from the `Python Package Index <https://pypi.python.org/
 
     $ pip3 install aioesphomeapi
 
+An optional cython extension is available for better performance, and the module will try to build it automatically.
+
+The extension requires a C compiler and the Python development headers, if they are not available the module will fall back to the pure Python implementation.
+
+Building the extension can be disabled by setting the environment variable ``SKIP_CYTHON`` to ``1``.
+
 Usage
 -----
 

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -9,7 +9,7 @@ cdef class APIFrameHelper:
     cdef object _on_error
     cdef object _transport
     cdef public object _writer
-    cdef object _ready_future
+    cdef public object _ready_future
     cdef bytearray _buffer
     cdef cython.uint _buffer_len
     cdef cython.uint _pos

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -1,4 +1,8 @@
-cdef APIFrameHelper:
+
+import cython
+
+
+cdef class APIFrameHelper:
 
     cdef object _loop
     cdef object _on_pkt

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -17,5 +17,5 @@ cdef class APIFrameHelper:
     cdef str _log_name
     cdef object _debug_enabled
 
-    @cython.locals(original_pos=int)
+    @cython.locals(original_pos=cython.uint, new_pos=cython.uint)
     cdef _read_exactly(self, int length)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -15,4 +15,4 @@ cdef class APIFrameHelper:
     cdef int _pos
     cdef object _client_info
     cdef str _log_name
-    cdef bint _debug_enabled
+    cdef object _debug_enabled

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -1,0 +1,14 @@
+cdef APIFrameHelper:
+
+    cdef object _loop
+    cdef object _on_pkt
+    cdef object _on_error
+    cdef object _transport
+    cdef object _writer
+    cdef object _ready_future
+    cdef bytearray _buffer
+    cdef int _buffer_len
+    cdef int _pos
+    cdef object _client_info
+    cdef str _log_name
+    cdef bint _debug_enabled

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -11,8 +11,11 @@ cdef class APIFrameHelper:
     cdef object _writer
     cdef object _ready_future
     cdef bytearray _buffer
-    cdef int _buffer_len
-    cdef int _pos
+    cdef cython.uint _buffer_len
+    cdef cython.uint _pos
     cdef object _client_info
     cdef str _log_name
     cdef object _debug_enabled
+
+    @cython.locals(original_pos=int)
+    cdef _read_exactly(self, int length)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -8,7 +8,7 @@ cdef class APIFrameHelper:
     cdef object _on_pkt
     cdef object _on_error
     cdef object _transport
-    cdef object _writer
+    cdef public object _writer
     cdef object _ready_future
     cdef bytearray _buffer
     cdef cython.uint _buffer_len

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -20,6 +20,8 @@ SOCKET_ERRORS = (
 WRITE_EXCEPTIONS = (RuntimeError, ConnectionResetError, OSError)
 
 _int = int
+
+
 class APIFrameHelper:
     """Helper class to handle the API frame protocol."""
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -125,8 +125,8 @@ class APIFrameHelper:
             self._transport = None
             self._writer = None
 
-    def pause_writing(self):
+    def pause_writing(self) -> None:
         """Stub."""
 
-    def resume_writing(self):
+    def resume_writing(self) -> None:
         """Stub."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -111,11 +111,9 @@ class APIFrameHelper:
         self._handle_error(
             exc or SocketClosedAPIError(f"{self._log_name}: Connection lost")
         )
-        return super().connection_lost(exc)
 
     def eof_received(self) -> bool | None:
         self._handle_error(SocketClosedAPIError(f"{self._log_name}: EOF received"))
-        return super().eof_received()
 
     def close(self) -> None:
         """Close the connection."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -108,12 +108,15 @@ class APIFrameHelper:
         self._on_error(exc)
 
     def connection_lost(self, exc: Exception | None) -> None:
+        """Handle the connection being lost."""
         self._handle_error(
             exc or SocketClosedAPIError(f"{self._log_name}: Connection lost")
         )
 
     def eof_received(self) -> bool | None:
+        """Handle EOF received."""
         self._handle_error(SocketClosedAPIError(f"{self._log_name}: EOF received"))
+        return False
 
     def close(self) -> None:
         """Close the connection."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -19,7 +19,7 @@ SOCKET_ERRORS = (
 
 WRITE_EXCEPTIONS = (RuntimeError, ConnectionResetError, OSError)
 
-
+_int = int
 class APIFrameHelper:
     """Helper class to handle the API frame protocol."""
 
@@ -64,7 +64,7 @@ class APIFrameHelper:
         if not self._ready_future.done():
             self._ready_future.set_exception(exc)
 
-    def _read_exactly(self, length: int) -> bytearray | None:
+    def _read_exactly(self, length: _int) -> bytearray | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""
         original_pos = self._pos
         new_pos = original_pos + length

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -20,7 +20,7 @@ SOCKET_ERRORS = (
 WRITE_EXCEPTIONS = (RuntimeError, ConnectionResetError, OSError)
 
 
-class APIFrameHelper(asyncio.Protocol):
+class APIFrameHelper:
     """Helper class to handle the API frame protocol."""
 
     __slots__ = (
@@ -121,3 +121,9 @@ class APIFrameHelper(asyncio.Protocol):
             self._transport.close()
             self._transport = None
             self._writer = None
+
+    def pause_writing(self):
+        """Stub."""
+
+    def resume_writing(self):
+         """Stub."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -126,4 +126,4 @@ class APIFrameHelper:
         """Stub."""
 
     def resume_writing(self):
-         """Stub."""
+        """Stub."""

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -1,0 +1,16 @@
+from .base cimport BaseFrameHelper
+
+cdef APINoiseFrameHelper:
+
+    cdef object _loop
+    cdef object _on_pkt
+    cdef object _on_error
+    cdef object _transport
+    cdef object _writer
+    cdef object _ready_future
+    cdef bytearray _buffer
+    cdef int _buffer_len
+    cdef int _pos
+    cdef object _client_info
+    cdef str _log_name
+    cdef bint _debug_enabled

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -1,9 +1,9 @@
 import cython
 
 
-from .base cimport BaseFrameHelper
+from .base cimport APIFrameHelper
 
-cdef class APINoiseFrameHelper(BaseFrameHelper):
+cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef object _noise_psk
     cdef object _expected_name
@@ -15,6 +15,4 @@ cdef class APINoiseFrameHelper(BaseFrameHelper):
     cdef object _encrypt
     cdef bint _is_ready
     
-    cpdef write_packet(self, int type_, bytes data)
-
     cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -3,6 +3,8 @@ import cython
 
 from .base cimport APIFrameHelper
 
+cdef object TYPE_CHECKING
+
 cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef object _noise_psk
@@ -14,5 +16,11 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef object _decrypt
     cdef object _encrypt
     cdef bint _is_ready
-    
+
+    @cython.locals(
+        preamble=cython.uint, 
+        msg_size_high=cython.uint, 
+        msg_size_low=cython.uint,
+        end_of_frame_pos=cython.uint,
+    )    
     cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -18,6 +18,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef bint _is_ready
 
     @cython.locals(
+        header=bytearray,
         preamble=cython.uint, 
         msg_size_high=cython.uint, 
         msg_size_low=cython.uint,

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -1,7 +1,7 @@
 import cython
 
-
 from .base cimport APIFrameHelper
+
 
 cdef object TYPE_CHECKING
 

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -1,16 +1,20 @@
+import cython
+
+
 from .base cimport BaseFrameHelper
 
-cdef APINoiseFrameHelper:
+cdef class APINoiseFrameHelper(BaseFrameHelper):
 
-    cdef object _loop
-    cdef object _on_pkt
-    cdef object _on_error
-    cdef object _transport
-    cdef object _writer
-    cdef object _ready_future
-    cdef bytearray _buffer
-    cdef int _buffer_len
-    cdef int _pos
-    cdef object _client_info
-    cdef str _log_name
-    cdef bint _debug_enabled
+    cdef object _noise_psk
+    cdef object _expected_name
+    cdef object _state
+    cdef object _dispatch
+    cdef object _server_name
+    cdef object _proto
+    cdef object _decrypt
+    cdef object _encrypt
+    cdef bint _is_ready
+    
+    cpdef write_packet(self, int type_, bytes data)
+
+    cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -144,7 +144,9 @@ class APINoiseFrameHelper(APIFrameHelper):
             header = self._read_exactly(3)
             if header is None:
                 return
-            preamble, msg_size_high, msg_size_low = header
+            preamble = header[0]
+            msg_size_high = header[1]
+            msg_size_low = header[2]
             if preamble != 0x01:
                 self._handle_error_and_close(
                     ProtocolAPIError(

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -2,6 +2,18 @@ import cython
 
 from .base cimport APIFrameHelper
 
+cdef object TYPE_CHECKING
+
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
+    @cython.locals(
+        msg_type=bytes,
+        length=bytes,
+        init_bytes=bytearray, 
+        end_of_frame_pos=cython.uint,
+        length_int=cython.uint,
+        preamble=cython.uint, 
+        length_high=cython.uint, 
+        maybe_msg_type=cython.uint
+    )
     cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -4,6 +4,8 @@ from .base cimport APIFrameHelper
 
 
 cdef object TYPE_CHECKING
+cdef object WRITE_EXCEPTIONS
+cdef object bytes_to_varuint, varuint_to_bytes
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
@@ -11,6 +13,7 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
         msg_type=bytes,
         length=bytes,
         init_bytes=bytearray, 
+        add_length=bytearray,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,
         preamble=cython.uint, 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -1,0 +1,3 @@
+from .base cimport BaseFrameHelper
+
+cdef APINoiseFrameHelper(BaseFrameHelper):

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -1,7 +1,7 @@
-from .base cimport BaseFrameHelper
+import cython
 
-cdef class APIPlaintextFrameHelper(BaseFrameHelper):
+from .base cimport APIFrameHelper
 
-    cpdef write_packet(self, int type_, bytes data)
+cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
     cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -2,6 +2,7 @@ import cython
 
 from .base cimport APIFrameHelper
 
+
 cdef object TYPE_CHECKING
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -1,3 +1,7 @@
 from .base cimport BaseFrameHelper
 
-cdef APINoiseFrameHelper(BaseFrameHelper):
+cdef class APIPlaintextFrameHelper(BaseFrameHelper):
+
+    cpdef write_packet(self, int type_, bytes data)
+
+    cpdef data_received(self, bytes data)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -90,7 +90,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     if add_length is None:
                         return
                     length += add_length
-                length_int = bytes_to_varuint(length)
+                length_int = bytes_to_varuint(length) or 0
                 # Since the length is longer than 1 byte we do not have the
                 # message type yet.
                 msg_type = b""

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -50,8 +50,10 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if init_bytes is None:
                 return
             msg_type_int: int | None = None
-            length_int: int | None = None
-            preamble, length_high, maybe_msg_type = init_bytes
+            length_int = 0
+            preamble = init_bytes[0]
+            length_high = init_bytes[1]
+            maybe_msg_type = init_bytes[2]
             if preamble != 0x00:
                 if preamble == 0x01:
                     self._handle_error_and_close(
@@ -105,7 +107,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 msg_type_int = bytes_to_varuint(msg_type)
 
             if TYPE_CHECKING:
-                assert length_int is not None
                 assert msg_type_int is not None
 
             if length_int == 0:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -325,7 +325,7 @@ class APIConnection:
         assert self._socket is not None
 
         if self._params.noise_psk is None:
-            _, fh = await loop.create_connection( # type: ignore[type-var]
+            _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APIPlaintextFrameHelper(
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
@@ -337,7 +337,7 @@ class APIConnection:
         else:
             noise_psk = self._params.noise_psk
             assert noise_psk is not None
-            _, fh = await loop.create_connection( # type: ignore[type-var]
+            _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
                     noise_psk=noise_psk,
                     expected_name=self._params.expected_name,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -334,6 +334,7 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
+            assert self._params.noise_psk is not None
             _, fh = await loop.create_connection(
                 lambda: APINoiseFrameHelper(
                     noise_psk=self._params.noise_psk,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -322,9 +322,10 @@ class APIConnection:
         fh: APIPlaintextFrameHelper | APINoiseFrameHelper
         loop = self._loop
         process_packet = self._process_packet_factory()
+        assert self._socket is not None
 
         if self._params.noise_psk is None:
-            _, fh = await loop.create_connection(
+            _, fh = await loop.create_connection( # type: ignore[type-var]
                 lambda: APIPlaintextFrameHelper(
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
@@ -334,10 +335,11 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
-            assert self._params.noise_psk is not None
-            _, fh = await loop.create_connection(
+            noise_psk = self._params.noise_psk
+            assert noise_psk is not None
+            _, fh = await loop.create_connection( # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
-                    noise_psk=self._params.noise_psk,
+                    noise_psk=noise_psk,
                     expected_name=self._params.expected_name,
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ disable = [
   "duplicate-code",
   "too-many-lines",
 ]
+
+[build-system]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.2']
+

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -111,6 +111,7 @@ async def test_requires_encryption_propagates(conn: APIConnection):
     with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
 
+        conn._socket = MagicMock()
         await conn._connect_init_frame_helper()
         loop.call_soon(conn._frame_helper._ready_future.set_result, None)
         conn._connection_state = ConnectionState.CONNECTED

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -108,9 +108,7 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
 async def test_requires_encryption_propagates(conn: APIConnection):
     loop = asyncio.get_event_loop()
     protocol = _get_mock_protocol(conn)
-    with patch.object(loop, "create_connection") as create_connection, patch.object(
-        protocol, "perform_handshake"
-    ):
+    with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
 
         await conn._connect_init_frame_helper()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -112,6 +112,7 @@ async def test_requires_encryption_propagates(conn: APIConnection):
         create_connection.return_value = (MagicMock(), protocol)
 
         await conn._connect_init_frame_helper()
+        loop.call_soon(conn._frame_helper._ready_future.set_result, None)
         conn._connection_state = ConnectionState.CONNECTED
 
         with pytest.raises(RequiresEncryptionAPIError):


### PR DESCRIPTION
The frame helper is where most of the overhead is for processing incoming packets now that we are using the upb implementation of protobuf.

Since we process 1000s of bluetooth packets per minute, the overhead of python shipping around and decoding the bytes can be a bit high.

This adds an optional cython extension to target the hot areas of the code.  I only bothered with receiving data as I don't know if there is a use case for high volume sending (if there is we can optimize that in another pass).

If cython is not available, the build script will not cythonize and install the pure python version.