### PR TITLE
Fix race in cleaning up connection

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -274,13 +274,12 @@ class APIClient:
     ) -> None:
         # Hook into on_stop handler to clear connection when stopped
         self._connection = None
-        if on_stop is None:
-            return
-        self._on_stop_task = asyncio.create_task(
-            on_stop(expected_disconnect),
-            name=f"{self.log_name} aioesphomeapi on_stop",
-        )
-        self._on_stop_task.add_done_callback(self._remove_on_stop_task)
+        if on_stop:
+            self._on_stop_task = asyncio.create_task(
+                on_stop(expected_disconnect),
+                name=f"{self.log_name} aioesphomeapi on_stop",
+            )
+            self._on_stop_task.add_done_callback(self._remove_on_stop_task)
 
     def _remove_on_stop_task(self, _fut: asyncio.Future[None]) -> None:
         """Remove the stop task.

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -260,7 +260,7 @@ class APIClient:
 
     async def connect(
         self,
-        on_stop: Callable[[bool], Coroutine[None]] | None = None,
+        on_stop: Callable[[bool], Coroutine[Any, Any, None]] | None = None,
         login: bool = False,
     ) -> None:
         """Connect to the device."""
@@ -269,7 +269,7 @@ class APIClient:
 
     def _on_stop(
         self,
-        on_stop: Callable[[bool], Coroutine[None]] | None,
+        on_stop: Callable[[bool], Coroutine[Any, Any, None]] | None,
         expected_disconnect: bool,
     ) -> None:
         # Hook into on_stop handler to clear connection when stopped

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -260,7 +260,7 @@ class APIClient:
 
     async def connect(
         self,
-        on_stop: Callable[[bool], Awaitable[None]] | None = None,
+        on_stop: Callable[[bool], Coroutine[None]] | None = None,
         login: bool = False,
     ) -> None:
         """Connect to the device."""
@@ -269,7 +269,7 @@ class APIClient:
 
     def _on_stop(
         self,
-        on_stop: Callable[[bool], Awaitable[None]] | None,
+        on_stop: Callable[[bool], Coroutine[None]] | None,
         expected_disconnect: bool,
     ) -> None:
         # Hook into on_stop handler to clear connection when stopped

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -60,7 +60,6 @@ cdef class APIConnection:
 
     cdef ConnectionParams _params
     cdef public object on_stop
-    cdef object _on_stop_task
     cdef public object _socket
     cdef public APIFrameHelper _frame_helper
     cdef public object api_version

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -11,7 +11,6 @@ import time
 # instead of the one from asyncio since they are the same in Python 3.11+
 from asyncio import CancelledError
 from asyncio import TimeoutError as asyncio_TimeoutError
-from collections.abc import Coroutine
 from dataclasses import astuple, dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,12 +4,13 @@ import asyncio
 import time
 from datetime import datetime, timezone
 from functools import partial
-from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from google.protobuf import message
 from zeroconf import Zeroconf
 from zeroconf.asyncio import AsyncZeroconf
+
 from aioesphomeapi import APIClient
 from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi._frame_helper.plain_text import _cached_varuint_to_bytes
@@ -117,7 +118,12 @@ async def connect(conn: APIConnection, login: bool = True):
     await conn.start_connection()
     await conn.finish_connection(login=login)
 
-async def connect_client(client: APIClient, login: bool = True, on_stop: Callable[[bool], Awaitable[None]] | None = None) -> None:
+
+async def connect_client(
+    client: APIClient,
+    login: bool = True,
+    on_stop: Callable[[bool], Awaitable[None]] | None = None,
+) -> None:
     """Wrapper for connection logic to do both parts."""
     await client.start_connection(on_stop=on_stop)
     await client.finish_connection(login=login)

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,11 +5,12 @@ import time
 from datetime import datetime, timezone
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Awaitable, Callable
 
 from google.protobuf import message
 from zeroconf import Zeroconf
 from zeroconf.asyncio import AsyncZeroconf
-
+from aioesphomeapi import APIClient
 from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi._frame_helper.plain_text import _cached_varuint_to_bytes
 from aioesphomeapi.api_pb2 import (
@@ -115,6 +116,11 @@ async def connect(conn: APIConnection, login: bool = True):
     """Wrapper for connection logic to do both parts."""
     await conn.start_connection()
     await conn.finish_connection(login=login)
+
+async def connect_client(client: APIClient, login: bool = True, on_stop: Callable[[bool], Awaitable[None]] | None = None) -> None:
+    """Wrapper for connection logic to do both parts."""
+    await client.start_connection(on_stop=on_stop)
+    await client.finish_connection(login=login)
 
 
 def send_plaintext_hello(protocol: APIPlaintextFrameHelper) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -24,14 +24,13 @@ from aioesphomeapi.core import (
     HandshakeAPIError,
     InvalidAuthAPIError,
     RequiresEncryptionAPIError,
-    SocketAPIError,
     TimeoutAPIError,
 )
 
 from .common import (
     async_fire_time_changed,
-    connect_client,
     connect,
+    connect_client,
     generate_plaintext_packet,
     get_mock_protocol,
     mock_data_received,
@@ -526,7 +525,9 @@ async def test_disconnect_fails_to_send_response(
     with patch.object(event_loop, "sock_connect"), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
     ):
-        connect_task = asyncio.create_task(connect_client(client, login=False, on_stop=_on_stop))
+        connect_task = asyncio.create_task(
+            connect_client(client, login=False, on_stop=_on_stop)
+        )
         await connected.wait()
         send_plaintext_hello(protocol)
         await connect_task
@@ -579,7 +580,9 @@ async def test_disconnect_success_case(
     with patch.object(event_loop, "sock_connect"), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
     ):
-        connect_task = asyncio.create_task(connect_client(client, login=False, on_stop=_on_stop))
+        connect_task = asyncio.create_task(
+            connect_client(client, login=False, on_stop=_on_stop)
+        )
         await connected.wait()
         send_plaintext_hello(protocol)
         await connect_task

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -20,7 +20,6 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_PTR
 from aioesphomeapi import APIConnectionError
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.client import APIClient
-from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
 
 from .common import (


### PR DESCRIPTION
Because the on_stop happens in a task it has to wait one event loop iteration to remove the connection from the client