### PR TITLE
Use background task logic for the on_stop callback

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -206,7 +206,6 @@ class APIClient:
         "cached_name",
         "_background_tasks",
         "_loop",
-        "_on_stop_task",
         "log_name",
     )
 


### PR DESCRIPTION
We had duplicate logic here now that we have a way to create background task we can do them all the same way