### PR TITLE
Add happy eyeballs support (RFC 8305)

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -280,7 +280,7 @@ class APIClient:
         """Set the log name of the device."""
         resolved_address: str | None = None
         if self._connection and self._connection.resolved_addr_info:
-            resolved_address = self._connection.resolved_addr_info.sockaddr.address
+            resolved_address = self._connection.resolved_addr_info[0].sockaddr.address
         self.log_name = build_log_name(
             self.cached_name,
             self.address,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -373,12 +373,12 @@ class APIConnection:
                 aiohappyeyeballs.pop_addr_infos_interleave(addr_infos, interleave)
 
         if sock is None:
-            if isinstance(last_exception, OSError):
-                raise SocketAPIError(
-                    f"Error connecting to {addr_infos}: {last_exception}"
+            if isinstance(last_exception, asyncio_TimeoutError):
+                raise TimeoutAPIError(
+                    f"Timeout while connecting to {addrs}"
                 ) from last_exception
             raise SocketAPIError(
-                f"Timeout while connecting to {addr_infos}"
+                f"Error connecting to {addrs}: {last_exception}"
             ) from last_exception
 
         self._socket = sock

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -372,15 +372,14 @@ class APIConnection:
                 last_exception = err
                 aiohappyeyeballs.pop_addr_infos_interleave(addr_infos, interleave)
 
-        if not sock:
+        if sock is None:
             if isinstance(last_exception, OSError):
                 raise SocketAPIError(
                     f"Error connecting to {addr_infos}: {last_exception}"
                 ) from last_exception
-            else:
-                raise SocketAPIError(
-                    f"Timeout while connecting to {addr_infos}"
-                ) from last_exception
+            raise SocketAPIError(
+                f"Timeout while connecting to {addr_infos}"
+            ) from last_exception
 
         self._socket = sock
         sock.setblocking(False)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -108,8 +108,10 @@ async def _async_resolve_host_zeroconf(
         timeout,
     )
     addrs: list[AddrInfo] = []
-    for ip in info.ip_addresses_by_version(IPVersion.All):
-        addrs.extend(_async_ip_address_to_addrs(ip, port))  # type: ignore[arg-type]
+    for ip in info.ip_addresses_by_version(IPVersion.V6Only):
+        addrs.extend(_async_ip_address_to_addrs(ip, port))
+    for ip in info.ip_addresses_by_version(IPVersion.V4Only):
+        addrs.extend(_async_ip_address_to_addrs(ip, port))
     return addrs
 
 
@@ -182,7 +184,7 @@ async def async_resolve_host(
     host: str,
     port: int,
     zeroconf_manager: ZeroconfManager | None = None,
-) -> AddrInfo:
+) -> list[AddrInfo]:
     addrs: list[AddrInfo] = []
 
     zc_error = None
@@ -210,6 +212,4 @@ async def async_resolve_host(
             raise zc_error
         raise ResolveAPIError(f"Could not resolve host {host} - got no results from OS")
 
-    # Use first matching result
-    # Future: return all matches and use first working one
-    return addrs[0]
+    return addrs

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -109,9 +109,9 @@ async def _async_resolve_host_zeroconf(
     )
     addrs: list[AddrInfo] = []
     for ip in info.ip_addresses_by_version(IPVersion.V6Only):
-        addrs.extend(_async_ip_address_to_addrs(ip, port))
+        addrs.extend(_async_ip_address_to_addrs(ip, port))  # type: ignore
     for ip in info.ip_addresses_by_version(IPVersion.V4Only):
-        addrs.extend(_async_ip_address_to_addrs(ip, port))
+        addrs.extend(_async_ip_address_to_addrs(ip, port))  # type: ignore
     return addrs
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs>=2.2.0
+aiohappyeyeballs>=2.3.0
 protobuf>=3.19.0
 zeroconf>=0.128.4,<1.0
 chacha20poly1305-reuseable>=0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs>=2.1.0
+aiohappyeyeballs>=2.2.0
 protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
 chacha20poly1305-reuseable>=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs>=2.0.0
+aiohappyeyeballs>=2.1.0
 protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
 chacha20poly1305-reuseable>=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohappyeyeballs>=1.8.1
 protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
 chacha20poly1305-reuseable>=0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs>=1.8.1
+aiohappyeyeballs>=2.0.0
 protobuf>=3.19.0
 zeroconf>=0.36.0,<1.0
 chacha20poly1305-reuseable>=0.2.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,9 @@ async def plaintext_connect_task_no_login(
     transport = MagicMock()
     connected = asyncio.Event()
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -151,7 +153,9 @@ async def plaintext_connect_task_no_login_with_expected_name(
     transport = MagicMock()
     connected = asyncio.Event()
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         event_loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -170,7 +174,9 @@ async def plaintext_connect_task_with_login(
     transport = MagicMock()
     connected = asyncio.Event()
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         event_loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -193,11 +199,15 @@ async def api_client(
         password=None,
     )
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         event_loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
-    ), patch("aioesphomeapi.client.APIConnection", PatchableAPIConnection):
+    ), patch(
+        "aioesphomeapi.client.APIConnection", PatchableAPIConnection
+    ):
         connect_task = asyncio.create_task(connect_client(client, login=False))
         await connected.wait()
         conn = client._connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,14 @@ def async_zeroconf():
 @pytest.fixture
 def resolve_host():
     with patch("aioesphomeapi.host_resolver.async_resolve_host") as func:
-        func.return_value = AddrInfo(
-            family=socket.AF_INET,
-            type=socket.SOCK_STREAM,
-            proto=socket.IPPROTO_TCP,
-            sockaddr=IPv4Sockaddr("10.0.0.512", 6052),
-        )
+        func.return_value = [
+            AddrInfo(
+                family=socket.AF_INET,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+                sockaddr=IPv4Sockaddr("10.0.0.512", 6052),
+            )
+        ]
         yield func
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -194,14 +194,14 @@ async def test_connect_backwards_compat() -> None:
 
 
 @pytest.mark.asyncio
-async def test_finish_connection_wraps_exceptions_as_unhandled_api_error() -> None:
+async def test_finish_connection_wraps_exceptions_as_unhandled_api_error(
+    aiohappyeyeballs_start_connection,
+) -> None:
     """Verify finish_connect re-wraps exceptions as UnhandledAPIError."""
 
     cli = APIClient("1.2.3.4", 1234, None)
     asyncio.get_event_loop()
-    with patch("aioesphomeapi.client.APIConnection", PatchableAPIConnection), patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ):
+    with patch("aioesphomeapi.client.APIConnection", PatchableAPIConnection):
         await cli.start_connection()
 
     with patch.object(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,10 +198,10 @@ async def test_finish_connection_wraps_exceptions_as_unhandled_api_error() -> No
     """Verify finish_connect re-wraps exceptions as UnhandledAPIError."""
 
     cli = APIClient("1.2.3.4", 1234, None)
-    loop = asyncio.get_event_loop()
-    with patch(
-        "aioesphomeapi.client.APIConnection", PatchableAPIConnection
-    ), patch.object(loop, "sock_connect"):
+    asyncio.get_event_loop()
+    with patch("aioesphomeapi.client.APIConnection", PatchableAPIConnection), patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ):
         await cli.start_connection()
 
     with patch.object(
@@ -217,9 +217,12 @@ async def test_finish_connection_wraps_exceptions_as_unhandled_api_error() -> No
 async def test_connection_released_if_connecting_is_cancelled() -> None:
     """Verify connection is unset if connecting is cancelled."""
     cli = APIClient("1.2.3.4", 1234, None)
-    loop = asyncio.get_event_loop()
+    asyncio.get_event_loop()
 
-    with patch.object(loop, "sock_connect", side_effect=partial(asyncio.sleep, 1)):
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
+        side_effect=partial(asyncio.sleep, 1),
+    ):
         start_task = asyncio.create_task(cli.start_connection())
         await asyncio.sleep(0)
         assert cli._connection is not None
@@ -229,9 +232,9 @@ async def test_connection_released_if_connecting_is_cancelled() -> None:
         await start_task
     assert cli._connection is None
 
-    with patch(
-        "aioesphomeapi.client.APIConnection", PatchableAPIConnection
-    ), patch.object(loop, "sock_connect"):
+    with patch("aioesphomeapi.client.APIConnection", PatchableAPIConnection), patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ):
         await cli.start_connection()
         await asyncio.sleep(0)
 
@@ -252,8 +255,9 @@ async def test_request_while_handshaking(event_loop) -> None:
         pass
 
     cli = PatchableApiClient("host", 1234, None)
-    with patch.object(
-        event_loop, "sock_connect", side_effect=partial(asyncio.sleep, 1)
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
+        side_effect=partial(asyncio.sleep, 1),
     ), patch.object(cli, "finish_connection"):
         connect_task = asyncio.create_task(cli.connect())
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -241,14 +241,15 @@ async def test_start_connection_times_out(
     conn: APIConnection, resolve_host, socket_socket
 ):
     """Test handling of start connection timing out."""
-    loop = asyncio.get_event_loop()
+    asyncio.get_event_loop()
 
     async def _mock_socket_connect(*args, **kwargs):
         await asyncio.sleep(500)
 
-    with patch.object(loop, "sock_connect", side_effect=_mock_socket_connect), patch(
-        "aioesphomeapi.connection.TCP_CONNECT_TIMEOUT", 0.0
-    ):
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
+        side_effect=_mock_socket_connect,
+    ), patch("aioesphomeapi.connection.TCP_CONNECT_TIMEOUT", 0.0):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await asyncio.sleep(0)
 
