### PR TITLE
Small cleanups to connection

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -451,7 +451,7 @@ class APIClient:
 
         assert self._connection is not None
         resp = await self._connection.send_messages_await_response_complex(
-            (ListEntitiesRequest(),), do_append, do_stop, msg_types, timeout=60
+            (ListEntitiesRequest(),), do_append, do_stop, msg_types, 60
         )
         entities: list[EntityInfo] = []
         services: list[UserService] = []
@@ -567,7 +567,7 @@ class APIClient:
 
         message_filter = partial(self._filter_bluetooth_message, address, handle)
         resp = await self._connection.send_messages_await_response_complex(
-            (request,), message_filter, message_filter, msg_types, timeout=timeout
+            (request,), message_filter, message_filter, msg_types, timeout
         )
 
         if isinstance(resp[0], BluetoothGATTErrorResponse):
@@ -893,7 +893,7 @@ class APIClient:
             do_append,
             do_stop,
             msg_types,
-            timeout=DEFAULT_BLE_TIMEOUT,
+            DEFAULT_BLE_TIMEOUT,
         )
         services = []
         for msg in resp:

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -2,6 +2,7 @@ import cython
 
 from ._frame_helper.base cimport APIFrameHelper
 
+
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
 

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -42,6 +42,7 @@ cdef object PingFailedAPIError
 cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
 
+cdef object in_do_connect
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -42,7 +42,7 @@ cdef object PingFailedAPIError
 cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
 
-cdef object in_do_connect
+cdef object in_do_connect, astuple
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -2,7 +2,6 @@ import cython
 
 from ._frame_helper.base cimport APIFrameHelper
 
-
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
 
@@ -43,9 +42,21 @@ cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
 
 
+
+@cython.dataclasses.dataclass
+cdef class ConnectionParams:
+    cdef public str address
+    cdef public object port
+    cdef public object password
+    cdef public object client_info
+    cdef public object keepalive
+    cdef public object zeroconf_manager
+    cdef public object noise_psk
+    cdef public object expected_name
+
 cdef class APIConnection:
 
-    cdef object _params
+    cdef ConnectionParams _params
     cdef public object on_stop
     cdef object _on_stop_task
     cdef public object _socket
@@ -95,3 +106,9 @@ cdef class APIConnection:
 
     @cython.locals(handlers=set)
     cpdef _remove_message_callback(self, object on_message, tuple msg_types)
+
+    cpdef _handle_disconnect_request_internal(self, object msg)
+
+    cpdef _handle_ping_request_internal(self, object msg)
+
+    cpdef _handle_get_time_request_internal(self, object msg)

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -33,7 +33,7 @@ cdef object partial
 cdef object hr
 
 cdef object RESOLVE_TIMEOUT
-cdef object CONNECT_AND_SETUP_TIMEOUT
+cdef object CONNECT_AND_SETUP_TIMEOUT, CONNECT_REQUEST_TIMEOUT
 
 cdef object APIConnectionError
 cdef object BadNameAPIError

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -339,7 +339,8 @@ class APIConnection:
         """Step 3 in connect process: initialize the frame helper and init read loop."""
         fh: APIPlaintextFrameHelper | APINoiseFrameHelper
         loop = self._loop
-        assert self._socket is not None
+        if TYPE_CHECKING:
+            assert self._socket is not None
 
         if (noise_psk := self._params.noise_psk) is None:
             _, fh = await loop.create_connection(  # type: ignore[type-var]

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -386,7 +386,7 @@ class APIConnection:
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
         messages = [self._make_hello_request()]
-        msg_types = (HelloResponse,)
+        msg_types = [HelloResponse]
         if login:
             messages.append(self._make_connect_request())
             msg_types.append(ConnectResponse)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -386,7 +386,7 @@ class APIConnection:
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
         messages = [self._make_hello_request()]
-        msg_types = [HelloResponse]
+        msg_types = (HelloResponse,)
         if login:
             messages.append(self._make_connect_request())
             msg_types.append(ConnectResponse)
@@ -730,7 +730,7 @@ class APIConnection:
         do_append: Callable[[message.Message], bool] | None,
         do_stop: Callable[[message.Message], bool] | None,
         msg_types: tuple[type[Any], ...],
-        timeout: float,
+        timeout: _float,
     ) -> list[message.Message]:
         """Send a message to the remote and build up a list response.
 
@@ -780,7 +780,7 @@ class APIConnection:
         return responses
 
     async def send_message_await_response(
-        self, send_msg: message.Message, response_type: Any, timeout: float = 10.0
+        self, send_msg: message.Message, response_type: Any, timeout: _float = 10.0
     ) -> Any:
         [response] = await self.send_messages_await_response_complex(
             (send_msg,),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,7 +79,7 @@ def auth_client():
 
 
 def patch_response_complex(client: APIClient, messages):
-    async def patched(req, app, stop, msg_types, timeout=5.0):
+    async def patched(req, app, stop, msg_types, timeout):
         resp = []
         for msg in messages:
             if app(msg):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -97,7 +97,7 @@ async def test_timeout_sending_message(
 
     with pytest.raises(TimeoutAPIError):
         await conn.send_messages_await_response_complex(
-            (PingRequest(),), None, None, (PingResponse,), timeout=0
+            (PingRequest(),), None, None, (PingResponse,), 0
         )
 
     transport.reset_mock()


### PR DESCRIPTION
- Adds cython typing to ConnectionParams dataclass as we could not do this before since it is only newly supported in cython 3

- Switch a few calls from `send_message` to `send_messages` to avoid calling the wrapper

- Make timeout a required arg for `send_messages_await_response_complex` since we previously had problems with the default value and all places are now passing a timeout