### PR TITLE
Bump zeroconf to >=0.128.4,<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 protobuf>=3.19.0
-zeroconf>=0.36.0,<1.0
+zeroconf>=0.128.4,<1.0
 chacha20poly1305-reuseable>=0.2.5
 noiseprotocol>=0.3.1,<1.0
 async-timeout>=4.0;python_version<'3.11'


### PR DESCRIPTION
0.128.4 has some significant bug fixes and the current requirement of 0.36.0 is missing some calls in ServiceInfo that we currently call so it does not work