### PR TITLE
Refactor reading varuints to significant simplify plaintext frame helper

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -25,6 +25,14 @@ cdef class APIFrameHelper:
     @cython.locals(original_pos="unsigned int", new_pos="unsigned int")
     cdef bytes _read(self, int length)
 
+    @cython.locals(
+        result="unsigned int",
+        bitpos="unsigned int",
+        val="unsigned char",
+        current_pos="unsigned int"
+    )
+    cdef int _read_varuint(self)
+
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data)
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -119,6 +119,21 @@ class APIFrameHelper:
             assert self._buffer is not None, "Buffer should be set"
         return self._buffer[original_pos:new_pos]
 
+    def _read_varuint(self) -> _int:
+        """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""
+        if TYPE_CHECKING:
+            assert self._buffer is not None, "Buffer should be set"
+        result = 0
+        bitpos = 0
+        while self._buffer_len > self._pos:
+            val = self._buffer[self._pos]
+            self._pos += 1
+            result |= (val & 0x7F) << bitpos
+            if (val & 0x80) == 0:
+                return result
+            bitpos += 7
+        return -1
+
     async def perform_handshake(self, timeout: float) -> None:
         """Perform the handshake with the server."""
         handshake_handle = self._loop.call_at(

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -14,26 +14,7 @@ cpdef _bytes_to_varuint(cython.bytes value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
-    @cython.locals(
-        msg_type=bytes,
-        length=bytes,
-        init_bytes=bytes,
-        add_length=bytes,
-        end_of_frame_pos=cython.uint,
-        length_int=cython.uint,
-        preamble="unsigned char",
-        length_high="unsigned char",
-        maybe_msg_type="unsigned char"
-    )
     cpdef data_received(self, object data)
-
-    @cython.locals(
-        result="unsigned int",
-        bitpos="unsigned int",
-        val="unsigned char",
-        current_pos="unsigned int"
-    )
-    cdef int _read_varuint(self)
 
     cdef void _error_on_incorrect_preamble(self, object preamble)
 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -27,6 +27,14 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
     )
     cpdef data_received(self, object data)
 
+    @cython.locals(
+        result="unsigned int",
+        bitpos="unsigned int",
+        val="unsigned char",
+        current_pos="unsigned int"
+    )
+    cdef int _read_varuint(self)
+
     cdef void _error_on_incorrect_preamble(self, object preamble)
 
     @cython.locals(

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -3,14 +3,9 @@ import cython
 from ..connection cimport APIConnection
 from .base cimport APIFrameHelper
 
-
-cdef bint TYPE_CHECKING
-cdef object bytes_to_varuint, varuint_to_bytes
+cdef object varuint_to_bytes
 
 cpdef _varuint_to_bytes(cython.int value)
-
-@cython.locals(result=cython.int, bitpos=cython.int, val=cython.int)
-cpdef _bytes_to_varuint(cython.bytes value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -16,7 +16,7 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
     cpdef data_received(self, object data)
 
-    cdef void _error_on_incorrect_preamble(self, object preamble)
+    cdef void _error_on_incorrect_preamble(self, int preamble)
 
     @cython.locals(
         type_="unsigned int",

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -3,6 +3,7 @@ import cython
 from ..connection cimport APIConnection
 from .base cimport APIFrameHelper
 
+
 cdef object varuint_to_bytes
 
 cpdef _varuint_to_bytes(cython.int value)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -68,9 +68,9 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if (preamble := self._read_varuint()) != 0x00:
                 self._error_on_incorrect_preamble(preamble)
                 return
-            if (length := self._read_varuint())  == -1:
+            if (length := self._read_varuint()) == -1:
                 return
-            if (msg_type := self._read_varuint())  == -1:
+            if (msg_type := self._read_varuint()) == -1:
                 return
 
             if length == 0:

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -76,21 +76,6 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
         self._write_bytes(b"".join(out), debug_enabled)
 
-    def _read_varuint(self) -> _int:
-        """Read a varuint from the buffer or None if all the bytes are not yet available."""
-        if TYPE_CHECKING:
-            assert self._buffer is not None, "Buffer should be set"
-        result = 0
-        bitpos = 0
-        while self._buffer_len > self._pos:
-            val = self._buffer[self._pos]
-            self._pos += 1
-            result |= (val & 0x7F) << bitpos
-            if (val & 0x80) == 0:
-                return result
-            bitpos += 7
-        return -1
-
     def data_received(  # pylint: disable=too-many-branches,too-many-return-statements
         self, data: bytes | bytearray | memoryview
     ) -> None:

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -12,10 +12,6 @@ from noise.connection import NoiseConnection  # type: ignore[import-untyped]
 from aioesphomeapi import APIConnection
 from aioesphomeapi._frame_helper import APINoiseFrameHelper, APIPlaintextFrameHelper
 from aioesphomeapi._frame_helper.noise import ESPHOME_NOISE_BACKEND
-from aioesphomeapi._frame_helper.plain_text import _bytes_to_varuint as bytes_to_varuint
-from aioesphomeapi._frame_helper.plain_text import (
-    _cached_bytes_to_varuint as cached_bytes_to_varuint,
-)
 from aioesphomeapi._frame_helper.plain_text import (
     _cached_varuint_to_bytes as cached_varuint_to_bytes,
 )
@@ -457,16 +453,6 @@ VARUINT_TESTCASES = [
 def test_varuint_to_bytes(val, encoded):
     assert varuint_to_bytes(val) == encoded
     assert cached_varuint_to_bytes(val) == encoded
-
-
-@pytest.mark.parametrize("val, encoded", VARUINT_TESTCASES)
-def test_bytes_to_varuint(val, encoded):
-    assert bytes_to_varuint(encoded) == val
-    assert cached_bytes_to_varuint(encoded) == val
-
-
-def test_bytes_to_varuint_invalid():
-    assert bytes_to_varuint(b"\xFF") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
python3 bench/raw_ble_plain_text.py 


before
```
Processed 3000000 bluetooth messages took 1.0178361660218798 seconds
```
after
```
Processed 3000000 bluetooth messages took 0.5595999580109492 seconds
```