### PR TITLE
Refactor frame helper to allow sending multiple packets at once

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -26,3 +26,5 @@ cdef class APIFrameHelper:
 
     @cython.locals(end_of_frame_pos=cython.uint)
     cdef _remove_from_buffer(self)
+
+    cpdef write_packets(self, list packets)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -28,3 +28,5 @@ cdef class APIFrameHelper:
     cdef _remove_from_buffer(self)
 
     cpdef write_packets(self, list packets)
+
+    cpdef close(self)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -28,5 +28,3 @@ cdef class APIFrameHelper:
     cdef _remove_from_buffer(self)
 
     cpdef write_packets(self, list packets)
-
-    cpdef close(self)

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -127,8 +127,11 @@ class APIFrameHelper:
             handshake_handle.cancel()
 
     @abstractmethod
-    def write_packet(self, type_: int, data: bytes) -> None:
-        """Write a packet to the socket."""
+    def write_packets(self, packets: list[tuple[int, bytes]]) -> None:
+        """Write a packets to the socket.
+
+        Packets are in the format of tuple[protobuf_type, protobuf_data]
+        """
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """Handle a new connection."""

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -36,6 +36,9 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         data=bytes,
         packet=tuple,
         data_len=cython.uint,
+        frame=bytes,
         frame_len=cython.uint
     )
     cpdef write_packets(self, list packets)
+
+    cpdef close(self)

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -40,5 +40,3 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         frame_len=cython.uint
     )
     cpdef write_packets(self, list packets)
-
-    cpdef close(self)

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -32,7 +32,10 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cpdef _handle_frame(self, bytes data)
 
     @cython.locals(
+        type_="unsigned int",
+        data=bytes,
+        packet=tuple,
         data_len=cython.uint,
         frame_len=cython.uint
     )
-    cpdef write_packet(self, cython.uint type_, bytes data)
+    cpdef write_packets(self, list packets)

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -317,6 +317,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             assert self._writer is not None, "Writer is not set"
 
         out: list[bytes] = []
+        debug_enabled = self._debug_enabled()
         for packet in packets:
             type_: int = packet[0]
             data: bytes = packet[1]
@@ -331,7 +332,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             )
             frame = self._encrypt(data_header + data)
 
-            if self._debug_enabled():
+            if debug_enabled is True:
                 _LOGGER.debug("%s: Sending frame: [%s]", self._log_name, frame.hex())
 
             frame_len = len(frame)

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -322,7 +322,12 @@ class APINoiseFrameHelper(APIFrameHelper):
             data: bytes = packet[1]
             data_len = len(data)
             data_header = bytes(
-                ((type_ >> 8) & 0xFF, type_ & 0xFF, (data_len >> 8) & 0xFF, data_len & 0xFF)
+                (
+                    (type_ >> 8) & 0xFF,
+                    type_ & 0xFF,
+                    (data_len >> 8) & 0xFF,
+                    data_len & 0xFF,
+                )
             )
             frame = self._encrypt(data_header + data)
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -244,13 +244,13 @@ class APINoiseFrameHelper(APIFrameHelper):
             psk_bytes = base64.b64decode(psk)
         except ValueError:
             raise InvalidEncryptionKeyAPIError(
-                f"{self._log_name}: Malformed PSK {psk}, expected "
+                f"{self._log_name}: Malformed PSK `{psk}`, expected "
                 "base64-encoded value",
                 server_name,
             )
         if len(psk_bytes) != 32:
             raise InvalidEncryptionKeyAPIError(
-                f"{self._log_name}:Malformed PSK {psk}, expected"
+                f"{self._log_name}:Malformed PSK `{psk}`, expected"
                 f" 32-bytes of base64 data",
                 server_name,
             )

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import base64
+import binascii
 import logging
 from enum import Enum
 from functools import partial
@@ -241,7 +241,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         psk = self._noise_psk
         server_name = self._server_name
         try:
