### PR TITLE
Remove unreachable code in connection

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -449,9 +449,6 @@ class APIConnection:
 
     def _async_send_keep_alive(self) -> None:
         """Send a keep alive message."""
-        if not self.is_connected:
-            return
-
         loop = self._loop
         now = loop.time()
 
@@ -491,8 +488,6 @@ class APIConnection:
 
     def _async_pong_not_received(self) -> None:
         """Ping not received."""
-        if not self.is_connected:
-            return
         if self._debug_enabled:
             _LOGGER.debug(
                 "%s: Ping response not received after %s seconds",


### PR DESCRIPTION
self.is_connected will always be false because both of these functions run on a timer that is always cancelled in the same as the place where self.is_connected is flipped and since there are no awaits there is no race, and no need for this check