### PR TITLE
Refactor frame helper to avoid py conversions when processing packets

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -1,30 +1,31 @@
 
 import cython
 
+from ..connection cimport APIConnection
+
 
 cdef bint TYPE_CHECKING
 
 cdef class APIFrameHelper:
 
     cdef object _loop
-    cdef object _on_pkt
-    cdef object _on_error
+    cdef APIConnection _connection
     cdef object _transport
     cdef public object _writer
     cdef public object _ready_future
     cdef bytes _buffer
-    cdef cython.uint _buffer_len
-    cdef cython.uint _pos
+    cdef unsigned int _buffer_len
+    cdef unsigned int _pos
     cdef object _client_info
     cdef str _log_name
     cdef object _debug_enabled
 
-    @cython.locals(original_pos=cython.uint, new_pos=cython.uint)
+    @cython.locals(original_pos="unsigned int", new_pos="unsigned int")
     cdef bytes _read_exactly(self, int length)
 
     cdef _add_to_buffer(self, bytes data)
 
-    @cython.locals(end_of_frame_pos=cython.uint)
+    @cython.locals(end_of_frame_pos="unsigned int")
     cdef _remove_from_buffer(self)
 
     cpdef write_packets(self, list packets)

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -1,5 +1,6 @@
 import cython
 
+from ..connection cimport APIConnection
 from .base cimport APIFrameHelper
 
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -25,6 +25,9 @@ from ..core import (
 )
 from .base import WRITE_EXCEPTIONS, APIFrameHelper
 
+if TYPE_CHECKING:
+    from ..connection import APIConnection
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -81,15 +84,14 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def __init__(
         self,
-        on_pkt: Callable[[int, bytes], None],
-        on_error: Callable[[Exception], None],
+        connection: "APIConnection",
         noise_psk: str,
         expected_name: str | None,
         client_info: str,
         log_name: str,
     ) -> None:
         """Initialize the API frame helper."""
-        super().__init__(on_pkt, on_error, client_info, log_name)
+        super().__init__(connection, client_info, log_name)
         self._noise_psk = noise_psk
         self._expected_name = expected_name
         self._set_state(NoiseConnectionState.HELLO)
@@ -364,7 +366,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         # N bytes: message data
         type_high = msg[0]
         type_low = msg[1]
-        self._on_pkt((type_high << 8) | type_low, msg[4:])
+        self._connection.process_packet((type_high << 8) | type_low, msg[4:])
 
     def _handle_closed(self, frame: bytes) -> None:  # pylint: disable=unused-argument
         """Handle a closed frame."""

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -1,5 +1,6 @@
 import cython
 
+from ..connection cimport APIConnection
 from .base cimport APIFrameHelper
 
 

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -166,7 +166,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 packet_data = maybe_packet_data
 
             self._remove_from_buffer()
-            self._on_pkt(msg_type_int, packet_data)
+            self._connection.process_packet(msg_type_int, packet_data)
             # If we have more data, continue processing
 
     def _error_on_incorrect_preamble(self, preamble: _int) -> None:

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -74,7 +74,7 @@ cdef class APIConnection:
     cdef send_messages(self, tuple messages)
 
     @cython.locals(handlers=set, handlers_copy=set)
-    cpdef _process_packet(self, object msg_type_proto, object data)
+    cpdef process_packet(self, object msg_type_proto, object data)
 
     cpdef _async_cancel_pong_timer(self)
 
@@ -84,7 +84,7 @@ cdef class APIConnection:
 
     cpdef _set_connection_state(self, object state)
 
-    cpdef _report_fatal_error(self, Exception err)
+    cpdef report_fatal_error(self, Exception err)
 
     @cython.locals(handlers=set)
     cpdef _add_message_callback_without_remove(self, object on_message, tuple msg_types)

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import base64
 from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from noise.connection import NoiseConnection  # type: ignore[import-untyped]
 
+from aioesphomeapi import APIConnection
 from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi._frame_helper.base import WRITE_EXCEPTIONS
 from aioesphomeapi._frame_helper.noise import ESPHOME_NOISE_BACKEND, NOISE_HELLO
