### PR TITLE
Fix discover cli tool when address is missing from mdns

### DIFF
--- a/aioesphomeapi/discover.py
+++ b/aioesphomeapi/discover.py
@@ -40,7 +40,7 @@ def async_service_update(
     version = decode_bytes_or_none(properties.get(b"version"))
     platform = decode_bytes_or_none(properties.get(b"platform"))
     board = decode_bytes_or_none(properties.get(b"board"))
-    address = None
+    address = ""
     if addresses := info.ip_addresses_by_version(IPVersion.V4Only):
         address = str(addresses[0])
 


### PR DESCRIPTION
```
  File "src/zeroconf/_services/__init__.py", line 56, in zeroconf._services.Signal.fire
  File "/opt/homebrew/lib/python3.11/site-packages/aioesphomeapi/discover.py", line 47, in async_service_update
    print(FORMAT.format(state, short_name, address, mac, version, platform, board))
```