### PR TITLE
Remove async_timeout requirement on python 3.11+

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,7 +46,7 @@ from .core import (
 from .model import APIVersion
 
 if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout
+    from async_timeout import timeout as asyncio_timeout  # type: ignore[import-not-found]
 else:
     from asyncio import timeout as asyncio_timeout
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,7 +46,9 @@ from .core import (
 from .model import APIVersion
 
 if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # type: ignore[import-not-found]
+    from async_timeout import (
+        timeout as asyncio_timeout,  # type: ignore[import-not-found]
+    )
 else:
     from asyncio import timeout as asyncio_timeout
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,8 +46,8 @@ from .core import (
 from .model import APIVersion
 
 if sys.version_info[:2] < (3, 11):
-    from async_timeout import (
-        timeout as asyncio_timeout,  # type: ignore[import-not-found]
+    from async_timeout import (  # type: ignore[import-not-found]
+        timeout as asyncio_timeout,
     )
 else:
     from asyncio import timeout as asyncio_timeout

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-# mypy: disable-error-code="import-not-found"
-
 import asyncio
 import contextvars
 import enum
@@ -46,6 +44,12 @@ from .core import (
     TimeoutAPIError,
 )
 from .model import APIVersion
+
+# mypy: disable-error-code="import-not-found"
+
+
+
+
 
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,9 +46,8 @@ from .core import (
 from .model import APIVersion
 
 if sys.version_info[:2] < (3, 11):
-    from async_timeout import (  # type: ignore[import-not-found]
-        timeout as asyncio_timeout,
-    )
+    # type: ignore[import-not-found]
+    from async_timeout import timeout as asyncio_timeout
 else:
     from asyncio import timeout as asyncio_timeout
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -5,6 +5,7 @@ import contextvars
 import enum
 import logging
 import socket
+import sys
 import time
 from collections.abc import Coroutine, Iterable
 from dataclasses import astuple, dataclass

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,11 +46,6 @@ from .core import (
 from .model import APIVersion
 
 # mypy: disable-error-code="import-not-found"
-
-
-
-
-
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout
 else:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# mypy: disable-error-code="import-not-found"
+
 import asyncio
 import contextvars
 import enum
@@ -46,7 +48,6 @@ from .core import (
 from .model import APIVersion
 
 if sys.version_info[:2] < (3, 11):
-    # type: ignore[import-not-found]
     from async_timeout import timeout as asyncio_timeout
 else:
     from asyncio import timeout as asyncio_timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
 chacha20poly1305-reuseable>=0.2.5
 noiseprotocol>=0.3.1,<1.0
-async-timeout>=4.0
+async-timeout>=4.0;python_version<'3.11'


### PR DESCRIPTION
`asyncio.timeout` is preferred over `async_timeout` now that its part of stdlib