### PR TITLE
Remove in_do_connect contextvar

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -42,7 +42,7 @@ cdef object PingFailedAPIError
 cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
 
-cdef object in_do_connect, astuple
+cdef object astuple
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import enum
 import logging
 import socket

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -523,7 +523,7 @@ class APIConnection:
         This part of the process establishes the socket connection but
         does not initialize the frame helper or send the hello message.
         """
-        if self.connection_state != ConnectionState.INITIALIZED:
+        if self.connection_state is not ConnectionState.INITIALIZED:
             raise ValueError(
                 "Connection can only be used once, connection is not in init state"
             )
@@ -579,7 +579,7 @@ class APIConnection:
         This part of the process initializes the frame helper and sends the hello message
         than starts the keep alive process.
         """
-        if self.connection_state != ConnectionState.SOCKET_OPENED:
+        if self.connection_state is not ConnectionState.SOCKET_OPENED:
             raise ValueError(
                 "Connection must be in SOCKET_OPENED state to finish connection"
             )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -20,6 +20,7 @@ from aioesphomeapi.api_pb2 import (
 from aioesphomeapi.connection import APIConnection, ConnectionParams, ConnectionState
 from aioesphomeapi.core import (
     APIConnectionError,
+    ConnectionNotEstablishedAPIError,
     HandshakeAPIError,
     InvalidAuthAPIError,
     RequiresEncryptionAPIError,
@@ -609,3 +610,12 @@ async def test_ping_does_not_disconnect_if_we_get_responses(
 
     # We should disconnect if we are getting ping responses
     assert conn.is_connected is True
+
+
+def test_raise_during_send_messages_when_not_yet_connected(conn: APIConnection) -> None:
+    """Test that we raise when sending messages before we are connected."""
+    with pytest.raises(ConnectionNotEstablishedAPIError):
+        conn.send_message(PingRequest())
+
+    with pytest.raises(ConnectionNotEstablishedAPIError):
+        conn.send_messages((PingRequest(),))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -616,6 +616,3 @@ def test_raise_during_send_messages_when_not_yet_connected(conn: APIConnection) 
     """Test that we raise when sending messages before we are connected."""
     with pytest.raises(ConnectionNotEstablishedAPIError):
         conn.send_message(PingRequest())
-
-    with pytest.raises(ConnectionNotEstablishedAPIError):
-        conn.send_messages((PingRequest(),))


### PR DESCRIPTION
With previous refactoring we no longer need this complexity. We never call `send_messages` during the connection set up anymore.