@@ -29,6 +31,24 @@ from aioesphomeapi.core import (
 from .common import async_fire_time_changed, utcnow
 
 PREAMBLE = b"\x00"
+
+
+def _make_mock_connection() -> tuple[APIConnection, list[tuple[int, bytes]]]:
+    """Make a mock connection."""
+    packets: list[tuple[int, bytes]] = []
+
+    class MockConnection(APIConnection):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Swallow args."""
+
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
+
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
+    return connection, packets
 
 
 class MockAPINoiseFrameHelper(APINoiseFrameHelper):
@@ -97,17 +117,7 @@ class MockAPINoiseFrameHelper(APINoiseFrameHelper):
 )
 async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
     for _ in range(3):
-        packets = []
-
-        class MockConnection:
-            def process_packet(self, type_: int, data: bytes):
-                packets.append((type_, data))
-
-            def report_fatal_error(self, exc: Exception):
-                raise exc
-
-        connection = MockConnection()
-
+        connection, packets = _make_mock_connection()
         helper = APIPlaintextFrameHelper(
             connection=connection, client_info="my client", log_name="test"
         )
@@ -142,16 +152,7 @@ async def test_noise_frame_helper_incorrect_key():
         "01000d01736572766963657465737400",
         "0100160148616e647368616b65204d4143206661696c757265",
     ]
-    packets = []
-
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, _ = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,
@@ -185,16 +186,7 @@ async def test_noise_frame_helper_incorrect_key_fragments():
         "01000d01736572766963657465737400",
         "0100160148616e647368616b65204d4143206661696c757265",
     ]
-    packets = []
-
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, _ = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,
@@ -230,16 +222,7 @@ async def test_noise_incorrect_name():
         "01000d01736572766963657465737400",
         "0100160148616e647368616b65204d4143206661696c757265",
     ]
-    packets = []
-
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, _ = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,
@@ -269,16 +252,8 @@ async def test_noise_timeout():
         "010000",  # hello packet
         "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4",
     ]
-    packets = []
 
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, _ = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,
@@ -328,20 +303,12 @@ async def test_noise_frame_helper_handshake_failure():
     """Test the noise frame helper handshake failure."""
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     psk_bytes = base64.b64decode(noise_psk)
-    packets = []
     writes = []
 
     def _writer(data: bytes):
         writes.append(data)
 
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, _ = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,
@@ -411,20 +378,12 @@ async def test_noise_frame_helper_handshake_success_with_single_packet():
     """Test the noise frame helper handshake success with a single packet."""
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     psk_bytes = base64.b64decode(noise_psk)
-    packets = []
     writes = []
 
     def _writer(data: bytes):
         writes.append(data)
 
-    class MockConnection:
-        def process_packet(self, type_: int, data: bytes):
-            packets.append((type_, data))
-
-        def report_fatal_error(self, exc: Exception):
-            raise exc
-
-    connection = MockConnection()
+    connection, packets = _make_mock_connection()
 
     helper = MockAPINoiseFrameHelper(
         connection=connection,

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -99,14 +99,17 @@ async def test_plaintext_frame_helper(in_bytes, pkt_data, pkt_type):
     for _ in range(3):
         packets = []
 
-        def _packet(type_: int, data: bytes):
-            packets.append((type_, data))
+        class MockConnection:
+            def process_packet(self, type_: int, data: bytes):
+                packets.append((type_, data))
 
-        def _on_error(exc: Exception):
-            raise exc
+            def report_fatal_error(self, exc: Exception):
+                raise exc
+
+        connection = MockConnection()
 
         helper = APIPlaintextFrameHelper(
-            on_pkt=_packet, on_error=_on_error, client_info="my client", log_name="test"
+            connection=connection, client_info="my client", log_name="test"
         )
 
         helper.data_received(in_bytes)
@@ -141,15 +144,17 @@ async def test_noise_frame_helper_incorrect_key():
     ]
     packets = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
 
-    def _on_error(exc: Exception):
-        raise exc
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
         client_info="my client",
@@ -182,15 +187,17 @@ async def test_noise_frame_helper_incorrect_key_fragments():
     ]
     packets = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
 
-    def _on_error(exc: Exception):
-        raise exc
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="servicetest",
         client_info="my client",
@@ -225,15 +232,17 @@ async def test_noise_incorrect_name():
     ]
     packets = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
 
-    def _on_error(exc: Exception):
-        raise exc
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="wrongname",
         client_info="my client",
@@ -262,15 +271,17 @@ async def test_noise_timeout():
     ]
     packets = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
 
-    def _on_error(exc: Exception):
-        raise exc
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
         expected_name="wrongname",
         client_info="my client",
@@ -320,18 +331,20 @@ async def test_noise_frame_helper_handshake_failure():
     packets = []
     writes = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
-
     def _writer(data: bytes):
         writes.append(data)
 
-    def _on_error(exc: Exception):
-        raise exc
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
+
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk=noise_psk,
         expected_name="servicetest",
         client_info="my client",
@@ -401,18 +414,20 @@ async def test_noise_frame_helper_handshake_success_with_single_packet():
     packets = []
     writes = []
 
-    def _packet(type_: int, data: bytes):
-        packets.append((type_, data))
-
     def _writer(data: bytes):
         writes.append(data)
 
-    def _on_error(exc: Exception):
-        raise exc
+    class MockConnection:
+        def process_packet(self, type_: int, data: bytes):
+            packets.append((type_, data))
+
+        def report_fatal_error(self, exc: Exception):
+            raise exc
+
+    connection = MockConnection()
 
     helper = MockAPINoiseFrameHelper(
-        on_pkt=_packet,
-        on_error=_on_error,
+        connection=connection,
         noise_psk=noise_psk,
         expected_name="servicetest",
         client_info="my client",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -35,8 +35,7 @@ from .common import (
 
 def _get_mock_protocol(conn: APIConnection):
     protocol = APIPlaintextFrameHelper(
-        on_pkt=conn._process_packet,
-        on_error=conn._report_fatal_error,
+        connection=conn,
         client_info="mock",
         log_name="mock_device",
     )


### PR DESCRIPTION
Since frame helper know about the `APIConnection` object now it can stay in native code the whole time to call the `process_packet` and `report_fatal_error` functions.  Its a bit more tight coupling but frame helper is already tightly coupled to connection and its all internal anyways.

This makes processing incoming packets ~21% faster 