### PR TITLE
Disable all pypy wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp36-* pp37-* pp38-*
+          CIBW_SKIP: cp36-* cp37-* cp38-* pp*
           CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
           CIBW_BUILD_VERBOSITY: 3
           REQUIRE_CYTHON: 1


### PR DESCRIPTION
We do not use pypy for any esphome images and having them doubles the build time.