### PR TITLE
Use a memoryview when processing bytes in the frame helper

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -18,7 +18,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef bint _is_ready
 
     @cython.locals(
-        header=bytes,
+        header="unsigned char[:]",
         preamble=cython.uint,
         msg_size_high=cython.uint,
         msg_size_low=cython.uint,

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -18,7 +18,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef bint _is_ready
 
     @cython.locals(
-        header="unsigned char[:]",
+        header="const unsigned char[:]",
         preamble=cython.uint,
         msg_size_high=cython.uint,
         msg_size_low=cython.uint,

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -10,14 +10,14 @@ cdef object bytes_to_varuint, varuint_to_bytes
 cpdef _varuint_to_bytes(cython.int value)
 
 @cython.locals(result=cython.int, bitpos=cython.int, val=cython.int)
-cpdef _bytes_to_varuint(cython.bytes value)
+cpdef _bytes_to_varuint(unsigned char[:] value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
     @cython.locals(
         msg_type=bytes,
         length=bytes,
-        init_bytes=bytes,
+        init_bytes="unsigned char[:]",
         add_length=bytes,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -10,14 +10,14 @@ cdef object bytes_to_varuint, varuint_to_bytes
 cpdef _varuint_to_bytes(cython.int value)
 
 @cython.locals(result=cython.int, bitpos=cython.int, val=cython.int)
-cpdef _bytes_to_varuint(unsigned char[:] value)
+cpdef _bytes_to_varuint(const unsigned char[:] value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
     @cython.locals(
         msg_type=bytes,
         length=bytes,
-        init_bytes="unsigned char[:]",
+        init_bytes="const unsigned char[:]",
         add_length=bytes,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,


### PR DESCRIPTION
This should avoid all the pyint conversions when splicing up the headers