### PR TITLE
Ensure expected_disconnect is True when sending DisconnectResponse fails

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -883,8 +883,11 @@ class APIConnection:
         self, _msg: DisconnectRequest
     ) -> None:
         """Handle a DisconnectRequest."""
-        self.send_message(DISCONNECT_RESPONSE_MESSAGE)
+        # Set _expected_disconnect to True before sending
+        # the response if for some reason sending the response
+        # fails we will still mark the disconnect as expected
         self._expected_disconnect = True
+        self.send_message(DISCONNECT_RESPONSE_MESSAGE)
         self._cleanup()
 
     def _handle_ping_request_internal(  # pylint: disable=unused-argument

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -485,7 +485,6 @@ async def test_force_disconnect_fails(
     with patch.object(protocol, "_writer", side_effect=OSError):
         await conn.force_disconnect()
     assert "Failed to send (forced) disconnect request" in caplog.text
-    assert conn._expected_disconnect is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,11 +7,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aioesphomeapi.api_pb2 import DisconnectRequest
-from aioesphomeapi.core import SocketAPIError
+
 from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
 from aioesphomeapi.api_pb2 import (
     DeviceInfoResponse,
+    DisconnectRequest,
     HelloResponse,
     PingRequest,
     PingResponse,
@@ -22,13 +22,14 @@ from aioesphomeapi.core import (
     HandshakeAPIError,
     InvalidAuthAPIError,
     RequiresEncryptionAPIError,
+    SocketAPIError,
     TimeoutAPIError,
 )
 
 from .common import (
-    generate_plaintext_packet,
     async_fire_time_changed,
     connect,
+    generate_plaintext_packet,
     send_plaintext_connect_response,
     send_plaintext_hello,
     utcnow,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -465,7 +465,6 @@ async def test_connect_correct_password(
     assert conn.is_connected
 
 
-
 @pytest.mark.asyncio
 async def test_force_disconnect_fails(
     caplog: pytest.LogCaptureFixture,
@@ -481,12 +480,10 @@ async def test_force_disconnect_fails(
     await connect_task
     assert conn.is_connected
 
-    with patch.object(protocol,"write_packets", side_effect=SocketAPIError):
+    with patch.object(protocol, "_writer", side_effect=OSError):
         await conn.force_disconnect()
     assert "Failed to send (forced) disconnect request" in caplog.text
     assert conn._expected_disconnect is True
-
-
 
 
 @pytest.mark.asyncio
@@ -504,7 +501,9 @@ async def test_disconnect_fails_to_send_response(
     await connect_task
     assert conn.is_connected
 
-    with pytest.raises(SocketAPIError), patch.object(protocol,"write_packets", side_effect=SocketAPIError):
+    with pytest.raises(SocketAPIError), patch.object(
+        protocol, "_writer", side_effect=OSError
+    ):
         disconnect_request = DisconnectRequest()
         protocol.data_received(generate_plaintext_packet(disconnect_request))
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -492,6 +492,8 @@ async def test_force_disconnect_fails(
 async def test_disconnect_fails_to_send_response(
     connection_params: ConnectionParams,
     event_loop: asyncio.AbstractEventLoop,
+    resolve_host,
+    socket_socket
 ) -> None:
     loop = asyncio.get_event_loop()
     protocol: APIPlaintextFrameHelper | None = None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -493,7 +493,7 @@ async def test_disconnect_fails_to_send_response(
     connection_params: ConnectionParams,
     event_loop: asyncio.AbstractEventLoop,
     resolve_host,
-    socket_socket
+    socket_socket,
 ) -> None:
     loop = asyncio.get_event_loop()
     protocol: APIPlaintextFrameHelper | None = None


### PR DESCRIPTION
If the ESP sends `DisconnectRequest` and shuts down the connection immediately before we can reply with `DisconnectResponse`, `expected_disconnect` could fail to be set because it was set after `DisconnectResponse` was sent.  I've never seen this actually happen but given the related issues below we should fix this race to eliminate it as a future problem.

related issues: https://github.com/esphome/issues/issues/4794 and https://github.com/esphome/issues/issues/5013

Although I don't think this will fix that problem since nobody reported that there was an error in the log about not being able to write the `DisconnectResponse`, but we should still fix this race.

