### PR TITLE
Make log runner code reusable and add coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ source = aioesphomeapi
 omit =
     aioesphomeapi/api_options_pb2.py
     aioesphomeapi/api_pb2.py
+    aioesphomeapi/log_reader.py
     bench/*.py
 
 [report]

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -7,16 +7,11 @@ import logging
 import sys
 from datetime import datetime
 
-import zeroconf
 
-from aioesphomeapi.api_pb2 import SubscribeLogsResponse  # type: ignore
-from aioesphomeapi.client import APIClient
-from aioesphomeapi.core import APIConnectionError
-from aioesphomeapi.model import LogLevel
-from aioesphomeapi.reconnect_logic import ReconnectLogic
+from .api_pb2 import SubscribeLogsResponse  # type: ignore
+from .client import APIClient
 
-_LOGGER = logging.getLogger(__name__)
-
+from .log_runner import async_run_logs
 
 async def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser("aioesphomeapi-logs")
@@ -42,41 +37,17 @@ async def main(argv: list[str]) -> None:
     )
 
     def on_log(msg: SubscribeLogsResponse) -> None:
-        time_ = datetime.now().time().strftime("[%H:%M:%S]")
-        text = msg.message
-        print(time_ + text.decode("utf8", "backslashreplace"))
+        time_ = datetime.now()
+        message: bytes = msg.message
+        text = message.decode("utf8", "backslashreplace")
+        print(f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]{text}")
 
-    has_connects = False
-
-    async def on_connect() -> None:
-        nonlocal has_connects
-        try:
-            await cli.subscribe_logs(
-                on_log,
-                log_level=LogLevel.LOG_LEVEL_VERY_VERBOSE,
-                dump_config=not has_connects,
-            )
-            has_connects = True
-        except APIConnectionError:
-            await cli.disconnect()
-
-    async def on_disconnect(  # pylint: disable=unused-argument
-        expected_disconnect: bool,
-    ) -> None:
-        _LOGGER.warning("Disconnected from API")
-
-    logic = ReconnectLogic(
-        client=cli,
-        on_connect=on_connect,
-        on_disconnect=on_disconnect,
-        zeroconf_instance=zeroconf.Zeroconf(),
-    )
-    await logic.start()
+    stop = await async_run_logs(cli, on_log)
     try:
         while True:
             await asyncio.sleep(60)
     except KeyboardInterrupt:
-        await logic.stop()
+        await stop()
 
 
 if __name__ == "__main__":

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -13,6 +13,7 @@ from .client import APIClient
 
 from .log_runner import async_run_logs
 
+
 async def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser("aioesphomeapi-logs")
     parser.add_argument("--port", type=int, default=6053)

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -58,4 +58,5 @@ def cli_entry_point() -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(cli_entry_point() or 0)
+    cli_entry_point()
+    sys.exit(0)

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -13,8 +13,6 @@ from .client import APIClient
 
 from .log_runner import async_run_logs
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser("aioesphomeapi-logs")
@@ -49,13 +47,16 @@ async def main(argv: list[str]) -> None:
     try:
         while True:
             await asyncio.sleep(60)
-    except KeyboardInterrupt:
+    finally:
         await stop()
 
 
 def cli() -> None:
     """Run the CLI."""
-    asyncio.run(main(sys.argv))
+    try:
+        asyncio.run(main(sys.argv))
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -7,10 +7,8 @@ import logging
 import sys
 from datetime import datetime
 
-
 from .api_pb2 import SubscribeLogsResponse  # type: ignore
 from .client import APIClient
-
 from .log_runner import async_run_logs
 
 

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -13,6 +13,8 @@ from .client import APIClient
 
 from .log_runner import async_run_logs
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser("aioesphomeapi-logs")
@@ -51,5 +53,10 @@ async def main(argv: list[str]) -> None:
         await stop()
 
 
+def cli() -> None:
+    """Run the CLI."""
+    asyncio.run(main(sys.argv))
+
+
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main(sys.argv)) or 0)
+    sys.exit(cli() or 0)

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -51,7 +51,7 @@ async def main(argv: list[str]) -> None:
         await stop()
 
 
-def cli() -> None:
+def cli_entry_point() -> None:
     """Run the CLI."""
     try:
         asyncio.run(main(sys.argv))
@@ -60,4 +60,4 @@ def cli() -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(cli() or 0)
+    sys.exit(cli_entry_point() or 0)

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -29,6 +29,8 @@ async def async_run_logs(
     dumped_config = not dump_config
 
     async def on_connect() -> None:
+        """Handle a connection."""
+        _LOGGER.warning("Connected to API")
         nonlocal dumped_config
         try:
             await cli.subscribe_logs(

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -52,4 +52,9 @@ async def async_run_logs(
         zeroconf_instance=zeroconf_instance or zeroconf.Zeroconf(),
     )
     await logic.start()
-    return logic.stop
+
+    async def _stop():
+        await logic.stop()
+        await cli.disconnect()
+
+    return _stop

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -30,7 +30,6 @@ async def async_run_logs(
 
     async def on_connect() -> None:
         """Handle a connection."""
-        _LOGGER.warning("Connected to API")
         nonlocal dumped_config
         try:
             await cli.subscribe_logs(

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -20,7 +20,7 @@ async def async_run_logs(
     log_level: LogLevel = LogLevel.LOG_LEVEL_VERY_VERBOSE,
     zeroconf_instance: zeroconf.Zeroconf | None = None,
     dump_config: bool = True,
-) -> Coroutine[Any, Any, None]:
+) -> Callable[[], Coroutine[Any, Any, None]]:
     """Run logs until canceled.
 
     Returns a coroutine that can be awaited to stop the logs.

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Callable, Coroutine
 
 import zeroconf
-from core import APIConnectionError
+from .core import APIConnectionError
 
 from .api_pb2 import SubscribeLogsResponse  # type: ignore
 from .client import APIClient
@@ -26,17 +26,17 @@ async def async_run_logs(
     Returns a coroutine that can be awaited to stop the logs.
     """
 
-    has_connects = dump_config
+    dumped_config = not dump_config
 
     async def on_connect() -> None:
-        nonlocal has_connects
+        nonlocal dumped_config
         try:
             await cli.subscribe_logs(
                 on_log,
                 log_level=log_level,
-                dump_config=not has_connects,
+                dump_config=not dumped_config,
             )
-            has_connects = True
+            dumped_config = True
         except APIConnectionError:
             await cli.disconnect()
 

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -55,7 +55,7 @@ async def async_run_logs(
     )
     await logic.start()
 
-    async def _stop():
+    async def _stop() -> None:
         await logic.stop()
         await cli.disconnect()
 

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -4,10 +4,10 @@ import logging
 from typing import Any, Callable, Coroutine
 
 import zeroconf
-from .core import APIConnectionError
 
 from .api_pb2 import SubscribeLogsResponse  # type: ignore
 from .client import APIClient
+from .core import APIConnectionError
 from .model import LogLevel
 from .reconnect_logic import ReconnectLogic
 

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Coroutine
+
+import zeroconf
+from core import APIConnectionError
+
+from .api_pb2 import SubscribeLogsResponse  # type: ignore
+from .client import APIClient
+from .model import LogLevel
+from .reconnect_logic import ReconnectLogic
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_run_logs(
+    cli: APIClient,
+    on_log: Callable[[SubscribeLogsResponse], None],
+    log_level: LogLevel = LogLevel.LOG_LEVEL_VERY_VERBOSE,
+    zeroconf_instance: zeroconf.Zeroconf | None = None,
+    dump_config: bool = True,
+) -> Coroutine[Any, Any, None]:
+    """Run logs until canceled.
+
+    Returns a coroutine that can be awaited to stop the logs.
+    """
+
+    has_connects = dump_config
+
+    async def on_connect() -> None:
+        nonlocal has_connects
+        try:
+            await cli.subscribe_logs(
+                on_log,
+                log_level=log_level,
+                dump_config=not has_connects,
+            )
+            has_connects = True
+        except APIConnectionError:
+            await cli.disconnect()
+
+    async def on_disconnect(  # pylint: disable=unused-argument
+        expected_disconnect: bool,
+    ) -> None:
+        _LOGGER.warning("Disconnected from API")
+
+    logic = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        zeroconf_instance=zeroconf_instance or zeroconf.Zeroconf(),
+    )
+    await logic.start()
+    return logic.stop

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_kwargs = {
     "python_requires": ">=3.9",
     "test_suite": "tests",
     "entry_points": {
-        'console_scripts': ['aioesphomeapi-logs=aioesphomeapi.log_reader:cli'],
+        'console_scripts': ['aioesphomeapi-logs=aioesphomeapi.log_reader:cli_entry_point'],
     },
 }
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup_kwargs = {
     "install_requires": REQUIRES,
     "python_requires": ">=3.9",
     "test_suite": "tests",
+    "entry_points": {
+        'console_scripts': ['aioesphomeapi-logs=aioesphomeapi.log_reader:cli'],
+    },
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 """aioesphomeapi setup script."""
 import os
-
-from setuptools import find_packages, setup
-import os
 from distutils.command.build_ext import build_ext
 
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -61,7 +59,9 @@ setup_kwargs = {
     "python_requires": ">=3.9",
     "test_suite": "tests",
     "entry_points": {
-        'console_scripts': ['aioesphomeapi-logs=aioesphomeapi.log_reader:cli_entry_point'],
+        "console_scripts": [
+            "aioesphomeapi-logs=aioesphomeapi.log_reader:cli_entry_point"
+        ],
     },
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,12 @@ from aioesphomeapi.client import APIClient, ConnectionParams
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
 
-from .common import PROTO_TO_MESSAGE_TYPE, connect, generate_plaintext_packet
+from .common import (
+    PROTO_TO_MESSAGE_TYPE,
+    connect,
+    generate_plaintext_packet,
+    send_plaintext_hello,
+)
 
 
 @pytest.fixture
@@ -132,14 +137,7 @@ async def api_client(
     ):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await connected.wait()
-        hello_response: message.Message = HelloResponse()
-        hello_response.api_version_major = 1
-        hello_response.api_version_minor = 9
-        hello_response.name = "fake"
-        hello_msg = hello_response.SerializeToString()
-        protocol.data_received(
-            generate_plaintext_packet(hello_msg, PROTO_TO_MESSAGE_TYPE[HelloResponse])
-        )
+        send_plaintext_hello(protocol)
         client._connection = conn
         await connect_task
         transport.reset_mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,20 +7,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from google.protobuf import message
 
 from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
-from aioesphomeapi.api_pb2 import HelloResponse
 from aioesphomeapi.client import APIClient, ConnectionParams
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
 
-from .common import (
-    PROTO_TO_MESSAGE_TYPE,
-    connect,
-    generate_plaintext_packet,
-    send_plaintext_hello,
-)
+from .common import connect, send_plaintext_hello
 
 
 @pytest.fixture

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,11 +7,9 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from google.protobuf import message
 
 from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
 from aioesphomeapi.api_pb2 import (
-    ConnectResponse,
     DeviceInfoResponse,
     HelloResponse,
     PingRequest,
@@ -27,10 +25,8 @@ from aioesphomeapi.core import (
 )
 
 from .common import (
-    PROTO_TO_MESSAGE_TYPE,
     async_fire_time_changed,
     connect,
-    generate_plaintext_packet,
     send_plaintext_connect_response,
     send_plaintext_hello,
     utcnow,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -31,6 +31,8 @@ from .common import (
     async_fire_time_changed,
     connect,
     generate_plaintext_packet,
+    send_plaintext_connect_response,
+    send_plaintext_hello,
     utcnow,
 )
 
@@ -441,22 +443,8 @@ async def test_connect_wrong_password(
 ) -> None:
     conn, transport, protocol, connect_task = plaintext_connect_task_with_login
 
-    hello_response: message.Message = HelloResponse()
-    hello_response.api_version_major = 1
-    hello_response.api_version_minor = 9
-    hello_response.name = "fake"
-    hello_msg = hello_response.SerializeToString()
-
-    connect_response: message.Message = ConnectResponse()
-    connect_response.invalid_password = True
-    connect_msg = connect_response.SerializeToString()
-
-    protocol.data_received(
-        generate_plaintext_packet(hello_msg, PROTO_TO_MESSAGE_TYPE[HelloResponse])
-    )
-    protocol.data_received(
-        generate_plaintext_packet(connect_msg, PROTO_TO_MESSAGE_TYPE[ConnectResponse])
-    )
+    send_plaintext_hello(protocol)
+    send_plaintext_connect_response(protocol, True)
 
     with pytest.raises(InvalidAuthAPIError):
         await connect_task
@@ -472,22 +460,8 @@ async def test_connect_correct_password(
 ) -> None:
     conn, transport, protocol, connect_task = plaintext_connect_task_with_login
 
-    hello_response: message.Message = HelloResponse()
-    hello_response.api_version_major = 1
-    hello_response.api_version_minor = 9
-    hello_response.name = "fake"
-    hello_msg = hello_response.SerializeToString()
-
-    connect_response: message.Message = ConnectResponse()
-    connect_response.invalid_password = False
-    connect_msg = connect_response.SerializeToString()
-
-    protocol.data_received(
-        generate_plaintext_packet(hello_msg, PROTO_TO_MESSAGE_TYPE[HelloResponse])
-    )
-    protocol.data_received(
-        generate_plaintext_packet(connect_msg, PROTO_TO_MESSAGE_TYPE[ConnectResponse])
-    )
+    send_plaintext_hello(protocol)
+    send_plaintext_connect_response(protocol, False)
 
     await connect_task
 

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -1,65 +1,19 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from google.protobuf import message
 
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.api_pb2 import SubscribeLogsResponse  # type: ignore
-from aioesphomeapi.api_pb2 import (
-    AlarmControlPanelCommandRequest,
-    BinarySensorStateResponse,
-    BluetoothDeviceClearCacheResponse,
-    BluetoothDeviceConnectionResponse,
-    BluetoothDevicePairingResponse,
-    BluetoothDeviceUnpairingResponse,
-    CameraImageRequest,
-    CameraImageResponse,
-    ClimateCommandRequest,
-    CoverCommandRequest,
-    DisconnectResponse,
-    ExecuteServiceArgument,
-    ExecuteServiceRequest,
-    FanCommandRequest,
-    LightCommandRequest,
-    ListEntitiesBinarySensorResponse,
-    ListEntitiesDoneResponse,
-    ListEntitiesServicesResponse,
-    LockCommandRequest,
-    MediaPlayerCommandRequest,
-    NumberCommandRequest,
-    SelectCommandRequest,
-    SwitchCommandRequest,
-    TextCommandRequest,
-)
+from aioesphomeapi.api_pb2 import DisconnectResponse
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.log_runner import async_run_logs
-from aioesphomeapi.model import (
-    AlarmControlPanelCommand,
-    APIVersion,
-    BinarySensorInfo,
-    BinarySensorState,
-    CameraState,
-    ClimateFanMode,
-    ClimateMode,
-    ClimatePreset,
-    ClimateSwingMode,
-    FanDirection,
-    FanSpeed,
-    LegacyCoverCommand,
-    LockCommand,
-    MediaPlayerCommand,
-    UserService,
-    UserServiceArg,
-    UserServiceArgType,
-)
-from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 
 from .common import (
     PROTO_TO_MESSAGE_TYPE,
     Estr,
-    connect,
     generate_plaintext_packet,
     get_mock_zeroconf,
     send_plaintext_connect_response,

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -1,0 +1,136 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from google.protobuf import message
+
+from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
+from aioesphomeapi.api_pb2 import SubscribeLogsResponse  # type: ignore
+from aioesphomeapi.api_pb2 import (
+    AlarmControlPanelCommandRequest,
+    BinarySensorStateResponse,
+    BluetoothDeviceClearCacheResponse,
+    BluetoothDeviceConnectionResponse,
+    BluetoothDevicePairingResponse,
+    BluetoothDeviceUnpairingResponse,
+    CameraImageRequest,
+    CameraImageResponse,
+    ClimateCommandRequest,
+    CoverCommandRequest,
+    DisconnectResponse,
+    ExecuteServiceArgument,
+    ExecuteServiceRequest,
+    FanCommandRequest,
+    LightCommandRequest,
+    ListEntitiesBinarySensorResponse,
+    ListEntitiesDoneResponse,
+    ListEntitiesServicesResponse,
+    LockCommandRequest,
+    MediaPlayerCommandRequest,
+    NumberCommandRequest,
+    SelectCommandRequest,
+    SwitchCommandRequest,
+    TextCommandRequest,
+)
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.connection import APIConnection
+from aioesphomeapi.log_runner import async_run_logs
+from aioesphomeapi.model import (
+    AlarmControlPanelCommand,
+    APIVersion,
+    BinarySensorInfo,
+    BinarySensorState,
+    CameraState,
+    ClimateFanMode,
+    ClimateMode,
+    ClimatePreset,
+    ClimateSwingMode,
+    FanDirection,
+    FanSpeed,
+    LegacyCoverCommand,
+    LockCommand,
+    MediaPlayerCommand,
+    UserService,
+    UserServiceArg,
+    UserServiceArgType,
+)
+from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
+
+from .common import (
+    PROTO_TO_MESSAGE_TYPE,
+    Estr,
+    connect,
+    generate_plaintext_packet,
+    get_mock_zeroconf,
+    send_plaintext_connect_response,
+    send_plaintext_hello,
+)
+
+
+@pytest.mark.asyncio
+async def test_log_runner(event_loop: asyncio.AbstractEventLoop, conn: APIConnection):
+    """Test the log runner logic."""
+    loop = asyncio.get_event_loop()
+    protocol: APIPlaintextFrameHelper | None = None
+    transport = MagicMock()
+    connected = asyncio.Event()
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    cli = PatchableAPIClient(
+        address=Estr("1.2.3.4"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=Estr("fake"),
+    )
+    messages = []
+
+    def on_log(msg: SubscribeLogsResponse) -> None:
+        messages.append(msg)
+
+    def _create_mock_transport_protocol(create_func, **kwargs):
+        nonlocal protocol
+        protocol = create_func()
+        protocol.connection_made(transport)
+        connected.set()
+        return transport, protocol
+
+    subscribed = asyncio.Event()
+    original_subscribe_logs = cli.subscribe_logs
+
+    async def _wait_subscribe_cli(*args, **kwargs):
+        await original_subscribe_logs(*args, **kwargs)
+        subscribed.set()
+
+    with patch.object(event_loop, "sock_connect"), patch.object(
+        loop, "create_connection", side_effect=_create_mock_transport_protocol
+    ), patch.object(cli, "subscribe_logs", _wait_subscribe_cli):
+        stop = await async_run_logs(cli, on_log, zeroconf_instance=get_mock_zeroconf())
+        await connected.wait()
+        protocol = cli._connection._frame_helper
+        send_plaintext_hello(protocol)
+        send_plaintext_connect_response(protocol, False)
+        await subscribed.wait()
+
+    response: message.Message = SubscribeLogsResponse()
+    response.message = b"Hello world"
+    protocol.data_received(
+        generate_plaintext_packet(
+            response.SerializeToString(),
+            PROTO_TO_MESSAGE_TYPE[SubscribeLogsResponse],
+        )
+    )
+    assert len(messages) == 1
+    assert messages[0].message == b"Hello world"
+    stop_task = asyncio.create_task(stop())
+    await asyncio.sleep(0)
+    disconnect_response = DisconnectResponse()
+    protocol.data_received(
+        generate_plaintext_packet(
+            disconnect_response.SerializeToString(),
+            PROTO_TO_MESSAGE_TYPE[DisconnectResponse],
+        )
+    )
+    await stop_task


### PR DESCRIPTION
The entry point was missing from `setup.py` so the `aioesphomeapi-logs` script was never created