### PR TITLE
Improve consistency of name logging

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -304,19 +304,21 @@ class APIClient:
     def address(self) -> str:
         return self._params.address
 
-    def _set_log_name(self) -> None:
-        """Set the log name of the device."""
-        address_is_host = self.address.endswith(".local")
+    def _get_log_name(self) -> str:
+        """Get the log name of the device."""
+        address = self.address
+        address_is_host = address.endswith(".local")
         if self._cached_name is not None:
             if address_is_host:
-                self._log_name = self._cached_name
-            else:
-                self._log_name = f"{self._cached_name} @ {self.address}"
-            return
-        elif address_is_host:
-            self._log_name = self.address[:-6]
-            return
-        self._log_name = self.address
+                return self._cached_name
+            return f"{self._cached_name} @ {address}"
+        if address_is_host:
+            return address[:-6]
+        return address
+
+    def _set_log_name(self) -> None:
+        """Set the log name of the device."""
+        self._log_name = self._get_log_name()
 
     def set_cached_name_if_unset(self, name: str) -> None:
         """Set the cached name of the device if not set."""

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -78,7 +78,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._log_name = self.name
         elif name:
             self.name = name
-            self._log_name = f"{self.name} @ {self._cli.address}"
+            self._log_name = f"{name} @ {self._cli.address}"
+            self._cli.set_cached_name_if_unset(name)
         else:
             self.name = None
             self._log_name = client.address
@@ -276,8 +277,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     async def start(self) -> None:
         """Start the connecting logic background task."""
-        if self.name:
-            self._cli.set_cached_name_if_unset(self.name)
         async with self._connected_lock:
             self._is_stopped = False
             if self._connection_state != ReconnectLogicState.DISCONNECTED:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock
+
+import pytest
+from zeroconf.asyncio import AsyncZeroconf
+
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.reconnect_logic import ReconnectLogic
+
+
+@pytest.mark.asyncio
+async def test_reconnect_logic_name_from_host():
+    """Test that the name is set correctly from the host."""
+    cli = APIClient(
+        address="mydevice.local",
+        port=6052,
+        password=None,
+    )
+
+    async def on_disconnect(expected_disconnect: bool) -> None:
+        pass
+
+    async def on_connect() -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=on_disconnect,
+        on_connect=on_connect,
+        zeroconf_instance=MagicMock(spec=AsyncZeroconf),
+    )
+    assert rl._log_name == "mydevice"
+    assert cli._log_name == "mydevice"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_logic_name_from_host_and_set():
+    """Test that the name is set correctly from the host."""
+    cli = APIClient(
+        address="mydevice.local",
+        port=6052,
+        password=None,
+    )
+
+    async def on_disconnect(expected_disconnect: bool) -> None:
+        pass
+
+    async def on_connect() -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=on_disconnect,
+        on_connect=on_connect,
+        zeroconf_instance=MagicMock(spec=AsyncZeroconf),
+        name="mydevice",
+    )
+    assert rl._log_name == "mydevice"
+    assert cli._log_name == "mydevice"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_logic_name_from_address():
+    """Test that the name is set correctly from the address."""
+    cli = APIClient(
+        address="1.2.3.4",
+        port=6052,
+        password=None,
+    )
+
+    async def on_disconnect(expected_disconnect: bool) -> None:
+        pass
+
+    async def on_connect() -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=on_disconnect,
+        on_connect=on_connect,
+        zeroconf_instance=MagicMock(spec=AsyncZeroconf),
+    )
+    assert rl._log_name == "1.2.3.4"
+    assert cli._log_name == "1.2.3.4"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_logic_name_from_name():
+    """Test that the name is set correctly from the address."""
+    cli = APIClient(
+        address="1.2.3.4",
+        port=6052,
+        password=None,
+    )
+
+    async def on_disconnect(expected_disconnect: bool) -> None:
+        pass
+
+    async def on_connect() -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=on_disconnect,
+        on_connect=on_connect,
+        zeroconf_instance=MagicMock(spec=AsyncZeroconf),
+        name="mydevice",
+    )
+    assert rl._log_name == "mydevice @ 1.2.3.4"
+    assert cli._log_name == "mydevice @ 1.2.3.4"


### PR DESCRIPTION
We have three places that log the name:
- reconnect_logic
- connection
- client

The goal it to make them all the same
since various callers pass the name
in different ways to preserve compat