### PR TITLE
Increase cli tool logging timestamps to include nanoseconds

### DIFF
--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -24,7 +24,7 @@ async def main(argv: list[str]) -> None:
     args = parser.parse_args(argv[1:])
 
     logging.basicConfig(
-        format="%(asctime)s %(levelname)-8s %(message)s",
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
         level=logging.DEBUG if args.verbose else logging.INFO,
         datefmt="%Y-%m-%d %H:%M:%S",
     )


### PR DESCRIPTION
I'm trying to figure out why there is a three second delay when connecting with noise


It seems the handshake finishes rather quickly but it can't read the first encrypted packet from the api for ~3s
```
[22:07:37][D][api.connection:181]: aioesphomeapi (192.168.209.204) requested disconnected
[22:07:37][VV][api.service:031]: send_disconnect_response: DisconnectResponse {}
[22:07:37][V][api:115]: Removing connection to aioesphomeapi
[22:07:38][D][api:102]: Accepted 192.168.209.204
[22:07:38][VV][api.socket:696]: 192.168.209.204: Handshake complete!
[22:07:38][W][component:214]: Component api took a long time for an operation (0.36 s).
[22:07:38][W][component:215]: Components should block for at most 20-30ms.
[22:07:41][VV][api.service:522]: on_hello_request: HelloRequest {
[22:07:41]  client_info: 'aioesphomeapi'
[22:07:41]  api_version_major: 1
[22:07:41]  api_version_minor: 9
[22:07:41]}
[22:07:41][V][api.connection:1070]: Hello from client: 'aioesphomeapi' | 192.168.209.204 | API Version 1.9
[22:07:41][VV][api.service:013]: send_hello_response: HelloResponse {
```