### PR TITLE
Reduce memory copy when buffering is not required

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -10,7 +10,7 @@ cdef class APIFrameHelper:
     cdef object _transport
     cdef public object _writer
     cdef public object _ready_future
-    cdef bytearray _buffer
+    cdef bytes _buffer
     cdef cython.uint _buffer_len
     cdef cython.uint _pos
     cdef object _client_info
@@ -18,4 +18,9 @@ cdef class APIFrameHelper:
     cdef object _debug_enabled
 
     @cython.locals(original_pos=cython.uint, new_pos=cython.uint)
-    cdef _read_exactly(self, int length)
+    cdef bytes _read_exactly(self, int length)
+
+    cdef _add_to_buffer(self, bytes data)
+
+    @cython.locals(end_of_frame_pos=cython.uint)
+    cdef _remove_from_buffer(self)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -1,6 +1,7 @@
 
 import cython
 
+
 cdef bint TYPE_CHECKING
 
 cdef class APIFrameHelper:

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -1,6 +1,7 @@
 
 import cython
 
+cdef bint TYPE_CHECKING
 
 cdef class APIFrameHelper:
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -72,12 +72,12 @@ class APIFrameHelper:
             self._buffer = data
         else:
             self._buffer += data
-        self._buffer_len += len(data)        
+        self._buffer_len += len(data)
 
     def _remove_from_buffer(self) -> None:
         """Remove data from the buffer."""
         end_of_frame_pos = self._pos
-        self._buffer_len -= end_of_frame_pos        
+        self._buffer_len -= end_of_frame_pos
         if self._buffer_len == 0:
             self._buffer = None
         else:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, cast
+from typing import Callable, cast, TYPE_CHECKING
+
 
 from ..core import HandshakeAPIError, SocketClosedAPIError
 
@@ -71,6 +72,8 @@ class APIFrameHelper:
         if self._buffer_len == 0:
             self._buffer = data
         else:
+            if TYPE_CHECKING:
+                assert self._buffer is not None, "Buffer should be set"
             self._buffer += data
         self._buffer_len += len(data)
 
@@ -81,6 +84,8 @@ class APIFrameHelper:
         if self._buffer_len == 0:
             self._buffer = None
         else:
+            if TYPE_CHECKING:
+                assert self._buffer is not None, "Buffer should be set"
             self._buffer = self._buffer[end_of_frame_pos:]
 
     def _read_exactly(self, length: _int) -> bytes | None:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -94,6 +94,8 @@ class APIFrameHelper:
         if self._buffer_len < new_pos:
             return None
         self._pos = new_pos
+        if TYPE_CHECKING:
+            assert self._buffer is not None, "Buffer should be set"
         return self._buffer[original_pos:new_pos]
 
     async def perform_handshake(self, timeout: float) -> None:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -4,8 +4,7 @@ import asyncio
 import logging
 from abc import abstractmethod
 from functools import partial
-from typing import Callable, cast, TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Callable, cast
 
 from ..core import HandshakeAPIError, SocketClosedAPIError
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -82,10 +82,10 @@ class APIFrameHelper:
         self._buffer_len -= end_of_frame_pos
         if self._buffer_len == 0:
             self._buffer = None
