### PR TITLE
Ensure an empty noise_psk or expected_name is treated as None

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -297,9 +297,9 @@ class APIClient:
             client_info=client_info,
             keepalive=keepalive,
             zeroconf_instance=zeroconf_instance,
-            # treat empty psk string as missing (like password)
-            noise_psk=_stringify_or_none(noise_psk),
-            expected_name=_stringify_or_none(expected_name),
+            # treat empty '' psk string as missing (like password)
+            noise_psk=_stringify_or_none(noise_psk) or None,
+            expected_name=_stringify_or_none(expected_name) or None,
         )
         self._connection: APIConnection | None = None
         self._cached_name: str | None = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -646,8 +646,8 @@ async def test_empty_noise_psk_or_expected_name():
         address=Estr("1.2.3.4"),
         port=6052,
         password=None,
-        noise_psk='',
-        expected_name='',
+        noise_psk="",
+        expected_name="",
     )
     assert cli._params.noise_psk is None
     assert type(cli._params.address) is str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -621,3 +621,34 @@ async def test_noise_psk_handles_subclassed_string():
     for _ in range(4):
         await asyncio.sleep(0)
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+
+
+@pytest.mark.asyncio
+async def test_no_noise_psk():
+    """Test not using a noise_psk."""
+    cli = APIClient(
+        address=Estr("1.2.3.4"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=Estr("mydevice"),
+    )
+    # Make sure its not a subclassed string
+    assert cli._params.noise_psk is None
+    assert type(cli._params.address) is str
+    assert type(cli._params.expected_name) is str
+
+
+@pytest.mark.asyncio
+async def test_empty_noise_psk_or_expected_name():
+    """Test an empty noise_psk is treated as None."""
+    cli = APIClient(
+        address=Estr("1.2.3.4"),
+        port=6052,
+        password=None,
+        noise_psk='',
+        expected_name='',
+    )
+    assert cli._params.noise_psk is None
+    assert type(cli._params.address) is str
+    assert cli._params.expected_name is None


### PR DESCRIPTION
HA passes `` when these values are `None`