### PR TITLE
Fix client connection code swallowing unhandled exceptions as debug logging

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -350,7 +350,9 @@ class APIClient:
         """Wrap an APIConnectionError."""
         if isinstance(exc, APIConnectionError):
             return exc
-        new_exc = UnhandledAPIConnectionError(f"Unexpected error while connecting to {self.log_name}: {exc}")
+        new_exc = UnhandledAPIConnectionError(
+            f"Unexpected error while connecting to {self.log_name}: {exc}"
+        )
         new_exc.__cause__ = exc
         return new_exc
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -85,7 +85,6 @@ from .core import (
     APIConnectionError,
     BluetoothGATTAPIError,
     TimeoutAPIError,
-    UnhandledAPIConnectionError,
     to_human_readable_address,
 )
 from .model import (

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -324,9 +324,9 @@ class APIClient:
 
         try:
             await self._connection.start_connection()
-        except Exception as e:
+        except Exception:
             self._connection = None
-            raise self._wrap_api_connection_error(e)
+            raise
         # If we resolved the address, we should set the log name now
         if self._connection.resolved_addr_info:
             self._set_log_name()
@@ -340,21 +340,11 @@ class APIClient:
             assert self._connection is not None
         try:
             await self._connection.finish_connection(login=login)
-        except Exception as e:
+        except Exception:
             self._connection = None
-            raise self._wrap_api_connection_error(e)
+            raise
         if received_name := self._connection.received_name:
             self._set_name_from_device(received_name)
-
-    def _wrap_api_connection_error(self, exc: Exception) -> APIConnectionError:
-        """Wrap an APIConnectionError."""
-        if isinstance(exc, APIConnectionError):
-            return exc
-        new_exc = UnhandledAPIConnectionError(
-            f"Unexpected error while connecting to {self.log_name}: {exc}"
-        )
-        new_exc.__cause__ = exc
-        return new_exc
 
     async def disconnect(self, force: bool = False) -> None:
         if self._connection is None:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -46,6 +46,7 @@ from .core import (
     ResolveAPIError,
     SocketAPIError,
     TimeoutAPIError,
+    UnhandledAPIConnectionError,
 )
 from .model import APIVersion
 from .zeroconf import ZeroconfManager
@@ -547,8 +548,12 @@ class APIConnection:
             cause = ex
         if isinstance(self._fatal_exception, APIConnectionError):
             klass = type(self._fatal_exception)
-        else:
+        elif isinstance(ex, CancelledError):
             klass = APIConnectionError
+        elif isinstance(ex, OSError):
+            klass = SocketAPIError
+        else:
+            klass = UnhandledAPIConnectionError
         new_exc = klass(f"Error while {action} connection: {err_str}")
         new_exc.__cause__ = cause or ex
         return new_exc

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -35,6 +35,7 @@ from .api_pb2 import (  # type: ignore
 )
 from .core import (
     MESSAGE_TYPE_TO_PROTO,
+    APIConnectionCancelledError,
     APIConnectionError,
     BadNameAPIError,
     ConnectionNotEstablishedAPIError,
@@ -549,7 +550,7 @@ class APIConnection:
         if isinstance(self._fatal_exception, APIConnectionError):
             klass = type(self._fatal_exception)
         elif isinstance(ex, CancelledError):
-            klass = APIConnectionError
+            klass = APIConnectionCancelledError
         elif isinstance(ex, OSError):
             klass = SocketAPIError
         else:

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -160,6 +160,10 @@ class APIConnectionError(Exception):
     pass
 
 
+class APIConnectionCancelledError(APIConnectionError):
+    pass
+
+
 class InvalidAuthAPIError(APIConnectionError):
     pass
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,6 +57,7 @@ from aioesphomeapi.api_pb2 import (
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.core import (
+    UnhandledAPIConnectionError,
     APIConnectionError,
     BluetoothGATTAPIError,
     TimeoutAPIError,
@@ -88,7 +89,7 @@ from aioesphomeapi.model import (
     UserServiceArgType,
 )
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
-
+from .conftest import PatchableAPIConnection
 from .common import (
     Estr,
     generate_plaintext_packet,
@@ -170,6 +171,22 @@ async def test_connect_backwards_compat() -> None:
 
     assert mock_start_connection.mock_calls == [call(None)]
     assert mock_finish_connection.mock_calls == [call(False)]
+
+
+
+@pytest.mark.asyncio
+async def test_finish_connection_wraps_exceptions_as_unhandled_api_error() -> None:
+    """Verify finish_connect re-wraps exceptions as UnhandledAPIError."""
+
+    cli = APIClient("1.2.3.4", 1234, None)
+    loop = asyncio.get_event_loop()
+    with patch("aioesphomeapi.client.APIConnection",PatchableAPIConnection), patch.object(loop, "sock_connect"):
+        await cli.start_connection()
+
+    with patch.object(cli._connection, "send_messages_await_response_complex", side_effect=Exception("foo")):
+        with pytest.raises(UnhandledAPIConnectionError, match="foo"):
+            await cli.finish_connection(False)
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,10 +57,10 @@ from aioesphomeapi.api_pb2 import (
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.core import (
-    UnhandledAPIConnectionError,
     APIConnectionError,
     BluetoothGATTAPIError,
     TimeoutAPIError,
+    UnhandledAPIConnectionError,
 )
 from aioesphomeapi.model import (
     AlarmControlPanelCommand,
@@ -89,13 +89,14 @@ from aioesphomeapi.model import (
     UserServiceArgType,
 )
 from aioesphomeapi.reconnect_logic import ReconnectLogic, ReconnectLogicState
-from .conftest import PatchableAPIConnection
+
 from .common import (
     Estr,
     generate_plaintext_packet,
     get_mock_zeroconf,
     mock_data_received,
 )
+from .conftest import PatchableAPIConnection
 
 
 @pytest.fixture
@@ -173,20 +174,24 @@ async def test_connect_backwards_compat() -> None:
     assert mock_finish_connection.mock_calls == [call(False)]
 
 
-
 @pytest.mark.asyncio
 async def test_finish_connection_wraps_exceptions_as_unhandled_api_error() -> None:
     """Verify finish_connect re-wraps exceptions as UnhandledAPIError."""
 
     cli = APIClient("1.2.3.4", 1234, None)
     loop = asyncio.get_event_loop()
-    with patch("aioesphomeapi.client.APIConnection",PatchableAPIConnection), patch.object(loop, "sock_connect"):
+    with patch(
+        "aioesphomeapi.client.APIConnection", PatchableAPIConnection
+    ), patch.object(loop, "sock_connect"):
         await cli.start_connection()
 
-    with patch.object(cli._connection, "send_messages_await_response_complex", side_effect=Exception("foo")):
+    with patch.object(
+        cli._connection,
+        "send_messages_await_response_complex",
+        side_effect=Exception("foo"),
+    ):
         with pytest.raises(UnhandledAPIConnectionError, match="foo"):
             await cli.finish_connection(False)
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The connection object was wrapping every non APIConnection exception as `APIConnectionError` but it should have wrapped it as `UnhandledAPIConnectionError` otherwise we will downgrade it to debug logging.

There may be some side effects here: Anything we think we were handling will now show as `logging.ERROR` instead of  `logging.DEBUG` or `logging.WARNING`. This is a good thing but it may cause users to create issues, but they will be for legitimate bugs in our connection handling