@@ -267,9 +268,12 @@ async def test_start_connection_os_error(
     conn: APIConnection, resolve_host, socket_socket
 ):
     """Test handling of start connection has an OSError."""
-    loop = asyncio.get_event_loop()
+    asyncio.get_event_loop()
 
-    with patch.object(loop, "sock_connect", side_effect=OSError("Socket error")):
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
+        side_effect=OSError("Socket error"),
+    ):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await asyncio.sleep(0)
         with pytest.raises(APIConnectionError, match="Socket error"):
@@ -284,9 +288,12 @@ async def test_start_connection_is_cancelled(
     conn: APIConnection, resolve_host, socket_socket
 ):
     """Test handling of start connection is cancelled."""
-    loop = asyncio.get_event_loop()
+    asyncio.get_event_loop()
 
-    with patch.object(loop, "sock_connect", side_effect=asyncio.CancelledError):
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
+        side_effect=asyncio.CancelledError,
+    ):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await asyncio.sleep(0)
         with pytest.raises(APIConnectionError, match="Starting connection cancelled"):
@@ -559,7 +566,9 @@ async def test_connect_resolver_times_out(
     with patch(
         "aioesphomeapi.host_resolver.async_resolve_host",
         side_effect=asyncio.TimeoutError,
-    ), patch.object(event_loop, "sock_connect"), patch.object(
+    ), patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         event_loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -590,7 +599,9 @@ async def test_disconnect_fails_to_send_response(
         nonlocal expected_disconnect
         expected_disconnect = _expected_disconnect
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -640,7 +651,9 @@ async def test_disconnect_success_case(
         nonlocal expected_disconnect
         expected_disconnect = _expected_disconnect
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -558,7 +558,7 @@ async def test_force_disconnect_fails(
 
 @pytest.mark.asyncio
 async def test_connect_resolver_times_out(
-    conn: APIConnection, socket_socket, event_loop
+    conn: APIConnection, socket_socket, event_loop, aiohappyeyeballs_start_connection
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     transport = MagicMock()
     connected = asyncio.Event()
@@ -566,8 +566,6 @@ async def test_connect_resolver_times_out(
     with patch(
         "aioesphomeapi.host_resolver.async_resolve_host",
         side_effect=asyncio.TimeoutError,
-    ), patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
     ), patch.object(
         event_loop,
         "create_connection",
@@ -584,6 +582,7 @@ async def test_disconnect_fails_to_send_response(
     event_loop: asyncio.AbstractEventLoop,
     resolve_host,
     socket_socket,
+    aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_event_loop()
     transport = MagicMock()
@@ -599,9 +598,7 @@ async def test_disconnect_fails_to_send_response(
         nonlocal expected_disconnect
         expected_disconnect = _expected_disconnect
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -636,6 +633,7 @@ async def test_disconnect_success_case(
     event_loop: asyncio.AbstractEventLoop,
     resolve_host,
     socket_socket,
+    aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_event_loop()
     transport = MagicMock()
@@ -651,9 +649,7 @@ async def test_disconnect_success_case(
         nonlocal expected_disconnect
         expected_disconnect = _expected_disconnect
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -39,9 +39,9 @@ def addr_infos():
 async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     info = MagicMock(auto_spec=AsyncServiceInfo)
     ipv6 = IPv6Address("2001:db8:85a3::8a2e:370:7334%0")
-    info.ip_addresses_by_version.return_value = [
-        ip_address(b"\n\x00\x00*"),
-        ipv6,
+    info.ip_addresses_by_version.side_effect = [
+        [ip_address(b"\n\x00\x00*")],
+        [ipv6],
     ]
     info.async_request = AsyncMock(return_value=True)
     with patch(
@@ -59,9 +59,9 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     zeroconf_manager = ZeroconfManager()
     info = MagicMock(auto_spec=AsyncServiceInfo)
     ipv6 = IPv6Address("2001:db8:85a3::8a2e:370:7334%0")
-    info.ip_addresses_by_version.return_value = [
-        ip_address(b"\n\x00\x00*"),
-        ipv6,
+    info.ip_addresses_by_version.side_effect = [
+        [ip_address(b"\n\x00\x00*")],
+        [ipv6],
     ]
     info.async_request = AsyncMock(return_value=True)
     with patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info):

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -144,7 +144,7 @@ async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
 
     resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
     resolve_addr.assert_not_called()
-    assert ret == addr_infos[0]
+    assert ret == addr_infos
 
 
 @pytest.mark.asyncio
@@ -157,7 +157,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
 
     resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
     resolve_addr.assert_called_once_with("example.local", 6052)
-    assert ret == addr_infos[0]
+    assert ret == addr_infos
 
 
 @pytest.mark.asyncio
@@ -178,7 +178,7 @@ async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)
-    assert ret == addr_infos[0]
+    assert ret == addr_infos
 
 
 @pytest.mark.asyncio
@@ -203,12 +203,14 @@ async def test_resolve_host_with_address(resolve_addr, resolve_zc):
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_not_called()
-    assert ret == hr.AddrInfo(
-        family=socket.AddressFamily.AF_INET,
-        type=socket.SocketKind.SOCK_STREAM,
-        proto=6,
-        sockaddr=hr.IPv4Sockaddr(address="127.0.0.1", port=6052),
-    )
+    assert ret == [
+        hr.AddrInfo(
+            family=socket.AddressFamily.AF_INET,
+            type=socket.SocketKind.SOCK_STREAM,
+            proto=6,
+            sockaddr=hr.IPv4Sockaddr(address="127.0.0.1", port=6052),
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -69,9 +69,13 @@ async def test_log_runner(event_loop: asyncio.AbstractEventLoop, conn: APIConnec
         await original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(cli, "subscribe_logs", _wait_subscribe_cli):
+    ), patch.object(
+        cli, "subscribe_logs", _wait_subscribe_cli
+    ):
         stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
         await connected.wait()
         protocol = cli._connection._frame_helper
@@ -135,9 +139,13 @@ async def test_log_runner_reconnects_on_disconnect(
         await original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(cli, "subscribe_logs", _wait_subscribe_cli):
+    ), patch.object(
+        cli, "subscribe_logs", _wait_subscribe_cli
+    ):
         stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
         await connected.wait()
         protocol = cli._connection._frame_helper
@@ -214,7 +222,9 @@ async def test_log_runner_reconnects_on_subscribe_failure(
     with patch.object(
         cli, "disconnect", partial(cli.disconnect, force=True)
     ), patch.object(cli, "subscribe_logs", _wait_and_fail_subscribe_cli):
-        with patch.object(loop, "sock_connect"), patch.object(
+        with patch(
+            "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+        ), patch.object(
             loop, "create_connection", side_effect=_create_mock_transport_protocol
         ):
             stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
@@ -227,9 +237,13 @@ async def test_log_runner_reconnects_on_subscribe_failure(
 
     assert cli._connection is None
 
-    with patch.object(loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(cli, "subscribe_logs"):
+    ), patch.object(
+        cli, "subscribe_logs"
+    ):
         connected.clear()
         await asyncio.sleep(0)
         async_fire_time_changed(

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -30,7 +30,11 @@ from .common import (
 
 
 @pytest.mark.asyncio
-async def test_log_runner(event_loop: asyncio.AbstractEventLoop, conn: APIConnection):
+async def test_log_runner(
+    event_loop: asyncio.AbstractEventLoop,
+    conn: APIConnection,
+    aiohappyeyeballs_start_connection,
+):
     """Test the log runner logic."""
     loop = asyncio.get_event_loop()
     protocol: APIPlaintextFrameHelper | None = None
@@ -69,13 +73,9 @@ async def test_log_runner(event_loop: asyncio.AbstractEventLoop, conn: APIConnec
         await original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(
-        cli, "subscribe_logs", _wait_subscribe_cli
-    ):
+    ), patch.object(cli, "subscribe_logs", _wait_subscribe_cli):
         stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
         await connected.wait()
         protocol = cli._connection._frame_helper
@@ -100,6 +100,7 @@ async def test_log_runner_reconnects_on_disconnect(
     event_loop: asyncio.AbstractEventLoop,
     conn: APIConnection,
     caplog: pytest.LogCaptureFixture,
+    aiohappyeyeballs_start_connection,
 ) -> None:
     """Test the log runner reconnects on disconnect."""
     loop = asyncio.get_event_loop()
@@ -139,13 +140,9 @@ async def test_log_runner_reconnects_on_disconnect(
         await original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(
-        cli, "subscribe_logs", _wait_subscribe_cli
-    ):
+    ), patch.object(cli, "subscribe_logs", _wait_subscribe_cli):
         stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
         await connected.wait()
         protocol = cli._connection._frame_helper
@@ -181,6 +178,7 @@ async def test_log_runner_reconnects_on_subscribe_failure(
     event_loop: asyncio.AbstractEventLoop,
     conn: APIConnection,
     caplog: pytest.LogCaptureFixture,
+    aiohappyeyeballs_start_connection,
 ) -> None:
     """Test the log runner reconnects on subscribe failure."""
     loop = asyncio.get_event_loop()
@@ -222,9 +220,7 @@ async def test_log_runner_reconnects_on_subscribe_failure(
     with patch.object(
         cli, "disconnect", partial(cli.disconnect, force=True)
     ), patch.object(cli, "subscribe_logs", _wait_and_fail_subscribe_cli):
-        with patch(
-            "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-        ), patch.object(
+        with patch.object(
             loop, "create_connection", side_effect=_create_mock_transport_protocol
         ):
             stop = await async_run(cli, on_log, aio_zeroconf_instance=async_zeroconf)
@@ -237,13 +233,9 @@ async def test_log_runner_reconnects_on_subscribe_failure(
 
     assert cli._connection is None
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop, "create_connection", side_effect=_create_mock_transport_protocol
-    ), patch.object(
-        cli, "subscribe_logs"
-    ):
+    ), patch.object(cli, "subscribe_logs"):
         connected.clear()
         await asyncio.sleep(0)
         async_fire_time_changed(

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -710,7 +710,9 @@ async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventL
         name="fake",
     )
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -726,7 +728,9 @@ async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventL
     assert cli._connection.is_connected is True
     await asyncio.sleep(0)
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -785,7 +789,9 @@ async def test_backoff_on_encryption_error(
         name="fake",
     )
 
-    with patch.object(event_loop, "sock_connect"), patch.object(
+    with patch(
+        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
+    ), patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -672,7 +672,9 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake(
 
 
 @pytest.mark.asyncio
-async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventLoop):
+async def test_handling_unexpected_disconnect(
+    event_loop: asyncio.AbstractEventLoop, aiohappyeyeballs_start_connection
+):
     """Test the disconnect callback fires with expected_disconnect=False."""
     loop = asyncio.get_event_loop()
     protocol: APIPlaintextFrameHelper | None = None
@@ -710,9 +712,7 @@ async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventL
         name="fake",
     )
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -728,9 +728,7 @@ async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventL
     assert cli._connection.is_connected is True
     await asyncio.sleep(0)
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
@@ -750,7 +748,9 @@ async def test_handling_unexpected_disconnect(event_loop: asyncio.AbstractEventL
 
 @pytest.mark.asyncio
 async def test_backoff_on_encryption_error(
-    event_loop: asyncio.AbstractEventLoop, caplog: pytest.LogCaptureFixture
+    event_loop: asyncio.AbstractEventLoop,
+    caplog: pytest.LogCaptureFixture,
+    aiohappyeyeballs_start_connection,
 ) -> None:
     """Test we backoff on encryption error."""
     loop = asyncio.get_event_loop()
@@ -789,9 +789,7 @@ async def test_backoff_on_encryption_error(
         name="fake",
     )
 
-    with patch(
-        "aioesphomeapi.connection.aiohappyeyeballs.start_connection"
-    ), patch.object(
+    with patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),


### PR DESCRIPTION
Adds Happy Eyeballs support (https://datatracker.ietf.org/doc/html/rfc8305)

--

This PR is a first step as I need to make sure this library works for the other projects as well. Its likely to sit for a bit while I test the library with all the projects that need it so there aren't any need to do breaking changes before all the other projects start consuming it:
- https://github.com/aio-libs/aiohttp/pull/7954
- https://github.com/Jc2k/aiohomekit/pull/349

--

replaces and closes #233