### PR TITLE
Split connection process to enable faster reconnects

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -354,14 +354,8 @@ class APIClient:
             )
 
     async def device_info(self) -> DeviceInfo:
+        self._check_authenticated()
         connection = self._connection
-        if not connection:
-            raise APIConnectionError(f"Not connected to {self._log_name}!")
-        if not connection or not connection.is_connected:
-            raise APIConnectionError(
-                f"Connection not ready yet for {self._log_name}; "
-                f"current state is {connection.connection_state}!"
-            )
         resp = await connection.send_message_await_response(
             DeviceInfoRequest(), DeviceInfoResponse
         )

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -103,6 +103,7 @@ from .api_pb2 import (  # type: ignore
 from .connection import APIConnection, ConnectionParams
 from .core import (
     APIConnectionError,
+    UnhandledAPIConnectionError,
     BluetoothGATTAPIError,
     TimeoutAPIError,
     to_human_readable_address,
@@ -340,7 +341,7 @@ class APIClient:
             raise
         except Exception as e:
             self._connection = None
-            raise APIConnectionError(
+            raise UnhandledAPIConnectionError(
                 f"Unexpected error while connecting to {self._log_name}: {e}"
             ) from e
 
@@ -357,7 +358,7 @@ class APIClient:
             raise
         except Exception as e:
             self._connection = None
-            raise APIConnectionError(
+            raise UnhandledAPIConnectionError(
                 f"Unexpected error while connecting to {self._log_name}: {e}"
             ) from e
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -313,7 +313,7 @@ class APIClient:
     ) -> None:
         """Connect to the device."""
         await self.start_connection(on_stop)
-        await self.finish_connection(login=login)
+        await self.finish_connection(login)
 
     async def start_connection(
         self,

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -319,6 +319,7 @@ class APIClient:
         self,
         on_stop: Callable[[bool], Awaitable[None]] | None = None,
     ) -> None:
+        """Start connecting to the device."""
         if self._connection is not None:
             raise APIConnectionError(f"Already connected to {self._log_name}!")
 
@@ -347,6 +348,7 @@ class APIClient:
         self,
         login: bool = False,
     ) -> None:
+        """Finish connecting to the device."""
         assert self._connection is not None
         try:
             await self._connection.finish_connection(login=login)

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -382,6 +382,7 @@ class APIClient:
     async def device_info(self) -> DeviceInfo:
         self._check_authenticated()
         connection = self._connection
+        assert connection is not None
         resp = await connection.send_message_await_response(
             DeviceInfoRequest(), DeviceInfoResponse
         )

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -352,8 +352,6 @@ class APIClient:
                 f"Authenticated connection not ready yet for {self._log_name}; "
                 f"current state is {connection.connection_state}!"
             )
-        if not connection.is_authenticated:
-            raise APIConnectionError(f"Not authenticated for {self._log_name}!")
 
     async def device_info(self) -> DeviceInfo:
         connection = self._connection

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -103,9 +103,9 @@ from .api_pb2 import (  # type: ignore
 from .connection import APIConnection, ConnectionParams
 from .core import (
     APIConnectionError,
-    UnhandledAPIConnectionError,
     BluetoothGATTAPIError,
     TimeoutAPIError,
+    UnhandledAPIConnectionError,
     to_human_readable_address,
 )
 from .host_resolver import ZeroconfInstanceType

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -312,10 +312,10 @@ class APIClient:
         login: bool = False,
     ) -> None:
         """Connect to the device."""
-        await self.start_connect(on_stop)
-        await self.finish_connect(login=login)
+        await self.start_connection(on_stop)
+        await self.finish_connection(login=login)
 
-    async def start_connect(
+    async def start_connection(
         self,
         on_stop: Callable[[bool], Awaitable[None]] | None = None,
     ) -> None:
@@ -344,7 +344,7 @@ class APIClient:
                 f"Unexpected error while connecting to {self._log_name}: {e}"
             ) from e
 
-    async def finish_connect(
+    async def finish_connection(
         self,
         login: bool = False,
     ) -> None:

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -298,7 +298,7 @@ class APIClient:
 
     @property
     def _log_name(self) -> str:
-        if self._cached_name is not None:
+        if self._cached_name is not None and not self.address.endswith(".local"):
             return f"{self._cached_name} @ {self.address}"
         return self.address
 

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -42,6 +42,7 @@ cdef class APIConnection:
     cdef object _loop
     cdef bint _send_pending_ping
     cdef public bint is_connected
+    cdef bint _handshake_complete
     cdef object _debug_enabled
 
     cpdef send_message(self, object msg)

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -27,7 +27,7 @@ cdef class APIConnection:
     cdef public object _socket
     cdef public object _frame_helper
     cdef public object api_version
-    cdef public object _connection_state
+    cdef public object connection_state
     cdef dict _message_handlers
     cdef public str log_name
     cdef set _read_exception_futures

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -28,7 +28,6 @@ cdef class APIConnection:
     cdef public object _frame_helper
     cdef public object api_version
     cdef public object _connection_state
-    cdef object _connect_complete
     cdef dict _message_handlers
     cdef public str log_name
     cdef set _read_exception_futures
@@ -36,14 +35,13 @@ cdef class APIConnection:
     cdef object _pong_timer
     cdef float _keep_alive_interval
     cdef float _keep_alive_timeout
-    cdef object _connect_task
+    cdef object _start_connect_task
+    cdef object _finish_connect_task
     cdef object _fatal_exception
     cdef bint _expected_disconnect
     cdef object _loop
     cdef bint _send_pending_ping
     cdef public bint is_connected
-    cdef public bint is_authenticated
-    cdef bint _is_socket_open
     cdef object _debug_enabled
 
     cpdef send_message(self, object msg)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -505,14 +505,14 @@ class APIConnection:
             # and raise the CancelledError
             self._cleanup()
             if isinstance(ex, asyncio.CancelledError):
-                raise
-            if self._fatal_exception:
-                raise self._fatal_exception
+                raise self._fatal_exception or APIConnectionError(
+                    "Connection cancelled"
+                )
             if not start_connect_task.cancelled() and (
                 task_exc := start_connect_task.exception()
             ):
                 raise task_exc
-            raise APIConnectionError("Connection cancelled")
+            raise
         finally:
             self._start_connect_task = None
         self._set_connection_state(ConnectionState.SOCKET_OPENED)
@@ -552,14 +552,14 @@ class APIConnection:
             # and raise the CancelledError
             self._cleanup()
             if isinstance(ex, asyncio.CancelledError):
-                raise
-            if self._fatal_exception:
-                raise self._fatal_exception
+                raise self._fatal_exception or APIConnectionError(
+                    "Connection cancelled"
+                )
             if not finish_connect_task.cancelled() and (
                 task_exc := finish_connect_task.exception()
             ):
                 raise task_exc
-            raise APIConnectionError("Connection cancelled")
+            raise
         finally:
             self._finish_connect_task = None
         self._set_connection_state(ConnectionState.CONNECTED)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -125,9 +125,6 @@ class ConnectionState(enum.Enum):
     CLOSED = 3
 
 
-OPEN_STATES = {ConnectionState.HANDSHAKE_FINISHED, ConnectionState.CONNECTED}
-
-
 class APIConnection:
     """This class represents _one_ connection to a remote native API device.
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -141,7 +141,7 @@ class APIConnection:
         "_socket",
         "_frame_helper",
         "api_version",
-        "_connection_state",
+        "connection_state",
         "_message_handlers",
         "log_name",
         "_read_exception_futures",

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -209,6 +209,8 @@ class APIConnection:
 
         Safe to call multiple times.
         """
+        if self.connection_state == ConnectionState.CLOSED:
+            return
         was_connected = self.is_connected
         self._set_connection_state(ConnectionState.CLOSED)
         _LOGGER.debug("Cleaning up connection to %s", self.log_name)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -174,7 +174,7 @@ class APIConnection:
         ) = None
         self.api_version: APIVersion | None = None
 
-        self._connection_state = ConnectionState.INITIALIZED
+        self.connection_state = ConnectionState.INITIALIZED
 
         # Message handlers currently subscribed to incoming messages
         self._message_handlers: dict[Any, set[Callable[[message.Message], None]]] = {}
@@ -198,11 +198,6 @@ class APIConnection:
         self.is_connected = False
         self._handshake_complete = False
         self._debug_enabled = partial(_LOGGER.isEnabledFor, logging.DEBUG)
-
-    @property
-    def connection_state(self) -> ConnectionState:
-        """Return the current connection state."""
-        return self._connection_state
 
     def set_log_name(self, name: str) -> None:
         """Set the friendly log name for this connection."""
@@ -484,7 +479,7 @@ class APIConnection:
         This part of the process establishes the socket connection but
         does not initialize the frame helper or send the hello message.
         """
-        if self._connection_state != ConnectionState.INITIALIZED:
+        if self.connection_state != ConnectionState.INITIALIZED:
             raise ValueError(
                 "Connection can only be used once, connection is not in init state"
             )
@@ -525,7 +520,7 @@ class APIConnection:
         This part of the process initializes the frame helper and sends the hello message
         than starts the keep alive process.
         """
-        if self._connection_state != ConnectionState.SOCKET_OPENED:
+        if self.connection_state != ConnectionState.SOCKET_OPENED:
             raise ValueError(
                 "Connection must be in SOCKET_OPENED state to finish connection"
             )
@@ -553,7 +548,7 @@ class APIConnection:
 
     def _set_connection_state(self, state: ConnectionState) -> None:
         """Set the connection state and log the change."""
-        self._connection_state = state
+        self.connection_state = state
         self.is_connected = state == ConnectionState.CONNECTED
         self._handshake_complete = state == ConnectionState.HANDSHAKE_COMPLETE
 
@@ -586,7 +581,7 @@ class APIConnection:
                 _LOGGER.debug("%s: Connection isn't established yet", self.log_name)
                 return
             raise ConnectionNotEstablishedAPIError(
-                f"Connection isn't established yet ({self._connection_state})"
+                f"Connection isn't established yet ({self.connection_state})"
             )
 
         msg_type = type(msg)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -156,7 +156,8 @@ class APIConnection:
         "_loop",
         "_send_pending_ping",
         "is_connected",
-        "_handshake_complete" "_debug_enabled",
+        "_handshake_complete",
+        "_debug_enabled",
     )
 
     def __init__(

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -478,18 +478,6 @@ class APIConnection:
         addr = await self._connect_resolve_host()
         await self._connect_socket_connect(addr)
 
-    async def connect(self, *, login: bool) -> None:
-        """Connect to the remote.
-
-        This function is for backwards compatibility.
-
-        The current recommended way to connect is to use start_connection
-        and finish_connection since start_connection can be safely
-        cancelled without putting too much pressure on the device.
-        """
-        await self.start_connection()
-        await self.finish_connection(login=login)
-
     async def start_connection(self) -> None:
         """Start the connection process.
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -118,7 +118,7 @@ class ConnectionParams:
 class ConnectionState(enum.Enum):
     # The connection is initialized, but connect() wasn't called yet
     INITIALIZED = 0
-    # The socket has been opened, but the connection hasn't been established yet
+    # The socket has been opened, but the handshake and login haven't been completed
     SOCKET_OPENED = 1
     # The handshake has been completed, messages can be exchanged
     HANDSHAKE_COMPLETE = 2

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -508,8 +508,10 @@ class APIConnection:
                 raise
             if self._fatal_exception:
                 raise self._fatal_exception
-            if not start_connect_task.cancelled() and start_connect_task.exception():
-                raise start_connect_task.exception()
+            if not start_connect_task.cancelled() and (
+                task_exc := start_connect_task.exception()
+            ):
+                raise task_exc
             raise APIConnectionError("Connection cancelled")
         finally:
             self._start_connect_task = None
@@ -553,8 +555,10 @@ class APIConnection:
                 raise
             if self._fatal_exception:
                 raise self._fatal_exception
-            if not finish_connect_task.cancelled() and finish_connect_task.exception():
-                raise finish_connect_task.exception()
+            if not finish_connect_task.cancelled() and (
+                task_exc := finish_connect_task.exception()
+            ):
+                raise task_exc
             raise APIConnectionError("Connection cancelled")
         finally:
             self._finish_connect_task = None

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -356,7 +356,6 @@ class APIConnection:
             )
 
         self._frame_helper = fh
-        self._set_connection_state(ConnectionState.HANDSHAKE_FINISHED)
         try:
             await fh.perform_handshake(HANDSHAKE_TIMEOUT)
         except asyncio.TimeoutError as err:

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -217,6 +217,10 @@ class ReadFailedAPIError(APIConnectionError):
     pass
 
 
+class UnhandledAPIConnectionError(APIConnectionError):
+    pass
+
+
 def to_human_readable_address(address: int) -> str:
     """Convert a MAC address to a human readable format."""
     return ":".join(TWO_CHAR.findall(f"{address:012X}"))

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -184,6 +184,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 return
             self._connect_task.cancel("Scheduling new connect attempt")
             self._connect_task = None
+            self._connection_state = ConnectionState.DISCONNECTED
 
         self._connect_task = asyncio.create_task(
             self._connect_once_or_reschedule(),
@@ -299,7 +300,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         # bail if either the already stopped or we haven't received device info yet
         if (
             self._connection_state
-            in {ConnectionState.READY, ConnectionState.HANDSHAKING}
+            not in {ConnectionState.DISCONNECTED, ConnectionState.CONNECTING}
             or self._is_stopped
             or self._filter_alias is None
         ):

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -159,6 +159,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._tries = 0
         self._connection_state = ConnectionState.READY
         await self._on_connect_cb()
+        self._stop_zc_listen()
         return True
 
     def _schedule_connect(self, delay: float) -> None:
@@ -214,11 +215,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 or self._is_stopped
             ):
                 return
-            if tries == 0:
-                # If this is the first try, stop listening for mDNS records
-                self._stop_zc_listen()
             if await self._try_connect():
-                self._stop_zc_listen()
                 return
             wait_time = int(round(min(1.8**tries, 60.0)))
             if tries == 1:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -146,7 +146,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         _LOGGER.info("Successfully connected to %s", self._log_name)
         self._connection_state = ReconnectLogicState.HANDSHAKING
         try:
-            self._cli.finish_connection(login=True)
+            await self._cli.finish_connection(login=True)
         except Exception as err:  # pylint: disable=broad-except
             self._connection_state = ReconnectLogicState.DISCONNECTED
             if self._on_connect_error_cb is not None:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -230,7 +230,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         _LOGGER.debug("Trying to connect to %s", self._log_name)
         async with self._connected_lock:
             _LOGGER.debug("Connected lock acquired for %s", self._log_name)
-            tries = min(self._tries, 10)  # prevent OverflowError
             if (
                 self._connection_state != ReconnectLogicState.DISCONNECTED
                 or self._is_stopped
@@ -238,6 +237,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 return
             if await self._try_connect():
                 return
+            tries = min(self._tries, 10)  # prevent OverflowError           
             wait_time = int(round(min(1.8**tries, 60.0)))
             if tries == 1:
                 _LOGGER.info(

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -160,7 +160,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 self._tries += 1
             return False
         self._tries = 0
-        _LOGGER.debug("Successfully handshake with to %s", self._log_name)
+        _LOGGER.info("Successful handshake with %s", self._log_name)
         self._connection_state = ReconnectLogicState.READY
         await self._on_connect_cb()
         self._stop_zc_listen()

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -10,11 +10,11 @@ import zeroconf
 
 from .client import APIClient
 from .core import (
-    UnhandledAPIConnectionError,
     APIConnectionError,
     InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
     RequiresEncryptionAPIError,
+    UnhandledAPIConnectionError,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable
-from typing import Callable
 from enum import Enum
+from typing import Callable
+
 import zeroconf
 
 from .client import APIClient

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -135,7 +135,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         assert self._connected_lock.locked(), "connected_lock must be locked"
         self._connection_state = ReconnectLogicState.CONNECTING
         try:
-            await self._cli.start_connection(on_stop=self._on_disconnect, login=True)
+            await self._cli.start_connection(on_stop=self._on_disconnect)
         except Exception as err:  # pylint: disable=broad-except
             self._connection_state = ReconnectLogicState.DISCONNECTED
             if self._on_connect_error_cb is not None:
@@ -146,7 +146,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         _LOGGER.info("Successfully connected to %s", self._log_name)
         self._connection_state = ReconnectLogicState.HANDSHAKING
         try:
-            self._cli.finish_connection()
+            self._cli.finish_connection(login=True)
         except Exception as err:  # pylint: disable=broad-except
             self._connection_state = ReconnectLogicState.DISCONNECTED
             if self._on_connect_error_cb is not None:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -69,7 +69,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self.name: str | None
         if client.address.endswith(".local"):
             self.name = client.address[:-6]
-            self._log_name = client.address
+            self._log_name = self.name
         elif name:
             self.name = name
             self._log_name = f"{self.name} @ {self._cli.address}"

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -237,7 +237,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 return
             if await self._try_connect():
                 return
-            tries = min(self._tries, 10)  # prevent OverflowError           
+            tries = min(self._tries, 10)  # prevent OverflowError
             wait_time = int(round(min(1.8**tries, 60.0)))
             if tries == 1:
                 _LOGGER.info(

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -157,6 +157,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 self._tries += 1
             return False
         self._tries = 0
+        _LOGGER.debug("Successfully handshake with to %s", self._log_name)
         self._connection_state = ConnectionState.READY
         await self._on_connect_cb()
         self._stop_zc_listen()

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -31,6 +31,12 @@ class ReconnectLogicState(Enum):
     DISCONNECTED = 3
 
 
+NOT_YET_CONNECTED_STATES = {
+    ReconnectLogicState.DISCONNECTED,
+    ReconnectLogicState.CONNECTING,
+}
+
+
 AUTH_EXCEPTIONS = (
     RequiresEncryptionAPIError,
     InvalidEncryptionKeyAPIError,
@@ -320,8 +326,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         # Check if already connected, no lock needed for this access and
         # bail if either the already stopped or we haven't received device info yet
         if (
-            self._connection_state
-            not in {ReconnectLogicState.DISCONNECTED, ReconnectLogicState.CONNECTING}
+            self._connection_state not in NOT_YET_CONNECTED_STATES
             or self._is_stopped
             or self._filter_alias is None
         ):

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -66,6 +66,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         """
         self.loop = asyncio.get_event_loop()
         self._cli = client
+        if name is None and client.address.endswith(".local"):
+            name = client.address[:-6]
         self.name = name
         self._on_connect_cb = on_connect
         self._on_disconnect_cb = on_disconnect

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable
 from typing import Callable
-
+from enum import Enum
 import zeroconf
 
 from .client import APIClient
@@ -20,6 +20,20 @@ _LOGGER = logging.getLogger(__name__)
 EXPECTED_DISCONNECT_COOLDOWN = 5.0
 MAXIMUM_BACKOFF_TRIES = 100
 TYPE_PTR = 12
+
+
+class ConnectionState(Enum):
+    CONNECTING = 0
+    HANDSHAKING = 1
+    READY = 2
+    DISCONNECTED = 3
+
+
+AUTH_EXCEPTIONS = (
+    RequiresEncryptionAPIError,
+    InvalidEncryptionKeyAPIError,
+    InvalidAuthAPIError,
+)
 
 
 class ReconnectLogic(zeroconf.RecordUpdateListener):
@@ -57,7 +71,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._zc = zeroconf_instance
         self._filter_alias: str | None = None
         # Flag to check if the device is connected
-        self._connected = False
+        self._connection_state = ConnectionState.DISCONNECTED
         self._connected_lock = asyncio.Lock()
         self._is_stopped = True
         self._zc_listening = False
@@ -93,7 +107,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         await self._on_disconnect_cb(expected_disconnect)
 
         async with self._connected_lock:
-            self._connected = False
+            self._connection_state = ConnectionState.DISCONNECTED
 
         wait = EXPECTED_DISCONNECT_COOLDOWN if expected_disconnect else 0
         # If we expected the disconnect we need
@@ -102,41 +116,48 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         # before its about to reboot in the event we are too fast.
         self._schedule_connect(wait)
 
+    def _async_log_connection_error(self, err: Exception) -> None:
+        """Log connection errors."""
+        level = logging.WARNING if self._tries == 0 else logging.DEBUG
+        _LOGGER.log(
+            level,
+            "Can't connect to ESPHome API for %s: %s (%s)",
+            self._log_name,
+            err,
+            type(err).__name__,
+            # Print stacktrace if unhandled (not APIConnectionError)
+            exc_info=not isinstance(err, APIConnectionError),
+        )
+
     async def _try_connect(self) -> bool:
         """Try connecting to the API client."""
         assert self._connected_lock.locked(), "connected_lock must be locked"
+        self._connection_state = ConnectionState.CONNECTING
         try:
-            await self._cli.connect(on_stop=self._on_disconnect, login=True)
+            await self._cli.start_connection(on_stop=self._on_disconnect, login=True)
         except Exception as err:  # pylint: disable=broad-except
             if self._on_connect_error_cb is not None:
                 await self._on_connect_error_cb(err)
-            level = logging.WARNING if self._tries == 0 else logging.DEBUG
-            _LOGGER.log(
-                level,
-                "Can't connect to ESPHome API for %s: %s (%s)",
-                self._log_name,
-                err,
-                type(err).__name__,
-                # Print stacktrace if unhandled (not APIConnectionError)
-                exc_info=not isinstance(err, APIConnectionError),
-            )
-            if isinstance(
-                err,
-                (
-                    RequiresEncryptionAPIError,
-                    InvalidEncryptionKeyAPIError,
-                    InvalidAuthAPIError,
-                ),
-            ):
+            self._async_log_connection_error(err)
+            self._tries += 1
+            return False
+        _LOGGER.info("Successfully connected to %s", self._log_name)
+        self._connection_state = ConnectionState.HANDSHAKING
+        try:
+            self._cli.finish_connection()
+        except Exception as err:  # pylint: disable=broad-except
+            if self._on_connect_error_cb is not None:
+                await self._on_connect_error_cb(err)
+            self._async_log_connection_error(err)
+            if isinstance(err, AUTH_EXCEPTIONS):
                 # If we get an encryption or password error,
                 # backoff for the maximum amount of time
                 self._tries = MAXIMUM_BACKOFF_TRIES
             else:
                 self._tries += 1
             return False
-        _LOGGER.info("Successfully connected to %s", self._log_name)
-        self._connected = True
         self._tries = 0
+        self._connection_state = ConnectionState.READY
         await self._on_connect_cb()
         return True
 
@@ -156,6 +177,14 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         Must only be called from _schedule_connect.
         """
+        if self._connect_task:
+            if self._connection_state != ConnectionState.CONNECTING:
+                # Connection state is far enough along that we should
+                # not restart the connect task
+                return
+            self._connect_task.cancel("Scheduling new connect attempt")
+            self._connect_task = None
+
         self._connect_task = asyncio.create_task(
             self._connect_once_or_reschedule(),
             name=f"{self._log_name}: aioesphomeapi connect",
@@ -178,12 +207,18 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         _LOGGER.debug("Trying to connect to %s", self._log_name)
         async with self._connected_lock:
             _LOGGER.debug("Connected lock acquired for %s", self._log_name)
-            self._stop_zc_listen()
-            if self._connected or self._is_stopped:
-                return
-            if await self._try_connect():
-                return
             tries = min(self._tries, 10)  # prevent OverflowError
+            if (
+                self._connection_state != ConnectionState.DISCONNECTED
+                or self._is_stopped
+            ):
+                return
+            if tries == 0:
+                # If this is the first try, stop listening for mDNS records
+                self._stop_zc_listen()
+            if await self._try_connect():
+                self._stop_zc_listen()
+                return
             wait_time = int(round(min(1.8**tries, 60.0)))
             if tries == 1:
                 _LOGGER.info(
@@ -195,22 +230,21 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 self._start_zc_listen()
             self._schedule_connect(wait_time)
 
+    def _remove_stop_task(self, _fut: asyncio.Future[None]) -> None:
+        """Remove the stop task from the connect loop.
+        We need to do this because the asyncio does not hold
+        a strong reference to the task, so it can be garbage
+        collected unexpectedly.
+        """
+        self._stop_task = None
+
     def stop_callback(self) -> None:
         """Stop the connect logic."""
-
-        def _remove_stop_task(_fut: asyncio.Future[None]) -> None:
-            """Remove the stop task from the connect loop.
-            We need to do this because the asyncio does not hold
-            a strong reference to the task, so it can be garbage
-            collected unexpectedly.
-            """
-            self._stop_task = None
-
         self._stop_task = asyncio.create_task(
             self.stop(),
             name=f"{self._log_name}: aioesphomeapi reconnect_logic stop_callback",
         )
-        self._stop_task.add_done_callback(_remove_stop_task)
+        self._stop_task.add_done_callback(self._remove_stop_task)
 
     async def start(self) -> None:
         """Start the connecting logic background task."""
@@ -218,7 +252,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._cli.set_cached_name_if_unset(self.name)
         async with self._connected_lock:
             self._is_stopped = False
-            if self._connected:
+            if self._connection_state != ConnectionState.DISCONNECTED:
                 return
             self._tries = 0
             self._schedule_connect(0.0)
@@ -261,10 +295,14 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         This is a mDNS record from the device and could mean it just woke up.
         """
-
         # Check if already connected, no lock needed for this access and
         # bail if either the already stopped or we haven't received device info yet
-        if self._connected or self._is_stopped or self._filter_alias is None:
+        if (
+            self._connection_state
+            in {ConnectionState.READY, ConnectionState.HANDSHAKING}
+            or self._is_stopped
+            or self._filter_alias is None
+        ):
             return
 
         for record_update in records:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -67,12 +67,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self.loop = asyncio.get_event_loop()
         self._cli = client
         self.name: str | None
-        if name:
-            self.name = name
-            self._log_name = f"{self.name} @ {self._cli.address}"
-        elif client.address.endswith(".local"):
+        if client.address.endswith(".local"):
             self.name = client.address[:-6]
             self._log_name = client.address
+        elif name:
+            self.name = name
+            self._log_name = f"{self.name} @ {self._cli.address}"
         else:
             self.name = None
             self._log_name = client.address

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -160,6 +160,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._tries += 1
             return False
         _LOGGER.info("Successfully connected to %s", self._log_name)
+        self._stop_zc_listen()
         self._connection_state = ReconnectLogicState.HANDSHAKING
         try:
             await self._cli.finish_connection(login=True)
@@ -179,7 +180,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         _LOGGER.info("Successful handshake with %s", self._log_name)
         self._connection_state = ReconnectLogicState.READY
         await self._on_connect_cb()
-        self._stop_zc_listen()
         return True
 
     def _schedule_connect(self, delay: float) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,7 +54,6 @@ def auth_client():
     )
     with patch.object(client, "_connection") as conn:
         conn.is_connected = True
