### PR TITLE
Refactor internal message handlers to use a single dispatch path

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -845,17 +845,23 @@ class APIConnection:
             self._handle_get_time_request_internal, (GetTimeRequest,)
         )
 
-    def _handle_disconnect_request_internal(self, msg: DisconnectRequest) -> None:
+    def _handle_disconnect_request_internal(  # pylint: disable=unused-argument
+        self, _msg: DisconnectRequest
+    ) -> None:
         """Handle a DisconnectRequest."""
         self.send_message(DISCONNECT_RESPONSE_MESSAGE)
         self._expected_disconnect = True
         self._cleanup()
 
-    def _handle_ping_request_internal(self, msg: PingRequest) -> None:
+    def _handle_ping_request_internal(  # pylint: disable=unused-argument
+        self, _msg: PingRequest
+    ) -> None:
         """Handle a PingRequest."""
         self.send_message(PING_RESPONSE_MESSAGE)
 
-    def _handle_get_time_request_internal(self, msg: GetTimeRequest) -> None:
+    def _handle_get_time_request_internal(  # pylint: disable=unused-argument
+        self, _msg: GetTimeRequest
+    ) -> None:
         """Handle a GetTimeRequest."""
         resp = GetTimeResponse()
         resp.epoch_seconds = int(time.time())

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -60,9 +60,6 @@ _LOGGER = logging.getLogger(__name__)
 
 BUFFER_SIZE = 1024 * 1024 * 2  # Set buffer limit to 2MB
 
-
-INTERNAL_MESSAGE_TYPES = {GetTimeRequest, PingRequest, DisconnectRequest}
-
 DISCONNECT_REQUEST_MESSAGE = DisconnectRequest()
 DISCONNECT_RESPONSE_MESSAGE = DisconnectResponse()
 PING_REQUEST_MESSAGE = PingRequest()


### PR DESCRIPTION
We had two ways of handling incoming packets:

- dispatch via registered handlers
- hard coded list of handlers

To simplify the handling of incoming packets we now register the internal handlers which leaves a single dispatch path for processing packets