### PR TITLE
Fix missed GATT notify if the device responds immediately after subscribe

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -994,12 +994,6 @@ class APIClient:
         callbacks without stopping the notify session on the remote device, which
         should be used when the connection is lost.
         """
-        await self._send_bluetooth_message_await_response(
-            address,
-            handle,
-            BluetoothGATTNotifyRequest(address=address, handle=handle, enable=True),
-            BluetoothGATTNotifyResponse,
-        )
 
         def _on_bluetooth_gatt_notify_data_response(
             msg: BluetoothGATTNotifyDataResponse,
@@ -1010,6 +1004,17 @@ class APIClient:
         remove_callback = self._get_connection().add_message_callback(
             _on_bluetooth_gatt_notify_data_response, (BluetoothGATTNotifyDataResponse,)
         )
+
+        try:
+            await self._send_bluetooth_message_await_response(
+                address,
+                handle,
+                BluetoothGATTNotifyRequest(address=address, handle=handle, enable=True),
+                BluetoothGATTNotifyResponse,
+            )
+        except Exception:
+            remove_callback()
+            raise
 
         async def stop_notify() -> None:
             if self._connection is None:

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -978,6 +978,17 @@ class APIClient:
             timeout=timeout,
         )
 
+    def _on_bluetooth_gatt_notify_data_response(
+        self,
+        address: int,
+        handle: int,
+        on_bluetooth_gatt_notify: Callable[[int, bytearray], None],
+        msg: BluetoothGATTNotifyDataResponse,
+    ) -> None:
+        """Handle a BluetoothGATTNotifyDataResponse message."""
+        if address == msg.address and handle == msg.handle:
+            on_bluetooth_gatt_notify(handle, bytearray(msg.data))
+
     async def bluetooth_gatt_start_notify(
         self,
         address: int,
@@ -994,15 +1005,14 @@ class APIClient:
         callbacks without stopping the notify session on the remote device, which
         should be used when the connection is lost.
         """
-
-        def _on_bluetooth_gatt_notify_data_response(
-            msg: BluetoothGATTNotifyDataResponse,
-        ) -> None:
-            if address == msg.address and handle == msg.handle:
-                on_bluetooth_gatt_notify(handle, bytearray(msg.data))
-
         remove_callback = self._get_connection().add_message_callback(
-            _on_bluetooth_gatt_notify_data_response, (BluetoothGATTNotifyDataResponse,)
+            partial(
+                self._on_bluetooth_gatt_notify_data_response,
+                address,
+                handle,
+                on_bluetooth_gatt_notify,
+            ),
+            (BluetoothGATTNotifyDataResponse,),
         )
 
         try:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -946,3 +946,15 @@ class APIConnection:
                 )
 
         self._cleanup()
+
+    def _get_message_handlers(
+        self,
+    ) -> dict[Any, set[Callable[[message.Message], None]]]:
+        """Get the message handlers.
+
+        This function is only used for testing for leaks.
+
+        It has to be bound to the real instance to work since
+        _message_handlers is not a public attribute.
+        """
+        return self._message_handlers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,10 @@ from .common import connect, get_mock_async_zeroconf, send_plaintext_hello
 KEEP_ALIVE_INTERVAL = 15.0
 
 
+class PatchableAPIConnection(APIConnection):
+    pass
+
+
 @pytest.fixture
 def async_zeroconf():
     return get_mock_async_zeroconf()
@@ -76,12 +80,12 @@ async def on_stop(expected_disconnect: bool) -> None:
 
 @pytest.fixture
 def conn(connection_params: ConnectionParams) -> APIConnection:
-    return APIConnection(connection_params, on_stop)
+    return PatchableAPIConnection(connection_params, on_stop)
 
 
 @pytest.fixture
 def noise_conn(noise_connection_params: ConnectionParams) -> APIConnection:
-    return APIConnection(noise_connection_params, on_stop)
+    return PatchableAPIConnection(noise_connection_params, on_stop)
 
 
 @pytest_asyncio.fixture(name="plaintext_connect_task_no_login")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1177,7 +1177,10 @@ async def test_bluetooth_gatt_start_notify(
         len(list(itertools.chain(*connection._get_message_handlers().values())))
         == handlers_before
     )
+    # Ensure abort callback is a no-op after cancel
+    # and doesn't raise
     abort_cb()
+
 
 @pytest.mark.asyncio
 async def test_bluetooth_gatt_start_notify_fails(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1200,7 +1200,9 @@ async def test_bluetooth_gatt_start_notify_fails(
     )
 
     with patch.object(
-        connection, "send_messages_await_response_complex", side_effect=APIConnectionError
+        connection,
+        "send_messages_await_response_complex",
+        side_effect=APIConnectionError,
     ), pytest.raises(APIConnectionError):
         await client.bluetooth_gatt_start_notify(1234, 1, on_bluetooth_gatt_notify)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
-import itertools
+
 import pytest
 from google.protobuf import message
 
@@ -1181,7 +1182,9 @@ async def test_bluetooth_gatt_start_notify_fails(
     def on_bluetooth_gatt_notify(handle: int, data: bytearray) -> None:
         notifies.append((handle, data))
 
-    handlers_before = len(list(itertools.chain(*connection._message_handlers.values())))
+    handlers_before = len(
+        list(itertools.chain(*connection._get_message_handlers().values()))
+    )
 
     with patch.object(
         connection, "send_messages", side_effect=APIConnectionError
@@ -1189,7 +1192,7 @@ async def test_bluetooth_gatt_start_notify_fails(
         await client.bluetooth_gatt_start_notify(1234, 1, on_bluetooth_gatt_notify)
 
     assert (
-        len(list(itertools.chain(*connection._message_handlers.values())))
+        len(list(itertools.chain(*connection._get_message_handlers().values())))
         == handlers_before
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1200,7 +1200,7 @@ async def test_bluetooth_gatt_start_notify_fails(
     )
 
     with patch.object(
-        connection, "send_messages", side_effect=APIConnectionError
+        connection, "send_messages_await_response_complex", side_effect=APIConnectionError
     ), pytest.raises(APIConnectionError):
         await client.bluetooth_gatt_start_notify(1234, 1, on_bluetooth_gatt_notify)
 


### PR DESCRIPTION
There was a race where we could miss a GATT notify response data if it was received in the same packet as the gatt notify response because the ESP was buffering the api reply because we did not install the listener before calling the subscribe