-        conn.is_authenticated = True
         yield client
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -114,7 +114,7 @@ async def test_requires_encryption_propagates(conn: APIConnection):
         conn._socket = MagicMock()
         await conn._connect_init_frame_helper()
         loop.call_soon(conn._frame_helper._ready_future.set_result, None)
-        conn._connection_state = ConnectionState.CONNECTED
+        conn.connection_state = ConnectionState.CONNECTED
 
         with pytest.raises(RequiresEncryptionAPIError):
             task = asyncio.create_task(conn._connect_hello())

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,6 +12,12 @@ from aioesphomeapi.core import RequiresEncryptionAPIError
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
 
 
+async def connect(conn: APIConnection, login: bool = True):
+    """Wrapper for connection logic to do both parts."""
+    await conn.start_connection()
+    await conn.finish_connection(login=login)
+
+
 @pytest.fixture
 def connection_params() -> ConnectionParams:
     return ConnectionParams(
@@ -81,7 +87,7 @@ async def test_connect(conn, resolve_host, socket_socket, event_loop):
     with patch.object(event_loop, "sock_connect"), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
     ):
-        connect_task = asyncio.create_task(conn.connect(login=False))
+        connect_task = asyncio.create_task(connect(conn, login=False))
         await connected.wait()
         protocol.data_received(
             bytes.fromhex(
@@ -149,7 +155,7 @@ async def test_plaintext_connection(conn: APIConnection, resolve_host, socket_so
     with patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
     ):
-        connect_task = asyncio.create_task(conn.connect(login=False))
+        connect_task = asyncio.create_task(connect(conn, login=False))
         await connected.wait()
 
     protocol.data_received(


### PR DESCRIPTION
Note: this isn't a breaking change for anything using the ReconnectLogic, but I figure someone might be calling the connection logic directly so I tagged it a major.

If the first connect fails, we now keep the zeroconf listener going and will cancel any in-flight connection attempts as soon as the device announces it online to mdns. This restores the connection logic to how is used to be before we did some fixes for races which prevented reconnecting from working sometimes. This version should not suffer from the same problem, and still retain the faster reconnects because it splits up the connection logic to be safer.

To accomplish this the connection process is now split into two parts:

start_connection and finish_connection

- start_connection is intended to be able to be safely cancelled without putting to much load on the ESP device since it does not do a handshake or login and is only in charge of establishing the connection
- finish_connection does the handshake, auth, and login. The reconnect logic will not cancel the in-flight connection attempt and try connecting again when the connection has already reached this state

also: zeroconf listen was broken on esphome itself and only worked in HA. It will work on both now

Testing

- [x] esphome code
- [x] HA use case

closes #575