### PR TITLE
Add the ability to pass the name the reconnect logic when running logs

### DIFF
--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -21,6 +21,7 @@ async def async_run(
     log_level: LogLevel = LogLevel.LOG_LEVEL_VERY_VERBOSE,
     aio_zeroconf_instance: AsyncZeroconf | None = None,
     dump_config: bool = True,
+    name: str | None = None,
 ) -> Callable[[], Coroutine[Any, Any, None]]:
     """Run logs until canceled.
 
@@ -54,6 +55,7 @@ async def async_run(
         on_connect=on_connect,
         on_disconnect=on_disconnect,
         zeroconf_instance=aiozc.zeroconf,
+        name=name,
     )
     await logic.start()
 


### PR DESCRIPTION
This allows the `zeroconf` logic to work to watch for a device to come back online after it goes offline when an ip is passed to connect

It also gives a nicer output

```
INFO Reading configuration winefridge.yaml...
INFO Starting log output from 192.168.214.210 using esphome API
INFO Successfully connected to winefridge @ 192.168.214.210 in 0.021s
INFO Successful handshake with winefridge @ 192.168.214.210 in 0.043s
```

vs
```
INFO Reading configuration winefridge.yaml...
INFO Starting log output from 192.168.214.210 using esphome API
INFO Successfully connected to 192.168.214.210 in 0.021s
INFO Successful handshake with 192.168.214.210 in 0.043s

```