### PR TITLE
Wait for handshake to finish to allow for clean disconnect when stopping reconnect logic

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -317,7 +317,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
     async def stop(self) -> None:
         """Stop the connecting logic background task. Does not disconnect the client."""
         self._cancel_connect("Stopping")
-        if self._connect_task and self._connection_state == ReconnectLogicState.CONNECTING:
+        if (
+            self._connect_task
+            and self._connection_state == ReconnectLogicState.CONNECTING
+        ):
             # If we are still establishing a connection, we can safely
             # cancel the connect task here, otherwise we need to wait
             # for the connect task to finish so we can gracefully

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -317,6 +317,13 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
     async def stop(self) -> None:
         """Stop the connecting logic background task. Does not disconnect the client."""
         self._cancel_connect("Stopping")
+        if self._connect_task and self._connection_state == ReconnectLogicState.CONNECTING:
+            # If we are still establishing a connection, we can safely
+            # cancel the connect task here, otherwise we need to wait
+            # for the connect task to finish so we can gracefully
+            # disconnect.
+            self._connect_task.cancel("Stopping")
+
         async with self._connected_lock:
             self._is_stopped = True
             # Cancel again while holding the lock

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -316,16 +316,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     async def stop(self) -> None:
         """Stop the connecting logic background task. Does not disconnect the client."""
-        self._cancel_connect("Stopping")
-        if (
-            self._connect_task
-            and self._connection_state == ReconnectLogicState.CONNECTING
-        ):
+        if self._connection_state == ReconnectLogicState.CONNECTING:
             # If we are still establishing a connection, we can safely
             # cancel the connect task here, otherwise we need to wait
             # for the connect task to finish so we can gracefully
             # disconnect.
-            self._connect_task.cancel("Stopping")
+            self._cancel_connect("Stopping")
 
         async with self._connected_lock:
             self._is_stopped = True

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -371,3 +371,33 @@ async def test_reconnect_zeroconf(
         assert log_text in caplog.text
 
     await rl.stop()
+    assert rl._is_stopped is True
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+
+
+@pytest.mark.asyncio
+async def test_reconnect_logic_stop_callback():
+    """Test that the stop_callback stops the ReconnectLogic."""
+    cli = APIClient(
+        address="1.2.3.4",
+        port=6052,
+        password=None,
+    )
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=_get_mock_zeroconf(),
+        name="mydevice",
+    )
+    await rl.start()
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+    await asyncio.sleep(0)
+    assert rl._connection_state is ReconnectLogicState.CONNECTING
+    assert rl._is_stopped is False
+    rl.stop_callback()
+    # Wait for cancellation to propagate
+    for _ in range(4):
+        await asyncio.sleep(0)
+    assert rl._is_stopped is True
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED


### PR DESCRIPTION
There was a very rare race where we could disconnect in the middle of the handshake if we had just finished connecting to the ESP which would prevent the disconnect request from being seen by the ESP

To fix this we now only cancel without the lock if we are still establishing the connection, otherwise try to wait for the handshake to finish so we can cleanly disconnect.

This didn't cause any visible issues besides a log message on the esp