### PR TITLE
Fix race scheduling reconnect from zeroconf records

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -413,5 +413,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             #
             # So we schedule a stop for the next event loop iteration.
             self.loop.call_soon(self._stop_zc_listen)
+            self._accept_zeroconf_records = False
             self._schedule_connect(0.0)
             return

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -426,6 +426,7 @@ async def test_reconnect_zeroconf(
         assert rl._accept_zeroconf_records is True
         assert not rl._is_stopped
 
+    caplog.clear()
     with patch.object(cli, "start_connection") as mock_start_connection, patch.object(
         cli, "finish_connection"
     ):
@@ -436,10 +437,13 @@ async def test_reconnect_zeroconf(
         assert (
             "Triggering connect because of received mDNS record" in caplog.text
         ) is should_trigger_zeroconf
+        assert rl._accept_zeroconf_records is not should_trigger_zeroconf
         assert rl._zc_listening is True  # should change after one iteration of the loop
         await asyncio.sleep(0)
         assert rl._zc_listening is not should_trigger_zeroconf
 
+        # The reconnect is scheduled to run in the next loop iteration
+        await asyncio.sleep(0)
         assert mock_start_connection.call_count == int(should_trigger_zeroconf)
         assert log_text in caplog.text
 


### PR DESCRIPTION
Because we cannot remove the listener until the next iteration of the event loop we would sometimes schedule multiple reconnect attempts from the records

fixes
```
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error resolving IP address: [Errno 8] nodename nor servname provided, or not known (APIConnectionError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 19.00 seconds
DEBUG Scheduling new connect attempt in 19.00 seconds
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Connected lock acquired for picoproxy @ 192.168.211.138
DEBUG Resolving host picoproxy._esphomelib._tcp.local. via mDNS
DEBUG picoproxy @ 192.168.211.138: Triggering connect because of received mDNS record record[ptr,in,_esphomelib._tcp.local.]=4500.0/4500,picoproxy._esphomelib._tcp.local.
DEBUG picoproxy @ 192.168.211.138: Cancelling existing connect task with state ReconnectLogicState.CONNECTING, to try again now!
DEBUG Removing zeroconf listener for picoproxy
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Cleaning up connection to picoproxy @ 192.168.211.138
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error while starting connection: Starting connection cancelled (APIConnectionCancelledError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 34.00 seconds
DEBUG Starting zeroconf listener for picoproxy
DEBUG Scheduling new connect attempt in 34.00 seconds
DEBUG Connected lock acquired for picoproxy @ 192.168.211.138
DEBUG Resolving host picoproxy._esphomelib._tcp.local. via mDNS
DEBUG picoproxy @ 192.168.211.138: Connecting to picoproxy.local:6053 (AddrInfo(family=<AddressFamily.AF_INET: 2>, type=<SocketKind.SOCK_STREAM: 1>, proto=6, sockaddr=IPv4Sockaddr(address='192.168.211.138', port=6053)))
DEBUG picoproxy @ 192.168.211.138: Triggering connect because of received mDNS record record[ptr,in,_esphomelib._tcp.local.]=4500.0/4500,picoproxy._esphomelib._tcp.local.
DEBUG picoproxy @ 192.168.211.138: Cancelling existing connect task with state ReconnectLogicState.CONNECTING, to try again now!
DEBUG Removing zeroconf listener for picoproxy
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Cleaning up connection to picoproxy @ 192.168.211.138
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error while starting connection: Starting connection cancelled (APIConnectionCancelledError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 60.00 seconds
DEBUG Starting zeroconf listener for picoproxy
DEBUG Scheduling new connect attempt in 60.00 seconds
DEBUG Connected lock acquired for picoproxy @ 192.168.211.138
DEBUG Resolving host picoproxy._esphomelib._tcp.local. via mDNS
DEBUG picoproxy @ 192.168.211.138: Connecting to picoproxy.local:6053 (AddrInfo(family=<AddressFamily.AF_INET: 2>, type=<SocketKind.SOCK_STREAM: 1>, proto=6, sockaddr=IPv4Sockaddr(address='192.168.211.138', port=6053)))
DEBUG picoproxy @ 192.168.211.138: Triggering connect because of received mDNS record record[ptr,in,_esphomelib._tcp.local.]=4500.0/4500,picoproxy._esphomelib._tcp.local.
DEBUG picoproxy @ 192.168.211.138: Cancelling existing connect task with state ReconnectLogicState.CONNECTING, to try again now!
DEBUG Removing zeroconf listener for picoproxy
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Cleaning up connection to picoproxy @ 192.168.211.138
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error while starting connection: Starting connection cancelled (APIConnectionCancelledError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 60.00 seconds
DEBUG Starting zeroconf listener for picoproxy
DEBUG Scheduling new connect attempt in 60.00 seconds
DEBUG Connected lock acquired for picoproxy @ 192.168.211.138
DEBUG Resolving host picoproxy._esphomelib._tcp.local. via mDNS
DEBUG picoproxy @ 192.168.211.138: Connecting to picoproxy.local:6053 (AddrInfo(family=<AddressFamily.AF_INET: 2>, type=<SocketKind.SOCK_STREAM: 1>, proto=6, sockaddr=IPv4Sockaddr(address='192.168.211.138', port=6053)))
DEBUG picoproxy @ 192.168.211.138: Triggering connect because of received mDNS record record[a,in-unique,picoproxy.local.]=120.0/120,192.168.211.138
DEBUG picoproxy @ 192.168.211.138: Cancelling existing connect task with state ReconnectLogicState.CONNECTING, to try again now!
DEBUG Removing zeroconf listener for picoproxy
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Cleaning up connection to picoproxy @ 192.168.211.138
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error while starting connection: Starting connection cancelled (APIConnectionCancelledError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 60.00 seconds
DEBUG Starting zeroconf listener for picoproxy
DEBUG Scheduling new connect attempt in 60.00 seconds
DEBUG Connected lock acquired for picoproxy @ 192.168.211.138
DEBUG Resolving host picoproxy._esphomelib._tcp.local. via mDNS
DEBUG picoproxy @ 192.168.211.138: Connecting to picoproxy.local:6053 (AddrInfo(family=<AddressFamily.AF_INET: 2>, type=<SocketKind.SOCK_STREAM: 1>, proto=6, sockaddr=IPv4Sockaddr(address='192.168.211.138', port=6053)))
DEBUG picoproxy @ 192.168.211.138: Triggering connect because of received mDNS record record[a,in-unique,picoproxy.local.]=120.0/120,192.168.211.138
DEBUG picoproxy @ 192.168.211.138: Cancelling existing connect task with state ReconnectLogicState.CONNECTING, to try again now!
DEBUG Removing zeroconf listener for picoproxy
DEBUG Trying to connect to picoproxy @ 192.168.211.138
DEBUG Cleaning up connection to picoproxy @ 192.168.211.138
DEBUG Can't connect to ESPHome API for picoproxy @ 192.168.211.138: Error while starting connection: Starting connection cancelled (APIConnectionCancelledError)
DEBUG Retrying picoproxy @ 192.168.211.138 in 60.00 seconds
DEBUG Starting zeroconf listener for picoproxy
```