### PR TITLE
Ensure passed params are always a str

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -249,9 +249,7 @@ def _stringify_or_none(value: str | None) -> str | None:
     the client as an Estr, but we want to pass it
     to the API as a string or None.
     """
-    if value is None:
-        return None
-    return str(value)
+    return None if value is None else str(value)
 
 
 # pylint: disable=too-many-public-methods

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -243,7 +243,7 @@ ExecuteServiceDataType = dict[
 
 
 def _stringify_or_none(value: str | None) -> str | None:
-    """Convert a string to a string or None.
+    """Convert a string like object to a str or None.
 
     The noise_psk is sometimes passed into
     the client as an Estr, but we want to pass it

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -291,7 +291,7 @@ class APIClient:
             IP passed as address but DHCP reassigned IP.
         """
         self._params = ConnectionParams(
-            address=address,
+            address=str(address),
             port=port,
             password=password,
             client_info=client_info,
@@ -299,7 +299,7 @@ class APIClient:
             zeroconf_instance=zeroconf_instance,
             # treat empty psk string as missing (like password)
             noise_psk=_stringify_or_none(noise_psk),
-            expected_name=expected_name,
+            expected_name=_stringify_or_none(expected_name),
         )
         self._connection: APIConnection | None = None
         self._cached_name: str | None = None

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -242,6 +242,18 @@ ExecuteServiceDataType = dict[
 ]
 
 
+def _stringify_or_none(value: str | None) -> str | None:
+    """Convert a string to a string or None.
+
+    The noise_psk is sometimes passed into
+    the client as an Estr, but we want to pass it
+    to the API as a string or None.
+    """
+    if value is None:
+        return None
+    return str(value)
+
+
 # pylint: disable=too-many-public-methods
 class APIClient:
     __slots__ = (
@@ -288,7 +300,7 @@ class APIClient:
             keepalive=keepalive,
             zeroconf_instance=zeroconf_instance,
             # treat empty psk string as missing (like password)
-            noise_psk=noise_psk or None,
+            noise_psk=_stringify_or_none(noise_psk),
             expected_name=expected_name,
         )
         self._connection: APIConnection | None = None

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -345,6 +345,8 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
+            if TYPE_CHECKING:
+                assert noise_psk is not None
             _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
                     noise_psk=noise_psk,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -347,7 +347,7 @@ class APIConnection:
         else:
             _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
-                    noise_psk=noise_psk, # type: ignore[arg-type]
+                    noise_psk=noise_psk,  # type: ignore[arg-type]
                     expected_name=self._params.expected_name,
                     on_pkt=self._process_packet,
                     on_error=self._report_fatal_error,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -345,11 +345,9 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
-            if TYPE_CHECKING:
-                assert noise_psk is not None
             _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
-                    noise_psk=noise_psk,
+                    noise_psk=noise_psk, # type: ignore[arg-type]
                     expected_name=self._params.expected_name,
                     on_pkt=self._process_packet,
                     on_error=self._report_fatal_error,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -345,10 +345,9 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
