### PR TITLE
Fix error in noise frame helper were we could write when the writer was unset

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import binascii
 import logging
 from functools import partial
@@ -128,10 +129,10 @@ class APINoiseFrameHelper(APIFrameHelper):
             exc.__cause__ = original_exc
         super()._handle_error(exc)
 
-    async def perform_handshake(self, timeout: float) -> None:
-        """Perform the handshake with the server."""
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        """Handle a new connection."""
+        super().connection_made(transport)
         self._send_hello_handshake()
-        await super().perform_handshake(timeout)
 
     def data_received(self, data: bytes | bytearray | memoryview) -> None:
         self._add_to_buffer(data)

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ from google.protobuf import message
 from zeroconf import Zeroconf
 from zeroconf.asyncio import AsyncZeroconf
 
-from aioesphomeapi._frame_helper import APIPlaintextFrameHelper
+from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi._frame_helper.plain_text import _cached_varuint_to_bytes
 from aioesphomeapi.api_pb2 import (
     ConnectResponse,
@@ -29,6 +29,20 @@ utcnow: partial[datetime] = partial(datetime.now, UTC)
 utcnow.__doc__ = "Get now in UTC time."
 
 PROTO_TO_MESSAGE_TYPE = {v: k for k, v in MESSAGE_TYPE_TO_PROTO.items()}
+
+
+def mock_data_received(
+    protocol: APINoiseFrameHelper | APIPlaintextFrameHelper, data: bytes
+) -> None:
+    """Mock data received on the protocol."""
+    try:
+        protocol.data_received(data)
+    except Exception as err:  # pylint: disable=broad-except
+        loop = asyncio.get_running_loop()
+        loop.call_soon(
+            protocol.connection_lost,
+            err,
+        )
 
 
 def get_mock_zeroconf() -> MagicMock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,7 @@ def socket_socket():
         yield func
 
 
-@pytest.fixture
-def connection_params() -> ConnectionParams:
+def get_mock_connection_params() -> ConnectionParams:
     return ConnectionParams(
         address="fake.address",
         port=6052,
@@ -58,6 +57,11 @@ def connection_params() -> ConnectionParams:
         noise_psk=None,
         expected_name=None,
     )
+
+
+@pytest.fixture
+def connection_params() -> ConnectionParams:
+    return get_mock_connection_params()
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,7 +88,12 @@ from aioesphomeapi.model import (
 )
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 
-from .common import Estr, generate_plaintext_packet, get_mock_zeroconf
+from .common import (
+    Estr,
+    generate_plaintext_packet,
+    get_mock_zeroconf,
+    mock_data_received,
+)
 
 
 @pytest.fixture
@@ -849,7 +854,7 @@ async def test_bluetooth_disconnect(
     response: message.Message = BluetoothDeviceConnectionResponse(
         address=1234, connected=False
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await disconnect_task
 
 
@@ -864,7 +869,7 @@ async def test_bluetooth_pair(
     pair_task = asyncio.create_task(client.bluetooth_device_pair(1234))
     await asyncio.sleep(0)
     response: message.Message = BluetoothDevicePairingResponse(address=1234)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await pair_task
 
 
@@ -879,7 +884,7 @@ async def test_bluetooth_unpair(
     unpair_task = asyncio.create_task(client.bluetooth_device_unpair(1234))
     await asyncio.sleep(0)
     response: message.Message = BluetoothDeviceUnpairingResponse(address=1234)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await unpair_task
 
 
@@ -894,7 +899,7 @@ async def test_bluetooth_clear_cache(
     clear_task = asyncio.create_task(client.bluetooth_device_clear_cache(1234))
     await asyncio.sleep(0)
     response: message.Message = BluetoothDeviceClearCacheResponse(address=1234)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await clear_task
 
 
@@ -914,7 +919,7 @@ async def test_device_info(
         friendly_name="My Device",
         has_deep_sleep=True,
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     device_info = await device_info_task
     assert device_info.name == "realname"
     assert device_info.friendly_name == "My Device"
@@ -923,7 +928,7 @@ async def test_device_info(
     disconnect_task = asyncio.create_task(client.disconnect())
     await asyncio.sleep(0)
     response: message.Message = DisconnectResponse()
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await disconnect_task
     with pytest.raises(APIConnectionError, match="CLOSED"):
         await client.device_info()
@@ -943,12 +948,12 @@ async def test_bluetooth_gatt_read(
     other_response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=4567, data=b"4567"
     )
-    protocol.data_received(generate_plaintext_packet(other_response))
+    mock_data_received(protocol, generate_plaintext_packet(other_response))
 
     response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=1234, data=b"1234"
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     assert await read_task == b"1234"
 
 
@@ -966,12 +971,12 @@ async def test_bluetooth_gatt_read_descriptor(
     other_response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=4567, data=b"4567"
     )
-    protocol.data_received(generate_plaintext_packet(other_response))
+    mock_data_received(protocol, generate_plaintext_packet(other_response))
 
     response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=1234, data=b"1234"
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     assert await read_task == b"1234"
 
 
@@ -991,10 +996,10 @@ async def test_bluetooth_gatt_write(
     other_response: message.Message = BluetoothGATTWriteResponse(
         address=1234, handle=4567
     )
-    protocol.data_received(generate_plaintext_packet(other_response))
+    mock_data_received(protocol, generate_plaintext_packet(other_response))
 
     response: message.Message = BluetoothGATTWriteResponse(address=1234, handle=1234)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await write_task
 
 
@@ -1034,10 +1039,10 @@ async def test_bluetooth_gatt_write_descriptor(
     other_response: message.Message = BluetoothGATTWriteResponse(
         address=1234, handle=4567
     )
-    protocol.data_received(generate_plaintext_packet(other_response))
+    mock_data_received(protocol, generate_plaintext_packet(other_response))
 
     response: message.Message = BluetoothGATTWriteResponse(address=1234, handle=1234)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     await write_task
 
 
@@ -1077,12 +1082,12 @@ async def test_bluetooth_gatt_read_descriptor(
     other_response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=4567, data=b"4567"
     )
-    protocol.data_received(generate_plaintext_packet(other_response))
+    mock_data_received(protocol, generate_plaintext_packet(other_response))
 
     response: message.Message = BluetoothGATTReadResponse(
         address=1234, handle=1234, data=b"1234"
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     assert await read_task == b"1234"
 
 
@@ -1102,9 +1107,9 @@ async def test_bluetooth_gatt_get_services(
     response: message.Message = BluetoothGATTGetServicesResponse(
         address=1234, services=[service1]
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     done_response: message.Message = BluetoothGATTGetServicesDoneResponse(address=1234)
-    protocol.data_received(generate_plaintext_packet(done_response))
+    mock_data_received(protocol, generate_plaintext_packet(done_response))
 
     services = await services_task
     assert services == ESPHomeBluetoothGATTServices(
@@ -1129,9 +1134,9 @@ async def test_bluetooth_gatt_get_services_errors(
     response: message.Message = BluetoothGATTGetServicesResponse(
         address=1234, services=[service1]
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     done_response: message.Message = BluetoothGATTErrorResponse(address=1234)
-    protocol.data_received(generate_plaintext_packet(done_response))
+    mock_data_received(protocol, generate_plaintext_packet(done_response))
 
     with pytest.raises(BluetoothGATTAPIError):
         await services_task
@@ -1164,9 +1169,10 @@ async def test_bluetooth_gatt_start_notify(
     data_response: message.Message = BluetoothGATTNotifyDataResponse(
         address=1234, handle=1, data=b"gotit"
     )
-    protocol.data_received(
+    mock_data_received(
+        protocol,
         generate_plaintext_packet(notify_response)
-        + generate_plaintext_packet(data_response)
+        + generate_plaintext_packet(data_response),
     )
 
     cancel_cb, abort_cb = await notify_task
@@ -1175,7 +1181,7 @@ async def test_bluetooth_gatt_start_notify(
     second_data_response: message.Message = BluetoothGATTNotifyDataResponse(
         address=1234, handle=1, data=b"after finished"
     )
-    protocol.data_received(generate_plaintext_packet(second_data_response))
+    mock_data_received(protocol, generate_plaintext_packet(second_data_response))
     assert notifies == [(1, b"gotit"), (1, b"after finished")]
     await cancel_cb()
 
@@ -1244,7 +1250,7 @@ async def test_subscribe_bluetooth_le_advertisements(
         manufacturer_data={},
         address_type=1,
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
 
     assert advs == [
         BluetoothLEAdvertisement(
@@ -1290,7 +1296,7 @@ async def test_subscribe_bluetooth_le_raw_advertisements(
             )
         ]
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     assert len(adv_groups) == 1
     first_adv = adv_groups[0][0]
     assert first_adv.address == 1234
@@ -1318,7 +1324,7 @@ async def test_subscribe_bluetooth_connections_free(
     )
     await asyncio.sleep(0)
     response: message.Message = BluetoothConnectionsFreeResponse(free=2, limit=3)
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
 
     assert connections == [(2, 3)]
     unsub()
@@ -1345,7 +1351,7 @@ async def test_subscribe_home_assistant_states(
     response: message.Message = SubscribeHomeAssistantStateResponse(
         entity_id="sensor.red", attribute="any"
     )
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
 
     assert states == [("sensor.red", "any")]
 

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -17,6 +17,7 @@ from .common import (
     Estr,
     generate_plaintext_packet,
     get_mock_async_zeroconf,
+    mock_data_received,
     send_plaintext_connect_response,
     send_plaintext_hello,
 )
@@ -74,11 +75,11 @@ async def test_log_runner(event_loop: asyncio.AbstractEventLoop, conn: APIConnec
 
     response: message.Message = SubscribeLogsResponse()
     response.message = b"Hello world"
-    protocol.data_received(generate_plaintext_packet(response))
+    mock_data_received(protocol, generate_plaintext_packet(response))
     assert len(messages) == 1
     assert messages[0].message == b"Hello world"
     stop_task = asyncio.create_task(stop())
     await asyncio.sleep(0)
     disconnect_response = DisconnectResponse()
-    protocol.data_received(generate_plaintext_packet(disconnect_response))
+    mock_data_received(protocol, generate_plaintext_packet(disconnect_response))
     await stop_task


### PR DESCRIPTION
We need to send the hello as soon as the connection is connected, otherwise the connection could already be closed by the time we start the handshake and we will not handle the error correctly.

Mocking `data_received` was not good enough because it was not wrapped in an exception check that would call `connection_lost` on error. The tests now work much more like production