### PR TITLE
Refactor Bluetooth raw advs to avoid protobuf name lookups

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -1,8 +1,4 @@
 # flake8: noqa
-from .api_pb2 import (  # type: ignore[attr-defined] # noqa: F401
-    BluetoothLERawAdvertisement,
-    BluetoothLERawAdvertisementsResponse,
-)
 from .ble_defs import ESP_CONNECTION_ERROR_DESCRIPTION, BLEConnectionError
 from .client import APIClient
 from .connection import APIConnection, ConnectionParams

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -594,7 +594,7 @@ class APIClient:
         def _on_ble_raw_advertisement_response(
             data: BluetoothLERawAdvertisementsResponse,
         ) -> None:
-            on_advertisements(BluetoothLERawAdvertisement.list_from_pb(data))
+            on_advertisements(BluetoothLERawAdvertisement.list_from_pb(data))  # type: ignore[misc]
 
         unsub_callback = self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -124,6 +124,7 @@ from .model import (
     BluetoothGATTError,
     BluetoothGATTServices,
     BluetoothLEAdvertisement,
+    BluetoothLERawAdvertisement,
     BluetoothProxyFeature,
     BluetoothProxySubscriptionFlag,
     ButtonInfo,
@@ -174,7 +175,6 @@ from .model import (
     UserServiceArgType,
     VoiceAssistantCommand,
     VoiceAssistantEventType,
-    BluetoothLERawAdvertisement,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -31,7 +31,6 @@ from .api_pb2 import (  # type: ignore
     BluetoothGATTWriteRequest,
     BluetoothGATTWriteResponse,
     BluetoothLEAdvertisementResponse,
-    BluetoothLERawAdvertisement,
     BluetoothLERawAdvertisementsResponse,
     ButtonCommandRequest,
     CameraImageRequest,
@@ -175,6 +174,7 @@ from .model import (
     UserServiceArgType,
     VoiceAssistantCommand,
     VoiceAssistantEventType,
+    BluetoothLERawAdvertisement,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -594,7 +594,7 @@ class APIClient:
         def _on_ble_raw_advertisement_response(
             data: BluetoothLERawAdvertisementsResponse,
         ) -> None:
-            on_advertisements(data.advertisements)
+            on_advertisements(BluetoothLERawAdvertisement.list_from_pb(data))
 
         unsub_callback = self._connection.send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -948,6 +948,26 @@ class BluetoothLEAdvertisement:
         )
 
 
+@_dataclass_decorator
+class BluetoothLERawAdvertisement:
+    address: int
+    rssi: int
+    data: bytes
+    address_type: int = 0
+
+    @classmethod
+    def list_from_pb(  # type: ignore[misc]
+        cls: BluetoothLERawAdvertisement, data: BluetoothLEAdvertisementResponse
+    ) -> list[BluetoothLERawAdvertisement]:
+        """Return a list of BluetoothLERawAdvertisement from a BluetoothLEAdvertisementResponse."""
+        return [
+            BluetoothLERawAdvertisement(
+                **{desc.name: val for desc, val in adv.ListFields()}
+            )
+            for adv in data.advertisements
+        ]
+
+
 @_frozen_dataclass_decorator
 class BluetoothDeviceConnection(APIModelBase):
     address: int = 0

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -953,7 +953,7 @@ class BluetoothLERawAdvertisement:
     address: int
     rssi: int
     address_type: int = 0
-    data: bytes = field(default_factory=bytes)  # pylint: disable=invalid-field-call
+    data: bytes = b""
 
     @classmethod
     def list_from_pb(  # type: ignore[misc]

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -952,8 +952,8 @@ class BluetoothLEAdvertisement:
 class BluetoothLERawAdvertisement:
     address: int
     rssi: int
-    data: bytes
     address_type: int = 0
+    data: bytes = field(default_factory=bytes)  # pylint: disable=invalid-field-call
 
     @classmethod
     def list_from_pb(  # type: ignore[misc]


### PR DESCRIPTION
The idea here is to use ListFields so we don't have to call all the name logic in [GetAttr](https://github.com/protocolbuffers/protobuf/blob/0a2fe573a292325600d1d99619a1a711a349d314/python/message.c#L999) every time


Its also possible all the work to create the tuples from ListFields is more expensive though.. so need to profile profile profile