### PR TITLE
Allow the stop callback to be cancelled when already disconnected

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -316,7 +316,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     async def stop(self) -> None:
         """Stop the connecting logic background task. Does not disconnect the client."""
-        if self._connection_state == ReconnectLogicState.CONNECTING:
+        if self._connection_state in NOT_YET_CONNECTED_STATES:
             # If we are still establishing a connection, we can safely
             # cancel the connect task here, otherwise we need to wait
             # for the connect task to finish so we can gracefully

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -403,10 +403,10 @@ async def test_reconnect_logic_stop_callback():
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-
 @pytest.mark.asyncio
 async def test_reconnect_logic_stop_callback_waits_for_handshake():
     """Test that the stop_callback waits for a handshake."""
+
     class PatchableAPIClient(APIClient):
         pass
 
@@ -428,7 +428,9 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake():
         await asyncio.sleep(10)
         raise APIConnectionError
 
-    with patch.object(cli, "start_connection"), patch.object(cli, "finish_connection", side_effect=slow_connect_fail):
+    with patch.object(cli, "start_connection"), patch.object(
+        cli, "finish_connection", side_effect=slow_connect_fail
+    ):
         await rl.start()
         for _ in range(3):
             await asyncio.sleep(0)


### PR DESCRIPTION
#614 fixed the case were we would cancel the handshake in progress, but it did not account for the race where we have not switched the state to connecting yet because we have not obtained the lock. While I could only get this to happen in a test its likely it possible in the real world if the timing is exactly perfect