-        else:
-            if TYPE_CHECKING:
-                assert self._buffer is not None, "Buffer should be set"
-            self._buffer = self._buffer[end_of_frame_pos:]
+            return
+        if TYPE_CHECKING:
+            assert self._buffer is not None, "Buffer should be set"
+        self._buffer = self._buffer[end_of_frame_pos:]
 
     def _read_exactly(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -3,7 +3,7 @@ import cython
 from .base cimport APIFrameHelper
 
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 
 cdef class APINoiseFrameHelper(APIFrameHelper):
 

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -18,10 +18,15 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef bint _is_ready
 
     @cython.locals(
-        header=bytearray,
+        header=bytes,
         preamble=cython.uint, 
         msg_size_high=cython.uint, 
         msg_size_low=cython.uint,
-        end_of_frame_pos=cython.uint,
     )    
     cpdef data_received(self, bytes data)
+
+    @cython.locals(
+        type_high=cython.uint,
+        type_low=cython.uint
+    )
+    cpdef _handle_frame(self, bytes data)

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -349,9 +349,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         type_low = msg[1]
         self._on_pkt((type_high << 8) | type_low, msg[4:])
 
-    def _handle_closed(  # pylint: disable=unused-argument
-        self, frame: bytes
-    ) -> None:
+    def _handle_closed(self, frame: bytes) -> None:  # pylint: disable=unused-argument
         """Handle a closed frame."""
         self._handle_error(ProtocolAPIError(f"{self._log_name}: Connection closed"))
 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -12,8 +12,8 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
     @cython.locals(
         msg_type=bytes,
         length=bytes,
-        init_bytes=bytearray, 
-        add_length=bytearray,
+        init_bytes=bytes, 
+        add_length=bytes,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,
         preamble=cython.uint, 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -3,7 +3,7 @@ import cython
 from .base cimport APIFrameHelper
 
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 cdef object WRITE_EXCEPTIONS
 cdef object bytes_to_varuint, varuint_to_bytes
 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -12,7 +12,7 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
     @cython.locals(
         msg_type=bytes,
         length=bytes,
-        init_bytes=bytes, 
+        init_bytes=bytes,
         add_length=bytes,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -37,10 +37,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             raise SocketAPIError(
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
-
+        
     def data_received(self, data: bytes) -> None:  # pylint: disable=too-many-branches
-        self._buffer += data
-        self._buffer_len += len(data)
+        self._add_to_buffer(data)
         while self._buffer:
             # Read preamble, which should always 0x00
             # Also try to get the length and msg type
@@ -80,10 +79,10 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                     msg_type_int = maybe_msg_type
                 else:
                     # Message type is longer than 1 byte
-                    msg_type = bytes(init_bytes[2:3])
+                    msg_type = init_bytes[2:3]
             else:
                 # Length is longer than 1 byte
-                length = bytes(init_bytes[1:3])
+                length = init_bytes[1:3]
                 # If the message is long, we need to read the rest of the length
                 while length[-1] & 0x80 == 0x80:
                     add_length = self._read_exactly(1)
@@ -112,18 +111,16 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if length_int == 0:
                 packet_data = b""
             else:
-                packet_data_bytearray = self._read_exactly(length_int)
+                maybe_packet_data = self._read_exactly(length_int)
                 # The packet data is not yet available, wait for more data
                 # to arrive before continuing, since callback_packet has not
                 # been called yet the buffer will not be cleared and the next
                 # call to data_received will continue processing the packet
                 # at the start of the frame.
-                if packet_data_bytearray is None:
+                if maybe_packet_data is None:
                     return
-                packet_data = bytes(packet_data_bytearray)
-
-            end_of_frame_pos = self._pos
-            del self._buffer[:end_of_frame_pos]
-            self._buffer_len -= end_of_frame_pos
+                packet_data = maybe_packet_data
+                
+            self._remove_from_buffer()
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -37,7 +37,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             raise SocketAPIError(
                 f"{self._log_name}: Error while writing data: {err}"
             ) from err
-        
+
     def data_received(self, data: bytes) -> None:  # pylint: disable=too-many-branches
         self._add_to_buffer(data)
         while self._buffer:
@@ -120,7 +120,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 if maybe_packet_data is None:
                     return
                 packet_data = maybe_packet_data
-                
+
             self._remove_from_buffer()
             self._on_pkt(msg_type_int, packet_data)
             # If we have more data, continue processing


### PR DESCRIPTION
This moves all the frame helper buffer management complexity into the base class
so its not reimplemented in plain_text and noise

Most of the time we do not have to buffer so we can hold
the bytes object and read the packet out of it instead
of having to copy it.

This is roughly a ~22% speed up processing the incoming bytes
in the frame helper.

This is another attempt at https://github.com/esphome/aioesphomeapi/pull/544#issuecomment-1712100612