### PR TITLE
Avoid building musllinux wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp*
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp* *musllinux*
           CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto aarch64


### PR DESCRIPTION
Home Assistant is already going to build these anyways for the wheel builder so its unlikely these are actually be used