### PR TITLE
Remove unreachable socket buffering check code in connection

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -291,14 +291,7 @@ class APIConnection:
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         # Try to reduce the pressure on esphome device as it measures
         # ram in bytes and we measure ram in megabytes.
-        try:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, BUFFER_SIZE)
-        except OSError as err:
-            _LOGGER.warning(
-                "%s: Failed to set socket receive buffer size: %s",
-                self.log_name,
-                err,
-            )
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, BUFFER_SIZE)
 
         if self._debug_enabled:
             _LOGGER.debug(


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows-hardware/drivers/network/so-rcvbuf is available in windows vista and later so its a bit unlikely someone will be using this library on windows pre-vista