### PR TITLE
Fix trying to convert hostnames to IP Addresses

### DIFF
--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -209,7 +209,7 @@ async def async_resolve_host(
         except APIConnectionError as err:
             zc_error = err
 
-    if not addrs:
+    else:
         addrs.extend(_async_ip_address_to_addrs(host, port))
 
     if not addrs:

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -146,3 +146,21 @@ async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)
+
+
+@pytest.mark.asyncio
+@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
+async def test_resolve_host_with_address(resolve_addr, resolve_zc):
+    resolve_zc.return_value = []
+    resolve_addr.return_value = addr_infos
+    ret = await hr.async_resolve_host("127.0.0.1", 6052)
+
+    resolve_zc.assert_not_called()
+    resolve_addr.assert_not_called()
+    assert ret == hr.AddrInfo(
+        family=socket.AddressFamily.AF_INET,
+        type=socket.SocketKind.SOCK_STREAM,
+        proto=6,
+        sockaddr=hr.IPv4Sockaddr(address="127.0.0.1", port=6052),
+    )


### PR DESCRIPTION
The logic in the host resolver would call `_async_ip_address_to_addrs` even when we knew the host was not an ip address. `_async_ip_address_to_addrs` does not do any dns resolution so passing in a hostname to it will always return an empty result