### PR TITLE
Fix `eof_received` not raising SocketClosedAPIError

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -548,7 +548,7 @@ class APIConnection:
         """Ensure a fatal exception is wrapped as as an APIConnectionError."""
         if isinstance(ex, APIConnectionError):
             return ex
-        cause: Exception | None = None
+        cause: BaseException | None = None
         if isinstance(ex, CancelledError):
             err_str = f"{action.title()} connection cancelled"
             if self._fatal_exception:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -543,8 +543,8 @@ class APIConnection:
         self._set_connection_state(ConnectionState.SOCKET_OPENED)
 
     def _wrap_fatal_connection_exception(
-        self, action: str, ex: Exception
-    ) -> type[Exception] | None:
+        self, action: str, ex: BaseException
+    ) -> APIConnectionError:
         """Ensure a fatal exception is wrapped as as an APIConnectionError."""
         if isinstance(ex, APIConnectionError):
             return ex

--- a/tests/common.py
+++ b/tests/common.py
@@ -117,3 +117,14 @@ def send_plaintext_connect_response(
 def send_ping_response(protocol: APIPlaintextFrameHelper) -> None:
     ping_response: message.Message = PingResponse()
     protocol.data_received(generate_plaintext_packet(ping_response))
+
+
+def get_mock_protocol(conn: APIConnection):
+    protocol = APIPlaintextFrameHelper(
+        connection=conn,
+        client_info="mock",
+        log_name="mock_device",
+    )
+    transport = MagicMock()
+    protocol.connection_made(transport)
+    return protocol

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -22,9 +22,9 @@ from aioesphomeapi._frame_helper.plain_text import (
 from aioesphomeapi._frame_helper.plain_text import _varuint_to_bytes as varuint_to_bytes
 from aioesphomeapi.connection import ConnectionState
 from aioesphomeapi.core import (
+    APIConnectionError,
     BadNameAPIError,
     HandshakeAPIError,
-    APIConnectionError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
     SocketClosedAPIError,

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -594,6 +594,7 @@ async def test_init_plaintext_with_wrong_preamble(conn: APIConnection):
     with pytest.raises(ProtocolAPIError):
         await task
 
+
 @pytest.mark.asyncio
 async def test_eof_received_closes_connection(
     plaintext_connect_task_with_login: tuple[

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -586,9 +586,10 @@ async def test_init_plaintext_with_wrong_preamble(conn: APIConnection):
         loop.call_soon(conn._frame_helper._ready_future.set_result, None)
         conn.connection_state = ConnectionState.CONNECTED
 
-        with pytest.raises(ProtocolAPIError):
-            task = asyncio.create_task(conn._connect_hello_login(login=True))
-            await asyncio.sleep(0)
-            # The preamble should be \x00 but we send \x09
-            protocol.data_received(b"\x09\x00\x00")
-            await task
+    task = asyncio.create_task(conn._connect_hello_login(login=True))
+    await asyncio.sleep(0)
+    # The preamble should be \x00 but we send \x09
+    protocol.data_received(b"\x09\x00\x00")
+
+    with pytest.raises(ProtocolAPIError):
+        await task

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -24,6 +24,7 @@ from aioesphomeapi.connection import ConnectionState
 from aioesphomeapi.core import (
     BadNameAPIError,
     HandshakeAPIError,
+    APIConnectionError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
     SocketClosedAPIError,
@@ -604,6 +605,8 @@ async def test_eof_received_closes_connection(
     conn, transport, protocol, connect_task = plaintext_connect_task_with_login
     assert protocol.eof_received() is False
     assert conn.is_connected is False
+    with pytest.raises(SocketClosedAPIError, match="EOF received"):
+        await connect_task
 
 
 @pytest.mark.asyncio
@@ -617,3 +620,5 @@ async def test_connection_lost_closes_connection_and_logs(
     protocol.connection_lost(OSError("original message"))
     assert conn.is_connected is False
     assert "original message" in caplog.text
+    with pytest.raises(APIConnectionError, match="original message"):
+        await connect_task

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -25,7 +25,6 @@ from aioesphomeapi.core import (
     HandshakeAPIError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
-    SocketAPIError,
     SocketClosedAPIError,
 )
 
@@ -384,6 +383,9 @@ def test_bytes_to_varuint(val, encoded):
     assert bytes_to_varuint(encoded) == val
     assert cached_bytes_to_varuint(encoded) == val
 
+
+def test_bytes_to_varuint_invalid():
+    assert bytes_to_varuint(b"\xFF") is None
 
 @pytest.mark.asyncio
 async def test_noise_frame_helper_handshake_failure():

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -593,3 +593,26 @@ async def test_init_plaintext_with_wrong_preamble(conn: APIConnection):
 
     with pytest.raises(ProtocolAPIError):
         await task
+
+@pytest.mark.asyncio
+async def test_eof_received_closes_connection(
+    plaintext_connect_task_with_login: tuple[
+        APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
+    ],
+) -> None:
+    conn, transport, protocol, connect_task = plaintext_connect_task_with_login
+    assert protocol.eof_received() is False
+    assert conn.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_connection_lost_closes_connection_and_logs(
+    caplog: pytest.LogCaptureFixture,
+    plaintext_connect_task_with_login: tuple[
+        APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
+    ],
+) -> None:
+    conn, transport, protocol, connect_task = plaintext_connect_task_with_login
+    protocol.connection_lost(OSError("original message"))
+    assert conn.is_connected is False
+    assert "original message" in caplog.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -58,11 +58,7 @@ from aioesphomeapi.model import (
 )
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 
-from .common import (
-    Estr,
-    generate_plaintext_packet,
-    get_mock_zeroconf,
-)
+from .common import Estr, generate_plaintext_packet, get_mock_zeroconf
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,7 +59,6 @@ from aioesphomeapi.model import (
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 
 from .common import (
-    PROTO_TO_MESSAGE_TYPE,
     Estr,
     generate_plaintext_packet,
     get_mock_zeroconf,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -31,6 +31,7 @@ from .common import (
     async_fire_time_changed,
     connect,
     generate_plaintext_packet,
+    get_mock_protocol,
     send_ping_response,
     send_plaintext_connect_response,
     send_plaintext_hello,
@@ -39,17 +40,6 @@ from .common import (
 from .conftest import KEEP_ALIVE_INTERVAL
 
 KEEP_ALIVE_TIMEOUT_RATIO = 4.5
-
-
-def _get_mock_protocol(conn: APIConnection):
-    protocol = APIPlaintextFrameHelper(
-        connection=conn,
-        client_info="mock",
-        log_name="mock_device",
-    )
-    transport = MagicMock()
-    protocol.connection_made(transport)
-    return protocol
 
 
 @pytest.mark.asyncio
@@ -152,7 +142,7 @@ async def test_disconnect_when_not_fully_connected(
 @pytest.mark.asyncio
 async def test_requires_encryption_propagates(conn: APIConnection):
     loop = asyncio.get_event_loop()
-    protocol = _get_mock_protocol(conn)
+    protocol = get_mock_protocol(conn)
     with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
 
@@ -357,7 +347,7 @@ async def test_plaintext_connection_fails_handshake(
     """
     loop = asyncio.get_event_loop()
     exception, raised_exception = exception_map
-    protocol = _get_mock_protocol(conn)
+    protocol = get_mock_protocol(conn)
     messages = []
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -14,7 +14,6 @@ from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.log_runner import async_run
 
 from .common import (
-    PROTO_TO_MESSAGE_TYPE,
     Estr,
     generate_plaintext_packet,
     get_mock_async_zeroconf,


### PR DESCRIPTION
- Improve coverage for the frame helpers
- `APIConnectionError` was being raised intead of `SocketClosedAPIError` which made it harder to figure out why it failed