### PR TITLE
Remove unreachable code in connection cleanup

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -220,8 +220,6 @@ class APIConnection:
         if self._debug_enabled:
             _LOGGER.debug("Cleaning up connection to %s", self.log_name)
         for fut in self._read_exception_futures:
-            if fut.done():
-                continue
             err = self._fatal_exception or APIConnectionError("Connection closed")
             new_exc = err
             if not isinstance(err, APIConnectionError):


### PR DESCRIPTION
We only set the result of _read_exception_futures in one place so there is no need to check if they are done anymore