### PR TITLE
Fix races in bluetooth device connect

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -530,9 +530,8 @@ class APIClient:
 
     def _handle_timeout(self, fut: asyncio.Future[None]) -> None:
         """Handle a timeout."""
-        if fut.done():
-            return
-        fut.set_exception(asyncio.TimeoutError)
+        if not fut.done():
+            fut.set_exception(asyncio.TimeoutError)
 
     def _on_bluetooth_device_connection_response(
         self,

--- a/aioesphomeapi/client_callbacks.pxd
+++ b/aioesphomeapi/client_callbacks.pxd
@@ -8,3 +8,5 @@ cdef object CameraImageResponse, CameraState
 cdef object HomeassistantServiceCall
 
 cdef object BluetoothLEAdvertisement
+
+cdef object asyncio_TimeoutError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1487,7 +1487,6 @@ async def test_bluetooth_device_connect(
 ) -> None:
     """Test bluetooth_device_connect."""
     client, connection, transport, protocol = api_client
-    send = client._connection.send_messages = MagicMock()
     states = []
 
     def on_bluetooth_connection_state(connected: bool, mtu: int, error: int) -> None:
@@ -1512,8 +1511,8 @@ async def test_bluetooth_device_connect(
 
     await connect_task
     assert states == [(True, 23, 0)]
-    send.assert_called_once_with(
-        (
+    transport.write.assert_called_once_with(
+        generate_plaintext_packet(
             BluetoothDeviceRequest(
                 address=1234,
                 request_type=method,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1539,12 +1539,12 @@ async def test_bluetooth_device_connect(
 
 
 @pytest.mark.asyncio
-async def test_bluetooth_device_connect_times_out(
+async def test_bluetooth_device_connect_and_disconnect_times_out(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
     ],
 ) -> None:
-    """Test bluetooth_device_connect times out."""
+    """Test bluetooth_device_connect and disconnect times out."""
     client, connection, transport, protocol = api_client
     states = []
 
@@ -1562,6 +1562,48 @@ async def test_bluetooth_device_connect_times_out(
             address_type=1,
         )
     )
+    with pytest.raises(TimeoutAPIError):
+        await connect_task
+    assert states == []
+
+
+@pytest.mark.asyncio
+async def test_bluetooth_device_connect_times_out_disconnect_ok(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test bluetooth_device_connect and disconnect times out."""
+    client, connection, transport, protocol = api_client
+    states = []
+
+    def on_bluetooth_connection_state(connected: bool, mtu: int, error: int) -> None:
+        states.append((connected, mtu, error))
+
+    connect_task = asyncio.create_task(
+        client.bluetooth_device_connect(
+            1234,
+            on_bluetooth_connection_state,
+            timeout=0,
+            feature_flags=0,
+            has_cache=True,
+            disconnect_timeout=1,
+            address_type=1,
+        )
+    )
+    await asyncio.sleep(0)
+    # The connect request should be written
+    assert len(transport.write.mock_calls) == 1
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    # Now that we timed out, the disconnect
+    # request should be written
+    assert len(transport.write.mock_calls) == 2
+    response: message.Message = BluetoothDeviceConnectionResponse(
+        address=1234, connected=False, mtu=23, error=8
+    )
+    mock_data_received(protocol, generate_plaintext_packet(response))
     with pytest.raises(TimeoutAPIError):
         await connect_task
     assert states == []


### PR DESCRIPTION
- The `on_bluetooth_connection_state` callback would still be called with `connected=False` if connecting timed out even though we raised `TimeoutError` because we called `_bluetooth_device_disconnect_guard_timeout` which also causes the ESP to send back `BluetoothDeviceConnectionResponse` before unsubbing the message listener so it would leak to the original caller.
- remove unreachable code. There was a check for KeyError and ValueError which are now impossible