-            psk_bytes = base64.b64decode(psk)
+            psk_bytes = binascii.a2b_base64(psk)
         except ValueError:
             raise InvalidEncryptionKeyAPIError(
                 f"{self._log_name}: Malformed PSK `{psk}`, expected "

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -28,3 +28,10 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
     cpdef data_received(self, bytes data)
 
     cpdef _error_on_incorrect_preamble(self, object preamble)
+
+    @cython.locals(
+        type_="unsigned int",
+        data=bytes,
+        packet=tuple
+    )
+    cpdef write_packets(self, list packets)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -78,7 +78,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             out.append(varuint_to_bytes(type_))
             out.append(data)
             if self._debug_enabled():
-                _LOGGER.debug("%s: Sending plaintext frame %s", self._log_name, data.hex())
+                _LOGGER.debug(
+                    "%s: Sending plaintext frame %s", self._log_name, data.hex()
+                )
 
         try:
             self._writer(b"".join(out))

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -70,6 +70,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             assert self._writer is not None, "Writer should be set"
 
         out: list[bytes] = []
+        debug_enabled = self._debug_enabled()
         for packet in packets:
             type_: int = packet[0]
             data: bytes = packet[1]
@@ -77,7 +78,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             out.append(varuint_to_bytes(len(data)))
             out.append(varuint_to_bytes(type_))
             out.append(data)
-            if self._debug_enabled():
+            if debug_enabled is True:
                 _LOGGER.debug(
                     "%s: Sending plaintext frame %s", self._log_name, data.hex()
                 )

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -2,6 +2,7 @@ import cython
 
 from ._frame_helper.base cimport APIFrameHelper
 
+
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
 

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -1,5 +1,6 @@
 import cython
 
+from ._frame_helper.base cimport APIFrameHelper
 
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
@@ -47,7 +48,7 @@ cdef class APIConnection:
     cdef public object on_stop
     cdef object _on_stop_task
     cdef public object _socket
-    cdef public object _frame_helper
+    cdef public APIFrameHelper _frame_helper
     cdef public object api_version
     cdef public object connection_state
     cdef dict _message_handlers

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -69,6 +69,8 @@ cdef class APIConnection:
 
     cpdef send_message(self, object msg)
 
+    cdef send_messages(self, tuple messages)
+
     @cython.locals(handlers=set, handlers_copy=set)
     cpdef _process_packet(self, object msg_type_proto, object data)
 
@@ -89,5 +91,3 @@ cdef class APIConnection:
 
     @cython.locals(handlers=set)
     cpdef _remove_message_callback(self, object on_message, tuple msg_types)
-
-    cdef _send_messages(self, tuple messages)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -629,14 +629,16 @@ class APIConnection:
                 f"Connection isn't established yet ({self.connection_state})"
             )
 
-        packets:list[tuple[int,bytes]] = []
+        packets: list[tuple[int, bytes]] = []
         for msg in msgs:
             msg_type = type(msg)
             if (message_type := PROTO_TO_MESSAGE_TYPE.get(msg_type)) is None:
                 raise ValueError(f"Message type id not found for type {msg_type}")
 
             if self._debug_enabled() is True:
-                _LOGGER.debug("%s: Sending %s: %s", self.log_name, msg_type.__name__, msg)
+                _LOGGER.debug(
+                    "%s: Sending %s: %s", self.log_name, msg_type.__name__, msg
+                )
 
             if TYPE_CHECKING:
                 assert self._frame_helper is not None

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -630,21 +630,24 @@ class APIConnection:
             )
 
         packets: list[tuple[int, bytes]] = []
+        debug_enabled = self._debug_enabled()
+
+
         for msg in msgs:
             msg_type = type(msg)
             if (message_type := PROTO_TO_MESSAGE_TYPE.get(msg_type)) is None:
                 raise ValueError(f"Message type id not found for type {msg_type}")
 
-            if self._debug_enabled() is True:
+            if debug_enabled is True:
                 _LOGGER.debug(
                     "%s: Sending %s: %s", self.log_name, msg_type.__name__, msg
                 )
 
-            if TYPE_CHECKING:
-                assert self._frame_helper is not None
+            packets.append((message_type, msg.SerializeToString()))
 
-            encoded = msg.SerializeToString()
-            packets.append((message_type, encoded))
+
+        if TYPE_CHECKING:
+            assert self._frame_helper is not None
 
         try:
             self._frame_helper.write_packets(packets)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -632,7 +632,6 @@ class APIConnection:
         packets: list[tuple[int, bytes]] = []
         debug_enabled = self._debug_enabled()
 
-
         for msg in msgs:
             msg_type = type(msg)
             if (message_type := PROTO_TO_MESSAGE_TYPE.get(msg_type)) is None:
@@ -644,7 +643,6 @@ class APIConnection:
                 )
 
             packets.append((message_type, msg.SerializeToString()))
-
 
         if TYPE_CHECKING:
             assert self._frame_helper is not None

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -475,7 +475,7 @@ async def test_noise_frame_helper_handshake_success_with_single_packet():
     assert not writes
 
     await handshake_task
-    helper.write_packet(1, b"to device")
+    helper.write_packets([(1, b"to device")])
     encrypted_packet = writes.pop()
     header = encrypted_packet[0:1]
     assert header == b"\x01"


### PR DESCRIPTION
Since we set `TCP_NODELAY` it means all packets get written to the wire as soon as the buffer has space which means they get written almost right away in most cases. When we know we need to send multiple packets there was no way to send them in one write which increased protocol latency. To fix this write_packet is now write_packets which will do the write to the transport in a single go which increases the change the ESP will not have to transfer data from the stack multiple times to read incoming data.

