### PR TITLE
Fix race running disconnect callback in reconnect logic

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -125,7 +125,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         # Run disconnect hook
         async with self._connected_lock:
-            await self._async_set_connection_state_while_locked(
+            self._async_set_connection_state_while_locked(
                 ReconnectLogicState.DISCONNECTED
             )
             await self._on_disconnect_cb(expected_disconnect)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -115,17 +115,17 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             # to cooldown before connecting in case the remote
             # is rebooting so we don't establish a connection right
             # before its about to reboot in the event we are too fast.
+            disconnect_type = "expected"
             wait = EXPECTED_DISCONNECT_COOLDOWN
-            _LOGGER.info(
-                "Processing expected disconnect from ESPHome API for %s",
-                self._cli.log_name,
-            )
         else:
+            disconnect_type = "unexpected"
             wait = 0
-            _LOGGER.warning(
-                "Processing unexpected disconnect from ESPHome API for %s",
-                self._cli.log_name,
-            )
+
+        _LOGGER.info(
+            "Processing %s disconnect from ESPHome API for %s",
+            disconnect_type,
+            self._cli.log_name,
+        )
 
         # Run disconnect hook
         async with self._connected_lock:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -106,8 +106,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Log and issue callbacks when disconnecting."""
-        if self._is_stopped:
-            return
         # This can happen often depending on WiFi signal strength.
         # So therefore all these connection warnings are logged
         # as infos. The "unavailable" logic will still trigger so the
@@ -130,6 +128,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             await self._async_set_connection_state_while_locked(ReconnectLogicState.DISCONNECTED)
             await self._on_disconnect_cb(expected_disconnect)
 
+        if self._is_stopped:
+            return
         # If we expected the disconnect we need
         # to cooldown before connecting in case the remote
         # is rebooting so we don't establish a connection right

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -115,17 +115,17 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             # to cooldown before connecting in case the remote
             # is rebooting so we don't establish a connection right
             # before its about to reboot in the event we are too fast.
-            disconnect_type = "expected"
             wait = EXPECTED_DISCONNECT_COOLDOWN
+            _LOGGER.info(
+                "Processing expected disconnect from ESPHome API for %s",
+                self._cli.log_name,
+            )
         else:
-            disconnect_type = "unexpected"
             wait = 0
-
-        _LOGGER.info(
-            "Processing %s disconnect from ESPHome API for %s",
-            disconnect_type,
-            self._cli.log_name,
-        )
+            _LOGGER.warning(
+                "Processing unexpected disconnect from ESPHome API for %s",
+                self._cli.log_name,
+            )
 
         # Run disconnect hook
         async with self._connected_lock:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -125,7 +125,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         # Run disconnect hook
         async with self._connected_lock:
-            await self._async_set_connection_state_while_locked(ReconnectLogicState.DISCONNECTED)
+            await self._async_set_connection_state_while_locked(
+                ReconnectLogicState.DISCONNECTED
+            )
             await self._on_disconnect_cb(expected_disconnect)
 
         if self._is_stopped:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -454,7 +454,7 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake():
 
 @pytest.mark.asyncio
 async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventLoop):
-    """Test the log runner logic."""
+    """Test the disconnect callback fires with expected_disconnect=False."""
     loop = asyncio.get_event_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()


### PR DESCRIPTION
We did not hold the lock while we ran the disconnect callback. Also it would not run if we were stopped and we disconnect which means that callers might not tear down things that were expected.

This likely was not an actual problem in production but we could have started to reconnect before the disconnect hook had finished