### PR TITLE
Ensure scope_id is preserved from zeroconf resolution on python versions that support it

### DIFF
--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -39,7 +39,7 @@ class IPv6Sockaddr(Sockaddr):
     """IPv6 socket address."""
 
     flowinfo: int
-    scope_id: int | str | None
+    scope_id: int
 
 
 @dataclass(frozen=True)
@@ -77,14 +77,14 @@ async def _async_zeroconf_get_service_info(
     return info
 
 
-def _int_or_str(value: str | None) -> int | str | None:
-    """Convert a string to int if possible."""
+def _scope_id_to_int(value: str | None) -> int:
+    """Convert a scope id to int if possible."""
     if value is None:
-        return value
+        return 0
     try:
         return int(value)
     except ValueError:
-        return value
+        return 0
 
 
 async def _async_resolve_host_zeroconf(
@@ -157,7 +157,7 @@ def _async_ip_address_to_addrs(
             address=str(ip).partition("%")[0],
             port=port,
             flowinfo=0,
-            scope_id=_int_or_str(ip.scope_id),
+            scope_id=_scope_id_to_int(ip.scope_id),
         )
     else:
         sockaddr = IPv4Sockaddr(

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -54,6 +54,7 @@ async def _async_zeroconf_get_service_info(
     zeroconf_manager: ZeroconfManager,
     service_type: str,
     service_name: str,
+    server: str,
     timeout: float,
 ) -> AsyncServiceInfo:
     # Use or create zeroconf instance, ensure it's an AsyncZeroconf
@@ -65,7 +66,7 @@ async def _async_zeroconf_get_service_info(
             "host network mode?"
         ) from exc
     try:
-        info = AsyncServiceInfo(service_type, service_name)
+        info = AsyncServiceInfo(service_type, service_name, server=server)
         await info.async_request(zc, int(timeout * 1000))
     except Exception as exc:
         raise ResolveAPIError(
@@ -91,10 +92,15 @@ async def _async_resolve_host_zeroconf(
     zeroconf_manager: ZeroconfManager | None = None,
 ) -> list[AddrInfo]:
     service_name = f"{host}.{SERVICE_TYPE}"
+    server = f"{host}.local."
 
     _LOGGER.debug("Resolving host %s via mDNS", service_name)
     info = await _async_zeroconf_get_service_info(
-        zeroconf_manager or ZeroconfManager(), SERVICE_TYPE, service_name, timeout
+        zeroconf_manager or ZeroconfManager(),
+        SERVICE_TYPE,
+        service_name,
+        server,
+        timeout,
     )
     addrs: list[AddrInfo] = []
     for ip in info.ip_addresses_by_version(IPVersion.All):

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -141,22 +141,22 @@ async def _async_resolve_host_getaddrinfo(host: str, port: int) -> list[AddrInfo
 
 
 def _async_ip_address_to_addrs(
-    ip_address: IPv4Address | IPv6Address, port: int
+    ip: IPv4Address | IPv6Address, port: int
 ) -> list[AddrInfo]:
     """Convert an ipaddress to AddrInfo."""
     addrs: list[AddrInfo] = []
-    is_ipv6 = ip_address.version == 6
+    is_ipv6 = ip.version == 6
     sockaddr: IPv6Sockaddr | IPv4Sockaddr
     if is_ipv6:
         sockaddr = IPv6Sockaddr(
-            address=str(ip_address).partition("%")[0],
+            address=str(ip).partition("%")[0],
             port=port,
             flowinfo=0,
-            scope_id=_int_or_str(ip_address.scope_id),
+            scope_id=_int_or_str(ip.scope_id),
         )
     else:
         sockaddr = IPv4Sockaddr(
-            address=str(ip_address),
+            address=str(ip),
             port=port,
         )
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import socket
 from dataclasses import dataclass
-from ipaddress import IPv4Address, IPv6Address, _BaseAddress, ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, cast
 
 from zeroconf import IPVersion

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -248,7 +248,7 @@ async def test_resolve_host_create_zeroconf_oserror(
         await hr._async_resolve_host_zeroconf("asdf", 6052)
 
 
-def test_int_or_str():
-    assert hr._int_or_str("123") == 123
-    assert hr._int_or_str("eth0") == "eth0"
-    assert hr._int_or_str(None) is None
+def test_scope_id_to_int():
+    assert hr._scope_id_to_int("123") == 123
+    assert hr._scope_id_to_int("eth0") == 0
+    assert hr._scope_id_to_int(None) == 0

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import socket
-from ipaddress import ip_address, IPv6Address
+from ipaddress import IPv6Address, ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -38,7 +38,7 @@ def addr_infos():
 @pytest.mark.asyncio
 async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     info = MagicMock(auto_spec=AsyncServiceInfo)
-    ipv6 = IPv6Address('2001:db8:85a3::8a2e:370:7334%0')
+    ipv6 = IPv6Address("2001:db8:85a3::8a2e:370:7334%0")
     info.ip_addresses_by_version.return_value = [
         ip_address(b"\n\x00\x00*"),
         ipv6,
@@ -58,7 +58,7 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
 async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     zeroconf_manager = ZeroconfManager()
     info = MagicMock(auto_spec=AsyncServiceInfo)
-    ipv6 = IPv6Address('2001:db8:85a3::8a2e:370:7334%0')
+    ipv6 = IPv6Address("2001:db8:85a3::8a2e:370:7334%0")
     info.ip_addresses_by_version.return_value = [
         ip_address(b"\n\x00\x00*"),
         ipv6,
@@ -147,7 +147,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
     with pytest.raises(ResolveAPIError):
-         await hr.async_resolve_host("example.local", 6052)
+        await hr.async_resolve_host("example.local", 6052)
 
 
 @pytest.mark.asyncio
@@ -227,6 +227,7 @@ async def test_resolve_host_create_zeroconf_oserror(
         "aioesphomeapi.zeroconf.AsyncZeroconf", side_effect=OSError("out of buffers")
     ), pytest.raises(ResolveAPIError, match="out of buffers"):
         await hr._async_resolve_host_zeroconf("asdf", 6052)
+
 
 def test_int_or_str():
     hr._int_or_str("123") == 123

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -84,6 +84,15 @@ async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
 
 
 @pytest.mark.asyncio
+async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
+    with patch(
+        "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
+        side_effect=Exception("no buffers"),
+    ), pytest.raises(ResolveAPIError, match="no buffers"):
+        await hr._async_resolve_host_zeroconf("asdf.local", 6052)
+
+
+@pytest.mark.asyncio
 async def test_resolve_host_getaddrinfo(event_loop, addr_infos):
     with patch.object(event_loop, "getaddrinfo") as mock:
         mock.return_value = [

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -93,6 +93,16 @@ async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
 
 
 @pytest.mark.asyncio
+@patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo", return_value=[])
+async def test_resolve_host_zeroconf_fails_end_to_end(async_zeroconf: AsyncZeroconf):
+    with patch(
+        "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
+        side_effect=Exception("no buffers"),
+    ), pytest.raises(ResolveAPIError, match="no buffers"):
+        await hr.async_resolve_host("asdf.local", 6052)
+
+
+@pytest.mark.asyncio
 async def test_resolve_host_getaddrinfo(event_loop, addr_infos):
     with patch.object(event_loop, "getaddrinfo") as mock:
         mock.return_value = [

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import socket
-from ipaddress import ip_address
+from ipaddress import ip_address, IPv6Address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -38,9 +38,10 @@ def addr_infos():
 @pytest.mark.asyncio
 async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     info = MagicMock(auto_spec=AsyncServiceInfo)
+    ipv6 = IPv6Address('2001:db8:85a3::8a2e:370:7334%0')
     info.ip_addresses_by_version.return_value = [
         ip_address(b"\n\x00\x00*"),
-        ip_address(b" \x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4"),
+        ipv6,
     ]
     info.async_request = AsyncMock(return_value=True)
     with patch(
@@ -57,9 +58,10 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
 async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     zeroconf_manager = ZeroconfManager()
     info = MagicMock(auto_spec=AsyncServiceInfo)
+    ipv6 = IPv6Address('2001:db8:85a3::8a2e:370:7334%0')
     info.ip_addresses_by_version.return_value = [
         ip_address(b"\n\x00\x00*"),
-        ip_address(b" \x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4"),
+        ipv6,
     ]
     info.async_request = AsyncMock(return_value=True)
     with patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info):
@@ -140,6 +142,15 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
 
 
 @pytest.mark.asyncio
+@patch("aioesphomeapi.host_resolver.AsyncServiceInfo.async_request", return_value=False)
+@patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
+async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
+    resolve_addr.return_value = addr_infos
+    with pytest.raises(ResolveAPIError):
+         await hr.async_resolve_host("example.local", 6052)
+
+
+@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
@@ -216,3 +227,7 @@ async def test_resolve_host_create_zeroconf_oserror(
         "aioesphomeapi.zeroconf.AsyncZeroconf", side_effect=OSError("out of buffers")
     ), pytest.raises(ResolveAPIError, match="out of buffers"):
         await hr._async_resolve_host_zeroconf("asdf", 6052)
+
+def test_int_or_str():
+    hr._int_or_str("123") == 123
+    hr._int_or_str("eth0") == "eth0"

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -230,5 +230,6 @@ async def test_resolve_host_create_zeroconf_oserror(
 
 
 def test_int_or_str():
-    hr._int_or_str("123") == 123
-    hr._int_or_str("eth0") == "eth0"
+    assert hr._int_or_str("123") == 123
+    assert hr._int_or_str("eth0") == "eth0"
+    assert hr._int_or_str(None) is None


### PR DESCRIPTION
This will only work if scope_id is an int, but at least we can fix that