### PR TITLE
Simplify raw ble advertisements callbacks

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -1,4 +1,10 @@
 # flake8: noqa
+from .api_pb2 import (  # type: ignore[attr-defined] # noqa: F401
+    BluetoothLERawAdvertisement,
+)
+from .api_pb2 import (  # type: ignore[attr-defined] # noqa: F401
+    BluetoothLERawAdvertisementsResponse,
+)
 from .ble_defs import ESP_CONNECTION_ERROR_DESCRIPTION, BLEConnectionError
 from .client import APIClient
 from .connection import APIConnection, ConnectionParams

--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -1,8 +1,6 @@
 # flake8: noqa
 from .api_pb2 import (  # type: ignore[attr-defined] # noqa: F401
     BluetoothLERawAdvertisement,
-)
-from .api_pb2 import (  # type: ignore[attr-defined] # noqa: F401
     BluetoothLERawAdvertisementsResponse,
 )
 from .ble_defs import ESP_CONNECTION_ERROR_DESCRIPTION, BLEConnectionError

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -171,7 +171,6 @@ from .model import (
     UserServiceArgType,
     VoiceAssistantCommand,
     VoiceAssistantEventType,
-    make_ble_raw_advertisement_processor,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -585,12 +585,17 @@ class APIClient:
         msg_types = (BluetoothLERawAdvertisementsResponse,)
 
         assert self._connection is not None
-        on_msg = make_ble_raw_advertisement_processor(on_advertisements)
+
+        def _on_ble_raw_advertisement_response(
+            data: BluetoothLERawAdvertisementsResponse,
+        ) -> None:
+            on_advertisements(data.advertisements)
+
         unsub_callback = self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(
                 flags=BluetoothProxySubscriptionFlag.RAW_ADVERTISEMENTS
             ),
-            on_msg,
+            _on_ble_raw_advertisement_response,
             msg_types,
         )
 

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -8,7 +8,6 @@ from functools import cache, lru_cache, partial
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 from uuid import UUID
 
-from .api_pb2 import BluetoothLERawAdvertisement  # type: ignore[attr-defined]
 from .util import fix_float_single_double_conversion
 
 if sys.version_info[:2] < (3, 10):
@@ -22,7 +21,6 @@ else:
 if TYPE_CHECKING:
     from .api_pb2 import (  # type: ignore
         BluetoothLEAdvertisementResponse,
-        BluetoothLERawAdvertisementsResponse,
         HomeassistantServiceMap,
     )
 

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -927,19 +927,6 @@ class BluetoothLEAdvertisement:
         )
 
 
-def make_ble_raw_advertisement_processor(
-    on_advertisements: Callable[[list[BluetoothLERawAdvertisement]], None]
-) -> Callable[[BluetoothLERawAdvertisementsResponse], None]:
-    """Make a processor for BluetoothLERawAdvertisementResponse."""
-
-    def _on_ble_raw_advertisement_response(
-        data: BluetoothLERawAdvertisementsResponse,
-    ) -> None:
-        on_advertisements(data.advertisements)
-
-    return _on_ble_raw_advertisement_response
-
-
 @_frozen_dataclass_decorator
 class BluetoothDeviceConnection(APIModelBase):
     address: int = 0


### PR DESCRIPTION
These used to be a lot more complex, and we can remove the make_ble_raw_advertisement_processor