### PR TITLE
Send hello and login asynchronously to speed up connecting

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -441,8 +441,8 @@ class APIClient:
             return isinstance(msg, ListEntitiesDoneResponse)
 
         assert self._connection is not None
-        resp = await self._connection.send_message_await_response_complex(
-            ListEntitiesRequest(), do_append, do_stop, msg_types, timeout=60
+        resp = await self._connection.send_messages_await_response_complex(
+            (ListEntitiesRequest(),), do_append, do_stop, msg_types, timeout=60
         )
         entities: list[EntityInfo] = []
         services: list[UserService] = []
@@ -557,8 +557,8 @@ class APIClient:
         assert self._connection is not None
 
         message_filter = partial(self._filter_bluetooth_message, address, handle)
-        resp = await self._connection.send_message_await_response_complex(
-            request, message_filter, message_filter, msg_types, timeout=timeout
+        resp = await self._connection.send_messages_await_response_complex(
+            (request,), message_filter, message_filter, msg_types, timeout=timeout
         )
 
         if isinstance(resp[0], BluetoothGATTErrorResponse):
@@ -791,9 +791,11 @@ class APIClient:
                 )
             return True
 
-        [response] = await self._connection.send_message_await_response_complex(
-            BluetoothDeviceRequest(
-                address=address, request_type=BluetoothDeviceRequestType.PAIR
+        [response] = await self._connection.send_messages_await_response_complex(
+            (
+                BluetoothDeviceRequest(
+                    address=address, request_type=BluetoothDeviceRequestType.PAIR
+                ),
             ),
             predicate_func,
             predicate_func,
@@ -812,9 +814,11 @@ class APIClient:
         def predicate_func(msg: BluetoothDeviceUnpairingResponse) -> bool:
             return bool(msg.address == address)
 
-        [response] = await self._connection.send_message_await_response_complex(
-            BluetoothDeviceRequest(
-                address=address, request_type=BluetoothDeviceRequestType.UNPAIR
+        [response] = await self._connection.send_messages_await_response_complex(
+            (
+                BluetoothDeviceRequest(
+                    address=address, request_type=BluetoothDeviceRequestType.UNPAIR
+                ),
             ),
             predicate_func,
             predicate_func,
@@ -833,9 +837,11 @@ class APIClient:
         def predicate_func(msg: BluetoothDeviceClearCacheResponse) -> bool:
             return bool(msg.address == address)
 
-        [response] = await self._connection.send_message_await_response_complex(
-            BluetoothDeviceRequest(
-                address=address, request_type=BluetoothDeviceRequestType.CLEAR_CACHE
+        [response] = await self._connection.send_messages_await_response_complex(
+            (
+                BluetoothDeviceRequest(
+                    address=address, request_type=BluetoothDeviceRequestType.CLEAR_CACHE
+                ),
             ),
             predicate_func,
             predicate_func,
@@ -853,10 +859,12 @@ class APIClient:
             return bool(msg.address == address and not msg.connected)
 
         assert self._connection is not None
-        await self._connection.send_message_await_response_complex(
-            BluetoothDeviceRequest(
-                address=address,
-                request_type=BluetoothDeviceRequestType.DISCONNECT,
+        await self._connection.send_messages_await_response_complex(
+            (
+                BluetoothDeviceRequest(
+                    address=address,
+                    request_type=BluetoothDeviceRequestType.DISCONNECT,
+                ),
             ),
             predicate_func,
             predicate_func,
@@ -883,8 +891,8 @@ class APIClient:
             return isinstance(msg, stop_types) and msg.address == address
 
         assert self._connection is not None
-        resp = await self._connection.send_message_await_response_complex(
-            BluetoothGATTGetServicesRequest(address=address),
+        resp = await self._connection.send_messages_await_response_complex(
+            (BluetoothGATTGetServicesRequest(address=address),),
             do_append,
             do_stop,
             msg_types,

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -89,3 +89,5 @@ cdef class APIConnection:
 
     @cython.locals(handlers=set)
     cpdef _remove_message_callback(self, object on_message, tuple msg_types)
+
+    cdef _send_messages(self, tuple messages)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -399,7 +399,7 @@ class APIConnection:
             raise TimeoutAPIError("Hello timed out") from err
 
         resp = responses.pop(0)
-        self._process_resp(resp)
+        self._process_hello_resp(resp)
         if login:
             login_response = responses.pop(0)
             self._process_login_response(login_response)
@@ -409,7 +409,7 @@ class APIConnection:
         if login_response.invalid_password:
             raise InvalidAuthAPIError("Invalid password!")
 
-    def _process_resp(self, resp: HelloResponse) -> None:
+    def _process_hello_resp(self, resp: HelloResponse) -> None:
         """Process a HelloResponse."""
         _LOGGER.debug(
             "%s: Successfully connected ('%s' API=%s.%s)",

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -389,8 +389,8 @@ class APIConnection:
             responses = await self.send_messages_await_response_complex(
                 tuple(messages),
                 None,
-                lambda resp: type(resp)
-                is msg_types[-1],  # pylint: disable=unidiomatic-typecheck
+                lambda resp: type(resp)  # pylint: disable=unidiomatic-typecheck
+                is msg_types[-1],
                 tuple(msg_types),
                 CONNECT_REQUEST_TIMEOUT,
             )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -411,9 +411,7 @@ class APIConnection:
             resp.api_version_major,
             resp.api_version_minor,
         )
-        api_version = APIVersion(
-            resp.api_version_major, resp.api_version_minor
-        )
+        api_version = APIVersion(resp.api_version_major, resp.api_version_minor)
         if api_version.major > 2:
             _LOGGER.error(
                 "%s: Incompatible version %s! Closing connection",
@@ -755,8 +753,9 @@ class APIConnection:
             await fut
         except asyncio_TimeoutError as err:
             timeout_expired = True
+            msg_types = ", ".join(t.__name__ for t in msg_types)
             raise TimeoutAPIError(
-                f"Timeout waiting for response to {type(send_msg).__name__} after {timeout}s"
+                f"Timeout waiting for response to {msg_types} after {timeout}s"
             ) from err
         finally:
             if not timeout_expired:
@@ -914,8 +913,8 @@ class APIConnection:
             # the esp will clean up the connection as soon
             # as possible.
             try:
-                await self.send_messages_await_response_complex(
-                    (DISCONNECT_REQUEST_MESSAGE,),
+                await self.send_message_await_response(
+                    DISCONNECT_REQUEST_MESSAGE,
                     DisconnectResponse,
                     timeout=DISCONNECT_RESPONSE_TIMEOUT,
                 )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -379,20 +379,18 @@ class APIConnection:
 
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
-        hello = self._make_hello_request()
+        messages = [self._make_hello_request()]
+        msg_types = [HelloResponse]
         if login:
-            messages = (hello, self._make_connect_request())
-            msg_types = (HelloResponse, ConnectResponse)
-        else:
-            messages = (hello,)
-            msg_types = (HelloResponse,)
+            messages.append(self._make_connect_request())
+            msg_types.append(ConnectResponse)
 
         try:
             responses = await self.send_messages_await_response_complex(
-                messages,
+                tuple(messages),
                 None,
                 lambda resp: type(resp) is msg_types[-1],
-                msg_types,
+                tuple(msg_types),
                 CONNECT_REQUEST_TIMEOUT,
             )
         except TimeoutAPIError as err:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -613,6 +613,16 @@ class APIConnection:
             connect.password = self._params.password
         return connect
 
+    def _send_messages(self, messages: tuple[message.Message, ...]) -> None:
+        """Send a message to the remote.
+
+        Currently this is a wrapper around send_message
+        but may be changed in the future to batch messages
+        together.
+        """
+        for msg in messages:
+            self.send_message(msg)
+
     def send_message(self, msg: message.Message) -> None:
         """Send a protobuf message to the remote."""
         if not self._handshake_complete:
@@ -728,8 +738,7 @@ class APIConnection:
         # Send the message right away to reduce latency.
         # This is safe because we are not awaiting between
         # sending the message and registering the handler
-        for msg in messages:
-            self.send_message(msg)
+        self._send_messages(messages)
         loop = self._loop
         # Unsafe to await between sending the message and registering the handler
         fut: asyncio.Future[None] = loop.create_future()

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -389,7 +389,8 @@ class APIConnection:
             responses = await self.send_messages_await_response_complex(
                 tuple(messages),
                 None,
-                lambda resp: type(resp) is msg_types[-1],
+                lambda resp: type(resp)
+                is msg_types[-1],  # pylint: disable=unidiomatic-typecheck
                 tuple(msg_types),
                 CONNECT_REQUEST_TIMEOUT,
             )

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -751,9 +751,9 @@ class APIConnection:
             await fut
         except asyncio_TimeoutError as err:
             timeout_expired = True
-            msg_types = ", ".join(t.__name__ for t in msg_types)
+            response_names = ", ".join(t.__name__ for t in msg_types)
             raise TimeoutAPIError(
-                f"Timeout waiting for response to {msg_types} after {timeout}s"
+                f"Timeout waiting for {response_names} after {timeout}s"
             ) from err
         finally:
             if not timeout_expired:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -369,6 +369,14 @@ class APIConnection:
             raise HandshakeAPIError(f"Handshake failed: {err}") from err
         self._set_connection_state(ConnectionState.HANDSHAKE_COMPLETE)
 
+    def _make_hello_request(self) -> HelloRequest:
+        """Make a HelloRequest."""
+        hello = HelloRequest()
+        hello.client_info = self._params.client_info
+        hello.api_version_major = 1
+        hello.api_version_minor = 9
+        return hello
+
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
         hello = self._make_hello_request()
@@ -605,14 +613,6 @@ class APIConnection:
         if self._params.password is not None:
             connect.password = self._params.password
         return connect
-
-    def _make_hello_request(self) -> HelloRequest:
-        """Make a HelloRequest."""
-        hello = HelloRequest()
-        hello.client_info = self._params.client_info
-        hello.api_version_major = 1
-        hello.api_version_minor = 9
-        return hello
 
     def send_message(self, msg: message.Message) -> None:
         """Send a protobuf message to the remote."""

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable
 from enum import Enum
 from typing import Callable
-import time
+
 import zeroconf
 from zeroconf.const import _TYPE_A as TYPE_A
 from zeroconf.const import _TYPE_PTR as TYPE_PTR

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ def patch_response_complex(client: APIClient, messages):
             raise ValueError("Response never stopped")
         return resp
 
-    client._connection.send_message_await_response_complex = patched
+    client._connection.send_messages_await_response_complex = patched
 
 
 def patch_response_callback(client: APIClient):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -176,9 +176,7 @@ async def test_timeout_sending_message(
     transport.write.assert_called_with(b"\x00\x00\x05")
 
     assert "disconnect request failed" in caplog.text
-    assert (
-        " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
-    )
+    assert " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -232,9 +230,7 @@ async def test_disconnect_when_not_fully_connected(
     transport.write.assert_called_with(b"\x00\x00\x05")
 
     assert "disconnect request failed" in caplog.text
-    assert (
-        " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
-    )
+    assert " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -177,7 +177,7 @@ async def test_timeout_sending_message(
 
     assert "disconnect request failed" in caplog.text
     assert (
-        " Timeout waiting for response to DisconnectRequest after 0.0s" in caplog.text
+        " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
     )
 
 
@@ -233,7 +233,7 @@ async def test_disconnect_when_not_fully_connected(
 
     assert "disconnect request failed" in caplog.text
     assert (
-        " Timeout waiting for response to DisconnectRequest after 0.0s" in caplog.text
+        " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
     )
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -20,13 +20,9 @@ from aioesphomeapi.api_pb2 import (
     PingRequest,
     PingResponse,
 )
-from aioesphomeapi.connection import (
-    PROTO_TO_MESSAGE_TYPE,
-    APIConnection,
-    ConnectionParams,
-    ConnectionState,
-)
+from aioesphomeapi.connection import APIConnection, ConnectionParams, ConnectionState
 from aioesphomeapi.core import (
+    MESSAGE_TYPE_TO_PROTO,
     APIConnectionError,
     HandshakeAPIError,
     InvalidAuthAPIError,
@@ -36,6 +32,9 @@ from aioesphomeapi.core import (
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
 
 from .common import async_fire_time_changed, utcnow
+
+PROTO_TO_MESSAGE_TYPE = {v: k for k, v in MESSAGE_TYPE_TO_PROTO.items()}
+
 
 logging.getLogger("aioesphomeapi").setLevel(logging.DEBUG)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -165,8 +165,8 @@ async def test_timeout_sending_message(
     await connect_task
 
     with pytest.raises(TimeoutAPIError):
-        await conn.send_message_await_response_complex(
-            PingRequest(), None, None, (PingResponse,), timeout=0
+        await conn.send_messages_await_response_complex(
+            (PingRequest(),), None, None, (PingResponse,), timeout=0
         )
 
     transport.reset_mock()
@@ -250,7 +250,7 @@ async def test_requires_encryption_propagates(conn: APIConnection):
         conn.connection_state = ConnectionState.CONNECTED
 
         with pytest.raises(RequiresEncryptionAPIError):
-            task = asyncio.create_task(conn._connect_hello())
+            task = asyncio.create_task(conn._connect_hello_login(login=True))
             await asyncio.sleep(0)
             protocol.data_received(b"\x01\x00\x00")
             await task


### PR DESCRIPTION
Current we send HelloRequest, wait for a response, than send ConnectRequest and wait for a response.

We can send the `HelloRequest` and `ConnectRequest`, and than wait for both responses instead as it reduces one round trip wait. 

This should speed up connecting with encryption enabled a little bit since it reported to be slow in https://github.com/home-assistant/core/issues/103517#issuecomment-1798017912

```
INFO Starting log output from largegarage.local using esphome API
INFO Successfully connected to largegarage in 0.061s
INFO Successful handshake with largegarage in 0.022s
[18:45:21][I][app:102]: ESPHome version 2023.11.0b2 compiled on Nov  8 2023, 23:13:11
```
```
INFO Starting log output from icemaker.local using esphome API
INFO Successfully connected to icemaker in 0.020s
INFO Successful handshake with icemaker in 0.045s
[18:46:15][I][app:102]: ESPHome version 2023.12.0-dev compiled on Nov  9 2023, 16:50:08
```