-            # Ensure noise_psk is a string and not an EStr
             _, fh = await loop.create_connection(  # type: ignore[type-var]
                 lambda: APINoiseFrameHelper(
-                    noise_psk=str(noise_psk),
+                    noise_psk=noise_psk,
                     expected_name=self._params.expected_name,
                     on_pkt=self._process_packet,
                     on_error=self._report_fatal_error,

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,9 @@ import time
 from datetime import datetime, timezone
 from functools import partial
 from unittest.mock import MagicMock
+
 from zeroconf import Zeroconf
+
 UTC = timezone.utc
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 # We use a partial here since it is implemented in native code
@@ -16,7 +18,6 @@ utcnow.__doc__ = "Get now in UTC time."
 
 def get_mock_zeroconf() -> MagicMock:
     return MagicMock(spec=Zeroconf)
-
 
 
 class Estr(str):

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,13 +4,23 @@ import asyncio
 import time
 from datetime import datetime, timezone
 from functools import partial
-
+from unittest.mock import MagicMock
+from zeroconf import Zeroconf
 UTC = timezone.utc
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 # We use a partial here since it is implemented in native code
 # and avoids the global lookup of UTC
 utcnow: partial[datetime] = partial(datetime.now, UTC)
 utcnow.__doc__ = "Get now in UTC time."
+
+
+def get_mock_zeroconf() -> MagicMock:
+    return MagicMock(spec=Zeroconf)
+
+
+
+class Estr(str):
+    """A subclassed string."""
 
 
 def as_utc(dattim: datetime) -> datetime:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -589,13 +589,17 @@ async def test_noise_psk_handles_subclassed_string():
         pass
 
     cli = PatchableAPIClient(
-        address="1.2.3.4",
+        address=Estr("1.2.3.4"),
         port=6052,
         password=None,
-        noise_psk=Estr("QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=")
+        noise_psk=Estr("QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="),
+        expected_name=Estr("mydevice"),
     )
     # Make sure its not a subclassed string
     assert type(cli._params.noise_psk) is str
+    assert type(cli._params.address) is str
+    assert type(cli._params.expected_name) is str
+
     rl = ReconnectLogic(
         client=cli,
         on_disconnect=AsyncMock(),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 from mock import AsyncMock, MagicMock, patch
-
+from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 from aioesphomeapi.api_pb2 import (
     AlarmControlPanelCommandRequest,
     BinarySensorStateResponse,
@@ -22,6 +22,9 @@ from aioesphomeapi.api_pb2 import (
     SwitchCommandRequest,
     TextCommandRequest,
 )
+import asyncio
+from .common import get_mock_zeroconf,Estr
+from aioesphomeapi.core import APIConnectionError
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.model import (
     AlarmControlPanelCommand,
@@ -575,3 +578,40 @@ async def test_text_command(auth_client, cmd, req):
 
     await auth_client.text_command(**cmd)
     send.assert_called_once_with(TextCommandRequest(**req))
+
+
+
+@pytest.mark.asyncio
+async def test_noise_psk_handles_subclassed_string():
+    """Test that the noise_psk gets converted to a string."""
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    cli = PatchableAPIClient(
+        address="1.2.3.4",
+        port=6052,
+        password=None,
+        noise_psk=Estr("QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=")
+    )
+    # Make sure its not a subclassed string
+    assert type(cli._params.noise_psk) is str
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+
+    with patch.object(cli, "start_connection"), patch.object(cli, "finish_connection"):
+        await rl.start()
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    rl.stop_callback()
+    # Wait for cancellation to propagate
+    for _ in range(4):
+        await asyncio.sleep(0)
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
+import asyncio
+
 import pytest
 from mock import AsyncMock, MagicMock, patch
-from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
+
 from aioesphomeapi.api_pb2 import (
     AlarmControlPanelCommandRequest,
     BinarySensorStateResponse,
@@ -22,10 +24,8 @@ from aioesphomeapi.api_pb2 import (
     SwitchCommandRequest,
     TextCommandRequest,
 )
-import asyncio
-from .common import get_mock_zeroconf,Estr
-from aioesphomeapi.core import APIConnectionError
 from aioesphomeapi.client import APIClient
+from aioesphomeapi.core import APIConnectionError
 from aioesphomeapi.model import (
     AlarmControlPanelCommand,
     APIVersion,
@@ -45,6 +45,9 @@ from aioesphomeapi.model import (
     UserServiceArg,
     UserServiceArgType,
 )
+from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
+
+from .common import Estr, get_mock_zeroconf
 
 
 @pytest.fixture
@@ -578,7 +581,6 @@ async def test_text_command(auth_client, cmd, req):
 
     await auth_client.text_command(**cmd)
     send.assert_called_once_with(TextCommandRequest(**req))
-
 
 
 @pytest.mark.asyncio

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -18,12 +18,8 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_PTR
 from aioesphomeapi import APIConnectionError
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
-
+from .common import get_mock_zeroconf
 logging.getLogger("aioesphomeapi").setLevel(logging.DEBUG)
-
-
-def _get_mock_zeroconf() -> MagicMock:
-    return MagicMock(spec=Zeroconf)
 
 
 @pytest.mark.asyncio
@@ -70,7 +66,7 @@ async def test_reconnect_logic_name_from_host_and_set():
         client=cli,
         on_disconnect=on_disconnect,
         on_connect=on_connect,
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
     )
     assert rl._log_name == "mydevice"
@@ -96,7 +92,7 @@ async def test_reconnect_logic_name_from_address():
         client=cli,
         on_disconnect=on_disconnect,
         on_connect=on_connect,
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
     )
     assert rl._log_name == "1.2.3.4"
     assert cli._log_name == "1.2.3.4"
@@ -121,7 +117,7 @@ async def test_reconnect_logic_name_from_name():
         client=cli,
         on_disconnect=on_disconnect,
         on_connect=on_connect,
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
     )
     assert rl._log_name == "mydevice @ 1.2.3.4"
@@ -160,7 +156,7 @@ async def test_reconnect_logic_state():
         client=cli,
         on_disconnect=on_disconnect,
         on_connect=on_connect,
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
         on_connect_error=on_connect_fail,
     )
@@ -237,7 +233,7 @@ async def test_reconnect_retry():
         client=cli,
         on_disconnect=on_disconnect,
         on_connect=on_connect,
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
         on_connect_error=on_connect_fail,
     )
@@ -387,7 +383,7 @@ async def test_reconnect_logic_stop_callback():
         client=cli,
         on_disconnect=AsyncMock(),
         on_connect=AsyncMock(),
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
     )
     await rl.start()
@@ -419,7 +415,7 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake():
         client=cli,
         on_disconnect=AsyncMock(),
         on_connect=AsyncMock(),
-        zeroconf_instance=_get_mock_zeroconf(),
+        zeroconf_instance=get_mock_zeroconf(),
         name="mydevice",
     )
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -18,7 +18,9 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_PTR
 from aioesphomeapi import APIConnectionError
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
+
 from .common import get_mock_zeroconf
+
 logging.getLogger("aioesphomeapi").setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
Consumers of the api may pass string like objects that are not actually python `str` objects.  Since `expected_name` and `noise_psk` are strongly typed to `str` in `APIConnection` to allow fast string operations, we ensure they are actual `str` objects before passing them from `APIClient` to `APIConnection`

related issue https://github.com/esphome/issues/issues/5090