### PR TITLE
Small speed up to writing outgoing packets

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -5,7 +5,6 @@ from ..connection cimport APIConnection
 
 
 cdef bint TYPE_CHECKING
-cdef object WRITE_EXCEPTIONS
 
 cdef class APIFrameHelper:
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -189,9 +189,4 @@ class APIFrameHelper:
         if TYPE_CHECKING:
             assert self._writer is not None, "Writer is not set"
 
-        try:
-            self._writer(data)
-        except WRITE_EXCEPTIONS as err:
-            raise SocketClosedAPIError(
-                f"{self._log_name}: Error while writing data: {err}"
-            ) from err
+        self._writer(data)

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -19,7 +19,6 @@ SOCKET_ERRORS = (
     TimeoutError,
 )
 
-WRITE_EXCEPTIONS = (RuntimeError, ConnectionResetError, OSError)
 
 _int = int
 _bytes = bytes

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -13,6 +13,8 @@ cdef object HANDSHAKE_TIMEOUT
 
 cdef bint TYPE_CHECKING
 
+cdef object WRITE_EXCEPTIONS
+
 cdef object DISCONNECT_REQUEST_MESSAGE
 cdef tuple DISCONNECT_RESPONSE_MESSAGES
 cdef tuple PING_REQUEST_MESSAGES
@@ -46,6 +48,7 @@ cdef object ReadFailedAPIError
 cdef object TimeoutAPIError
 cdef object SocketAPIError
 cdef object InvalidAuthAPIError
+cdef object SocketClosedAPIError
 
 cdef object astuple
 
@@ -57,8 +60,8 @@ cdef object CONNECTION_STATE_CLOSED
 
 cdef object make_hello_request
 
-cpdef handle_timeout(object fut)
-cpdef handle_complex_message(
+cpdef void handle_timeout(object fut)
+cpdef void handle_complex_message(
     object fut,
     list responses,
     object do_append,
@@ -130,7 +133,7 @@ cdef class APIConnection:
 
     cdef void _set_connection_state(self, object state)
 
-    cpdef report_fatal_error(self, Exception err)
+    cpdef void report_fatal_error(self, Exception err)
 
     @cython.locals(handlers=set)
     cdef void _add_message_callback_without_remove(self, object on_message, tuple msg_types)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -19,7 +19,6 @@ from google.protobuf import message
 
 import aioesphomeapi.host_resolver as hr
 
-from ._frame_helper.base import WRITE_EXCEPTIONS
 from ._frame_helper.noise import APINoiseFrameHelper
 from ._frame_helper.plain_text import APIPlaintextFrameHelper
 from .api_pb2 import (  # type: ignore
@@ -96,6 +95,8 @@ CONNECT_REQUEST_TIMEOUT = 30.0
 # The connect timeout should be the maximum time we expect the esp to take
 # to reboot and connect to the network/WiFi.
 TCP_CONNECT_TIMEOUT = 60.0
+
+WRITE_EXCEPTIONS = (RuntimeError, ConnectionResetError, OSError)
 
 
 _int = int


### PR DESCRIPTION
There were two try blocks to convert exception types. Simplify by removing one of the try blocks and converting the exceptions in the connection class