### PR TITLE
Avoid expensive debug logging checks in packet processor

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -205,6 +205,7 @@ class APIClient:
             Can be used to prevent accidentally connecting to a different device if
             IP passed as address but DHCP reassigned IP.
         """
+        self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(
             address=str(address),
             port=port,
@@ -222,7 +223,6 @@ class APIClient:
         self._loop = asyncio.get_event_loop()
         self._on_stop_task: asyncio.Task[None] | None = None
         self._set_log_name()
-        self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
 
     def set_debug(self, enabled: bool) -> None:
         """Enable debug logging."""

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -316,7 +316,10 @@ class APIClient:
             raise APIConnectionError(f"Already connected to {self.log_name}!")
 
         self._connection = APIConnection(
-            self._params, partial(self._on_stop, on_stop), log_name=self.log_name
+            self._params,
+            partial(self._on_stop, on_stop),
+            self._debug_enabled,
+            log_name=self.log_name,
         )
 
         try:

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -168,7 +168,17 @@ def _stringify_or_none(value: str | None) -> str | None:
 
 # pylint: disable=too-many-public-methods
 class APIClient:
+    """The ESPHome API client.
+
+    This class is the main entrypoint for interacting with the API.
+
+    It is recommended to use this class in combination with the
+    ReconnectLogic class to automatically reconnect to the device
+    if the connection is lost.
+    """
+
     __slots__ = (
+        "_debug_enabled",
         "_params",
         "_connection",
         "cached_name",

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -319,7 +319,7 @@ class APIClient:
             self._params,
             partial(self._on_stop, on_stop),
             self._debug_enabled,
-            log_name=self.log_name,
+            self.log_name,
         )
 
         try:

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -79,7 +79,7 @@ cdef class APIConnection:
     cdef bint _send_pending_ping
     cdef public bint is_connected
     cdef bint _handshake_complete
-    cdef object _debug_enabled
+    cdef bint _debug_enabled
     cdef public str received_name
     cdef public object resolved_addr_info
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -164,7 +164,7 @@ class APIConnection:
         params: ConnectionParams,
         on_stop: Callable[[bool], None],
         debug_enabled: bool,
-        log_name: str,
+        log_name: str | None,
     ) -> None:
         self._params = params
         self.on_stop: Callable[[bool], None] | None = on_stop

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -162,7 +162,7 @@ class APIConnection:
         params: ConnectionParams,
         on_stop: Callable[[bool], None],
         debug_enabled: bool,
-        log_name: str | None = None,
+        log_name: str,
     ) -> None:
         self._params = params
         self.on_stop: Callable[[bool], None] | None = on_stop

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -128,6 +128,8 @@ class APIConnection:
 
     An instance of this class may only be used once, for every new connection
     a new instance should be established.
+
+    This class should only be created from APIClient and should not be used directly.
     """
 
     __slots__ = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def noise_connection_params() -> ConnectionParams:
     )
 
 
-async def on_stop(expected_disconnect: bool) -> None:
+def on_stop(expected_disconnect: bool) -> None:
     pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,12 +84,12 @@ async def on_stop(expected_disconnect: bool) -> None:
 
 @pytest.fixture
 def conn(connection_params: ConnectionParams) -> APIConnection:
-    return PatchableAPIConnection(connection_params, on_stop)
+    return PatchableAPIConnection(connection_params, on_stop, True, None)
 
 
 @pytest.fixture
 def noise_conn(noise_connection_params: ConnectionParams) -> APIConnection:
-    return PatchableAPIConnection(noise_connection_params, on_stop)
+    return PatchableAPIConnection(noise_connection_params, on_stop, True, None)
 
 
 @pytest_asyncio.fixture(name="plaintext_connect_task_no_login")

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -124,7 +124,9 @@ def _make_mock_connection() -> tuple[APIConnection, list[tuple[int, bytes]]]:
     class MockConnection(APIConnection):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             """Swallow args."""
-            super().__init__(get_mock_connection_params(), AsyncMock(), *args, **kwargs)
+            super().__init__(
+                get_mock_connection_params(), AsyncMock(), True, None, *args, **kwargs
+            )
 
         def process_packet(self, type_: int, data: bytes):
             packets.append((type_, data))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from google.protobuf import message
-import logging
+
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.api_pb2 import (
     AlarmControlPanelCommandRequest,


### PR DESCRIPTION
This should only be a breaking change for HA (we can avoid actually breaking anything by flipping the flag when HA changes the logging)

fixes #699

Testing
- [x] HA (needs a two line change, and than only a breaking change in the respect that to adjusting debug logging at run time after the integration is set up)
- [x] Esphome (not a breaking change)
- [x] logging cli (not a breaking change)