### PR TITLE
Stop building wheels for python 3.9/3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp*
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp*
           CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto aarch64


### PR DESCRIPTION
This change is only to decrease the time it takes to do a release and save space on PyPI. The release time is > 45 minutes because of the addition of aarch64 wheels which have to be done in qemu since github doesn't have native arm runners.

When esphome 2023.11.0 is released, the containers will be python 3.11 based so we will no longer need wheels for old python versions.

This does not increase the library minimum python version and wheels can still be built locally for older python versions.

