### PR TITLE
Remove unreachable check in connection send_messages

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -41,6 +41,7 @@ cdef object HandshakeAPIError
 cdef object PingFailedAPIError
 cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
+cdef object SocketAPIError
 
 cdef object astuple
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -616,14 +616,11 @@ class APIConnection:
 
         for msg in msgs:
             msg_type = type(msg)
-            if (message_type := PROTO_TO_MESSAGE_TYPE.get(msg_type)) is None:
-                raise ValueError(f"Message type id not found for type {msg_type}")
-
+            message_type = PROTO_TO_MESSAGE_TYPE[msg_type]
             if debug_enabled:
                 _LOGGER.debug(
                     "%s: Sending %s: %s", self.log_name, msg_type.__name__, msg
                 )
-
             packets.append((message_type, msg.SerializeToString()))
 
         if TYPE_CHECKING:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -615,8 +615,7 @@ class APIConnection:
             (PROTO_TO_MESSAGE_TYPE[type(msg)], msg.SerializeToString()) for msg in msgs
         ]
 
-        debug_enabled = self._debug_enabled
-        if debug_enabled:
+        if debug_enabled := self._debug_enabled:
             for msg in msgs:
                 _LOGGER.debug(
                     "%s: Sending %s: %s", self.log_name, type(msg).__name__, msg

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -611,17 +611,16 @@ class APIConnection:
                 f"Connection isn't established yet ({self.connection_state})"
             )
 
-        packets: list[tuple[int, bytes]] = []
-        debug_enabled = self._debug_enabled
+        packets: list[tuple[int, bytes]] = [
+            (PROTO_TO_MESSAGE_TYPE[type(msg)], msg.SerializeToString()) for msg in msgs
+        ]
 
-        for msg in msgs:
-            msg_type = type(msg)
-            message_type = PROTO_TO_MESSAGE_TYPE[msg_type]
-            if debug_enabled:
+        debug_enabled = self._debug_enabled
+        if debug_enabled:
+            for msg in msgs:
                 _LOGGER.debug(
-                    "%s: Sending %s: %s", self.log_name, msg_type.__name__, msg
+                    "%s: Sending %s: %s", self.log_name, type(msg).__name__, msg
                 )
-            packets.append((message_type, msg.SerializeToString()))
 
         if TYPE_CHECKING:
             assert self._frame_helper is not None


### PR DESCRIPTION
All of the calls come from client code which is internal and since we never manually construct protobuf messages it would not be possible to try to send one that did not exist. Instead we should raise KeyError since this would be a refactoring error during development and would never actually happen in production