### PR TITLE
Fix handshake getting the wrong exception when the ESP drops the connection because its not using noise

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -154,6 +154,7 @@ class APIFrameHelper:
         self.close()
 
     def _handle_error(self, exc: Exception) -> None:
+        self._set_ready_future_exception(exc)
         self._connection.report_fatal_error(exc)
 
     def connection_lost(self, exc: Exception | None) -> None:

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -111,7 +111,6 @@ class APINoiseFrameHelper(APIFrameHelper):
         super().close()
 
     def _handle_error_and_close(self, exc: Exception) -> None:
-        self._set_ready_future_exception(exc)
         super()._handle_error_and_close(exc)
 
     def _handle_error(self, exc: Exception) -> None:

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -110,9 +110,6 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._state = NOISE_STATE_CLOSED
         super().close()
 
-    def _handle_error_and_close(self, exc: Exception) -> None:
-        super()._handle_error_and_close(exc)
-
     def _handle_error(self, exc: Exception) -> None:
         """Handle an error, and provide a good message when during hello."""
         if self._state == NOISE_STATE_HELLO and isinstance(exc, ConnectionResetError):

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -623,7 +623,9 @@ async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> N
 
 @pytest.mark.xfail(reason="We get the wrong exception from the task")
 @pytest.mark.asyncio
-async def test_init_noise_attempted_when_esp_uses_plaintext(noise_conn: APIConnection) -> None:
+async def test_init_noise_attempted_when_esp_uses_plaintext(
+    noise_conn: APIConnection,
+) -> None:
     loop = asyncio.get_event_loop()
     transport = MagicMock()
     protocol: APINoiseFrameHelper | None = None
@@ -643,9 +645,10 @@ async def test_init_noise_attempted_when_esp_uses_plaintext(noise_conn: APIConne
 
         protocol.connection_lost(ConnectionResetError())
 
-        with pytest.raises(APIConnectionError, match="The connection dropped immediately"):
+        with pytest.raises(
+            APIConnectionError, match="The connection dropped immediately"
+        ):
             await task
-
 
 
 @pytest.mark.asyncio

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -621,7 +621,6 @@ async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> N
             await task
 
 
-@pytest.mark.xfail(reason="We get the wrong exception from the task")
 @pytest.mark.asyncio
 async def test_init_noise_attempted_when_esp_uses_plaintext(
     noise_conn: APIConnection,


### PR DESCRIPTION
We didn't set the future exception when there was fatal error in the frame helper so the caller would not get a good error when the connection was closed because the ESP does not use encryption but we were trying to anyways