### PR TITLE
Fix signedness with incoming plaintext data

### DIFF
--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -21,9 +21,9 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
         add_length=bytes,
         end_of_frame_pos=cython.uint,
         length_int=cython.uint,
-        preamble=char,
-        length_high=char,
-        maybe_msg_type=char
+        preamble="unsigned char",
+        length_high="unsigned char",
+        maybe_msg_type="unsigned char"
     )
     cpdef data_received(self, object data)
 


### PR DESCRIPTION
#692 introduced a regression because it did not treat the bytes as unsigned