### PR TITLE
Run tests on multiple python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,50 +15,43 @@ concurrency:
 
 jobs:
   ci:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }} py ${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.extension }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - id: flake8
-            name: Lint with flake8
-          - id: pylint
-            name: Lint with pylint
-          - id: black
-            name: Check formatting with black
-          - id: isort
-            name: Check import order with isort
-          - id: mypy
-            name: Check typing with mypy
-          - id: pytest
-            name: Run tests with pytest
-          - id: protoc
-            name: Check protobuf files match
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"   
+        os:
+          - ubuntu-latest                    
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         id: python
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
 
       - name: Get pip cache dir
         id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: Restore PIP cache
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt', 'requirements_test.txt') }}
           restore-keys: |
             pip-${{ steps.python.outputs.python-version }}-
       - name: Set up Python environment
+        env:
+          SKIP_CYTHON: 1
         run: |
           pip3 install -r requirements.txt -r requirements_test.txt
           pip3 install -e .
-
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/flake8.json"
@@ -68,17 +61,22 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/pytest.json"
 
       - run: flake8 aioesphomeapi
-        if: ${{ matrix.id == 'flake8' }}
+        name: Lint with flake8
+        if: ${{ matrix.python-version == '3.11' }}
       - run: pylint aioesphomeapi
-        if: ${{ matrix.id == 'pylint' }}
+        name: Lint with pylint
+        if: ${{ matrix.python-version == '3.11' }}
       - run: black --check --diff --color aioesphomeapi tests
-        if: ${{ matrix.id == 'black' }}
+        name: Check formatting with black
+        if: ${{ matrix.python-version == '3.11' }}
       - run: isort --check --diff aioesphomeapi tests
-        if: ${{ matrix.id == 'isort' }}
+        name: Check import order with isort
+        if: ${{ matrix.python-version == '3.11' }}
       - run: mypy aioesphomeapi
-        if: ${{ matrix.id == 'mypy' }}
+        name: Check typing with mypy
+        if: ${{ matrix.python-version == '3.11' }}
       - run: pytest -vv --tb=native tests
-        if: ${{ matrix.id == 'pytest' }}
+        name: Run tests with pytest
       - run: |
           docker run \
             -v "$PWD":/aioesphomeapi \
@@ -89,4 +87,5 @@ jobs:
             echo 'docker run -v "$PWD":/aioesphomeapi ghcr.io/esphome/aioesphomeapi-proto-builder:latest'
             exit 1
           fi
-        if: ${{ matrix.id == 'protoc' }}
+        name: Check protobuf files match
+        if: ${{ matrix.python-version == '3.11' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
           restore-keys: |
             pip-${{ steps.python.outputs.python-version }}-
       - name: Set up Python environment
-        env:
-          SKIP_CYTHON: 1
         run: |
           pip3 install -r requirements.txt -r requirements_test.txt
           pip3 install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    name: ${{ matrix.name }} py ${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.extension }})
+    name: ${{ matrix.name }} py ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -325,7 +325,7 @@ class APIConnection:
         assert self._socket is not None
 
         if self._params.noise_psk is None:
-            _, fh = await loop.create_connection(  # type: ignore[type-var]
+            _, fh = await loop.create_connection(
                 lambda: APIPlaintextFrameHelper(
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
@@ -337,7 +337,7 @@ class APIConnection:
         else:
             noise_psk = self._params.noise_psk
             assert noise_psk is not None
-            _, fh = await loop.create_connection(  # type: ignore[type-var]
+            _, fh = await loop.create_connection(
                 lambda: APINoiseFrameHelper(
                     noise_psk=noise_psk,
                     expected_name=self._params.expected_name,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -322,9 +322,10 @@ class APIConnection:
         fh: APIPlaintextFrameHelper | APINoiseFrameHelper
         loop = self._loop
         process_packet = self._process_packet_factory()
+        assert self._socket is not None
 
         if self._params.noise_psk is None:
-            _, fh = await loop.create_connection(
+            _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APIPlaintextFrameHelper(
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,
@@ -334,9 +335,11 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
-            _, fh = await loop.create_connection(
+            noise_psk = self._params.noise_psk
+            assert noise_psk is not None
+            _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
-                    noise_psk=self._params.noise_psk,
+                    noise_psk=noise_psk,
                     expected_name=self._params.expected_name,
                     on_pkt=process_packet,
                     on_error=self._report_fatal_error,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -108,12 +108,12 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
 async def test_requires_encryption_propagates(conn: APIConnection):
     loop = asyncio.get_event_loop()
     protocol = _get_mock_protocol(conn)
-    with patch.object(loop, "create_connection") as create_connection, patch.object(
-        protocol, "perform_handshake"
-    ):
+    with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
 
+        conn._socket = MagicMock()
         await conn._connect_init_frame_helper()
+        loop.call_soon(conn._frame_helper._ready_future.set_result, None)
         conn._connection_state = ConnectionState.CONNECTED
 
         with pytest.raises(RequiresEncryptionAPIError):


### PR DESCRIPTION
pylint showed us some bugs hiding out in https://github.com/esphome/aioesphomeapi/pull/565 because we weren't running tests on newer python

All the linters will only run on py3.11 since py3.12 is not ready yet