### PR TITLE
Add support for passing multiple addresses to the client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - run: mypy aioesphomeapi
         name: Check typing with mypy
         if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
-      - run: pytest -vvvs --cov=aioesphomeapi --cov-report=xml --tb=native tests
+      - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --tb=native tests
         name: Run tests with pytest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - run: mypy aioesphomeapi
         name: Check typing with mypy
         if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
-      - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --tb=native tests
+      - run: pytest -vvvs --cov=aioesphomeapi --cov-report=xml --tb=native tests
         name: Run tests with pytest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -283,13 +283,13 @@ class APIClient:
 
     def _set_log_name(self) -> None:
         """Set the log name of the device."""
-        ip_address: str | None = None
+        connected_address: str | None = None
         if self._connection and self._connection.connected_address:
-            ip_address = self._connection.connected_address
+            connected_address = self._connection.connected_address
         self.log_name = build_log_name(
             self.cached_name,
             self._params.addresses,
-            ip_address,
+            connected_address,
         )
         if self._connection:
             self._connection.set_log_name(self.log_name)

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -284,11 +284,8 @@ class APIClient:
     def _set_log_name(self) -> None:
         """Set the log name of the device."""
         ip_address: str | None = None
-        if self._connection:
-            if self._connection.connected_address:
-                ip_address = self._connection.connected_address
-            elif self._connection.resolved_addr_info:
-                ip_address = self._connection.resolved_addr_info[0].sockaddr.address
+        if self._connection and self._connection.connected_address:
+            ip_address = self._connection.connected_address
         self.log_name = build_log_name(
             self.cached_name,
             self.address,
@@ -336,8 +333,8 @@ class APIClient:
             self.log_name,
         )
         await self._execute_connection_coro(self._connection.start_connection())
-        # If we resolved the address, we should set the log name now
-        if self._connection.resolved_addr_info:
+        # If we connected, we should set the log name now
+        if self._connection.connected_address:
             self._set_log_name()
 
     async def finish_connection(

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -288,7 +288,7 @@ class APIClient:
             ip_address = self._connection.connected_address
         self.log_name = build_log_name(
             self.cached_name,
-            self.address,
+            self._params.addresses,
             ip_address,
         )
         if self._connection:

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -74,7 +74,7 @@ cdef object _handle_complex_message
 
 @cython.dataclasses.dataclass
 cdef class ConnectionParams:
-    cdef public str address
+    cdef public list addresses
     cdef public object port
     cdef public object password
     cdef public object client_info
@@ -109,6 +109,7 @@ cdef class APIConnection:
     cdef bint _debug_enabled
     cdef public str received_name
     cdef public object resolved_addr_info
+    cdef public str connected_address
 
     cpdef void send_message(self, object msg)
 

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -108,7 +108,6 @@ cdef class APIConnection:
     cdef bint _handshake_complete
     cdef bint _debug_enabled
     cdef public str received_name
-    cdef public object resolved_addr_info
     cdef public str connected_address
 
     cpdef void send_message(self, object msg)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -231,7 +231,7 @@ class APIConnection:
         # Message handlers currently subscribed to incoming messages
         self._message_handlers: dict[Any, set[Callable[[message.Message], None]]] = {}
         # The friendly name to show for this connection in the logs
-        self.log_name = log_name or params.addresses
+        self.log_name = log_name or ",".join(params.addresses)
 
         # futures currently subscribed to exceptions in the read task
         self._read_exception_futures: set[asyncio.Future[None]] = set()

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -338,11 +338,9 @@ class APIConnection:
         """Step 2 in connect process: connect the socket."""
         if self._debug_enabled:
             _LOGGER.debug(
-                "%s: Connecting to %s:%s (%s)",
+                "%s: Connecting to %s",
                 self.log_name,
-                self._params.addresses,
-                self._params.port,
-                addrs,
+                ", ".join(str(addr.sockaddr) for addr in addrs),
             )
 
         addr_infos: list[aiohappyeyeballs.AddrInfoType] = [

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -207,7 +207,6 @@ class APIConnection:
         "_handshake_complete",
         "_debug_enabled",
         "received_name",
-        "resolved_addr_info",
         "connected_address",
     )
 
@@ -252,7 +251,6 @@ class APIConnection:
         self._handshake_complete = False
         self._debug_enabled = debug_enabled
         self.received_name: str = ""
-        self.resolved_addr_info: list[hr.AddrInfo] = []
         self.connected_address: str | None = None
 
     def set_log_name(self, name: str) -> None:
@@ -572,8 +570,7 @@ class APIConnection:
 
     async def _do_connect(self) -> None:
         """Do the actual connect process."""
-        self.resolved_addr_info = await self._connect_resolve_host()
-        await self._connect_socket_connect(self.resolved_addr_info)
+        await self._connect_socket_connect(await self._connect_resolve_host())
 
     async def start_connection(self) -> None:
         """Start the connection process.

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -393,11 +393,10 @@ class APIConnection:
 
         if self._debug_enabled:
             _LOGGER.debug(
-                "%s: Opened socket to %s:%s (%s)",
+                "%s: Opened socket to %s:%s",
                 self.log_name,
                 self.connected_address,
                 self._params.port,
-                addrs,
             )
 
     async def _connect_init_frame_helper(self) -> None:

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -218,6 +218,8 @@ async def async_resolve_host(
         if zc_error:
             # Only show ZC error if getaddrinfo also didn't work
             raise zc_error
-        raise ResolveAPIError(f"Could not resolve host {host} - got no results from OS")
+        raise ResolveAPIError(
+            f"Could not resolve host {hosts} - got no results from OS"
+        )
 
     return addrs

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -189,9 +189,9 @@ async def async_resolve_host(
 
     for host in hosts:
         host_addrs: list[AddrInfo] = []
-        host_is_name = host_is_name_part(host) or address_is_local(host)
+        host_is_local_name = host_is_name_part(host) or address_is_local(host)
 
-        if host_is_name:
+        if host_is_local_name:
             name = host.partition(".")[0]
             try:
                 host_addrs.extend(
@@ -202,7 +202,7 @@ async def async_resolve_host(
             except ResolveAPIError as err:
                 zc_error = err
 
-        if not host_is_name:
+        if not host_is_local_name:
             try:
                 host_addrs.extend(_async_ip_address_to_addrs(ip_address(host), port))
             except ValueError:

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -207,7 +207,7 @@ async def async_resolve_host(
                 host_addrs.extend(_async_ip_address_to_addrs(ip_address(host), port))
             except ValueError:
                 # Not an IP address
-                continue
+                pass
 
         if not host_addrs:
             host_addrs.extend(await _async_resolve_host_getaddrinfo(host, port))

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -46,6 +46,8 @@ def build_log_name(
             name = address.partition(".")[0]
         elif not preferred_address:
             preferred_address = address
+    if not preferred_address:
+        return name or addresses[0]
     if (
         name
         and name != preferred_address

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -40,11 +40,12 @@ def build_log_name(
     name: str | None, addresses: list[str], connected_address: str | None
 ) -> str:
     """Return a log name for a connection."""
+    preferred_address = connected_address
     for address in addresses:
         if not name and address_is_local(address) or host_is_name_part(address):
             name = address.partition(".")[0]
-            break
-    preferred_address = connected_address or address
+        elif not preferred_address:
+            preferred_address = address
     if (
         name
         and name != preferred_address

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -36,11 +36,15 @@ def address_is_local(address: str) -> bool:
     return address.removesuffix(".").endswith(".local")
 
 
-def build_log_name(name: str | None, address: str, resolved_address: str | None) -> str:
+def build_log_name(
+    name: str | None, addresses: list[str], connected_address: str | None
+) -> str:
     """Return a log name for a connection."""
-    if not name and address_is_local(address) or host_is_name_part(address):
-        name = address.partition(".")[0]
-    preferred_address = resolved_address or address
+    for address in addresses:
+        if not name and address_is_local(address) or host_is_name_part(address):
+            name = address.partition(".")[0]
+            break
+    preferred_address = connected_address or address
     if (
         name
         and name != preferred_address

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import socket
 from dataclasses import replace
 from functools import partial
 from typing import Callable
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import pytest_asyncio
@@ -119,7 +119,11 @@ def conn_with_expected_name(connection_params: ConnectionParams) -> APIConnectio
 @pytest.fixture()
 def aiohappyeyeballs_start_connection():
     with patch("aioesphomeapi.connection.aiohappyeyeballs.start_connection") as func:
-        func.return_value = MagicMock(type=socket.SOCK_STREAM)
+        mock_socket = Mock()
+        mock_socket.type = socket.SOCK_STREAM
+        mock_socket.fileno.return_value = 1
+        mock_socket.getpeername.return_value = ("10.0.0.512", 323)
+        func.return_value = mock_socket
         yield func
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def patchable_api_client() -> APIClient:
 
 def get_mock_connection_params() -> ConnectionParams:
     return ConnectionParams(
-        address="fake.address",
+        addresses=["fake.address"],
         port=6052,
         password=None,
         client_info="Tests client",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import socket
 from dataclasses import replace
 from functools import partial
 from typing import Callable
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 import pytest_asyncio
@@ -47,12 +47,6 @@ def resolve_host():
                 sockaddr=IPv4Sockaddr("10.0.0.512", 6052),
             )
         ]
-        yield func
-
-
-@pytest.fixture
-def socket_socket():
-    with patch("socket.socket") as func:
         yield func
 
 
@@ -119,7 +113,7 @@ def conn_with_expected_name(connection_params: ConnectionParams) -> APIConnectio
 @pytest.fixture()
 def aiohappyeyeballs_start_connection():
     with patch("aioesphomeapi.connection.aiohappyeyeballs.start_connection") as func:
-        mock_socket = Mock()
+        mock_socket = create_autospec(socket.socket, spec_set=True, instance=True)
         mock_socket.type = socket.SOCK_STREAM
         mock_socket.fileno.return_value = 1
         mock_socket.getpeername.return_value = ("10.0.0.512", 323)
@@ -143,7 +137,6 @@ def _create_mock_transport_protocol(
 async def plaintext_connect_task_no_login(
     conn: APIConnection,
     resolve_host,
-    socket_socket,
     event_loop,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
@@ -165,7 +158,6 @@ async def plaintext_connect_task_no_login(
 async def plaintext_connect_task_no_login_with_expected_name(
     conn_with_expected_name: APIConnection,
     resolve_host,
-    socket_socket,
     event_loop,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
@@ -188,7 +180,6 @@ async def plaintext_connect_task_no_login_with_expected_name(
 async def plaintext_connect_task_with_login(
     conn_with_password: APIConnection,
     resolve_host,
-    socket_socket,
     event_loop,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
@@ -207,7 +198,7 @@ async def plaintext_connect_task_with_login(
 
 @pytest_asyncio.fixture(name="api_client")
 async def api_client(
-    resolve_host, socket_socket, event_loop, aiohappyeyeballs_start_connection
+    resolve_host, event_loop, aiohappyeyeballs_start_connection
 ) -> tuple[APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -593,7 +593,9 @@ async def test_noise_frame_helper_bad_encryption(
 
 
 @pytest.mark.asyncio
-async def test_init_plaintext_with_wrong_preamble(conn: APIConnection):
+async def test_init_plaintext_with_wrong_preamble(
+    conn: APIConnection, aiohappyeyeballs_start_connection
+):
     loop = asyncio.get_event_loop()
     protocol = get_mock_protocol(conn)
     with patch.object(loop, "create_connection") as create_connection:

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -199,7 +199,8 @@ class MockAPINoiseFrameHelper(APINoiseFrameHelper):
         ),
     ],
 )
-def test_plaintext_frame_helper(
+@pytest.mark.asyncio
+async def test_plaintext_frame_helper(
     in_bytes: bytes, pkt_data: bytes, pkt_type: int
 ) -> None:
     for _ in range(3):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,7 +170,8 @@ def patch_api_version(client: APIClient, version: APIVersion):
     client._connection.api_version = version
 
 
-def test_expected_name(auth_client: APIClient) -> None:
+@pytest.mark.asyncio
+async def test_expected_name(auth_client: APIClient) -> None:
     """Ensure expected name can be set externally."""
     assert auth_client.expected_name is None
     auth_client.expected_name = "awesome"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -571,7 +571,8 @@ async def test_connect_resolver_times_out(
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
     ), pytest.raises(
-        ResolveAPIError, match="Timeout while resolving IP address for fake.address"
+        ResolveAPIError,
+        match=r"Timeout while resolving IP address for \['fake.address'\]",
     ):
         await connect(conn, login=False)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -572,7 +572,7 @@ async def test_connect_resolver_times_out(
         side_effect=partial(_create_mock_transport_protocol, transport, connected),
     ), pytest.raises(
         ResolveAPIError,
-        match=r"Timeout while resolving IP address for \['fake.address'\]",
+        match="Timeout while resolving IP address for fake.address",
     ):
         await connect(conn, login=False)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -221,7 +221,7 @@ async def test_plaintext_connection(
 
 @pytest.mark.asyncio
 async def test_start_connection_socket_error(
-    conn: APIConnection, resolve_host, socket_socket
+    conn: APIConnection, resolve_host, aiohappyeyeballs_start_connection
 ):
     """Test handling of socket error during start connection."""
     loop = asyncio.get_event_loop()
@@ -238,7 +238,7 @@ async def test_start_connection_socket_error(
 
 @pytest.mark.asyncio
 async def test_start_connection_times_out(
-    conn: APIConnection, resolve_host, socket_socket
+    conn: APIConnection, resolve_host, aiohappyeyeballs_start_connection
 ):
     """Test handling of start connection timing out."""
     asyncio.get_event_loop()
@@ -264,9 +264,7 @@ async def test_start_connection_times_out(
 
 
 @pytest.mark.asyncio
-async def test_start_connection_os_error(
-    conn: APIConnection, resolve_host, socket_socket
-):
+async def test_start_connection_os_error(conn: APIConnection, resolve_host):
     """Test handling of start connection has an OSError."""
     asyncio.get_event_loop()
 
@@ -284,9 +282,7 @@ async def test_start_connection_os_error(
 
 
 @pytest.mark.asyncio
-async def test_start_connection_is_cancelled(
-    conn: APIConnection, resolve_host, socket_socket
-):
+async def test_start_connection_is_cancelled(conn: APIConnection, resolve_host):
     """Test handling of start connection is cancelled."""
     asyncio.get_event_loop()
 
@@ -305,7 +301,7 @@ async def test_start_connection_is_cancelled(
 
 @pytest.mark.asyncio
 async def test_finish_connection_is_cancelled(
-    conn: APIConnection, resolve_host, socket_socket
+    conn: APIConnection, resolve_host, aiohappyeyeballs_start_connection
 ):
     """Test handling of finishing connection being cancelled."""
     loop = asyncio.get_event_loop()
@@ -368,7 +364,7 @@ async def test_finish_connection_times_out(
 async def test_plaintext_connection_fails_handshake(
     conn: APIConnection,
     resolve_host: AsyncMock,
-    socket_socket: MagicMock,
+    aiohappyeyeballs_start_connection: MagicMock,
     exception_map: tuple[Exception, Exception],
 ) -> None:
     """Test that the frame helper is closed before the underlying socket.
@@ -558,7 +554,7 @@ async def test_force_disconnect_fails(
 
 @pytest.mark.asyncio
 async def test_connect_resolver_times_out(
-    conn: APIConnection, socket_socket, event_loop, aiohappyeyeballs_start_connection
+    conn: APIConnection, event_loop, aiohappyeyeballs_start_connection
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     transport = MagicMock()
     connected = asyncio.Event()
@@ -582,7 +578,6 @@ async def test_disconnect_fails_to_send_response(
     connection_params: ConnectionParams,
     event_loop: asyncio.AbstractEventLoop,
     resolve_host,
-    socket_socket,
     aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_event_loop()
@@ -633,7 +628,6 @@ async def test_disconnect_success_case(
     connection_params: ConnectionParams,
     event_loop: asyncio.AbstractEventLoop,
     resolve_host,
-    socket_socket,
     aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_event_loop()

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -174,7 +174,7 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = addr_infos
-    ret = await hr.async_resolve_host(["example.local"], 6052)
+    ret = await hr.async_resolve_host(["example.com"], 6052)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)
@@ -187,7 +187,7 @@ async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = []
     with pytest.raises(APIConnectionError):
-        await hr.async_resolve_host(["example.local"], 6052)
+        await hr.async_resolve_host(["example.com"], 6052)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -99,7 +99,7 @@ async def test_resolve_host_zeroconf_fails_end_to_end(async_zeroconf: AsyncZeroc
         "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
         side_effect=Exception("no buffers"),
     ), pytest.raises(ResolveAPIError, match="no buffers"):
-        await hr.async_resolve_host("asdf.local", 6052)
+        await hr.async_resolve_host(["asdf.local"], 6052)
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ async def test_resolve_host_getaddrinfo_oserror(event_loop):
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = addr_infos
-    ret = await hr.async_resolve_host("example.local", 6052)
+    ret = await hr.async_resolve_host(["example.local"], 6052)
 
     resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
     resolve_addr.assert_not_called()
@@ -153,7 +153,7 @@ async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = []
     resolve_addr.return_value = addr_infos
-    ret = await hr.async_resolve_host("example.local", 6052)
+    ret = await hr.async_resolve_host(["example.local"], 6052)
 
     resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
     resolve_addr.assert_called_once_with("example.local", 6052)
@@ -166,7 +166,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
     with pytest.raises(ResolveAPIError):
-        await hr.async_resolve_host("example.local", 6052)
+        await hr.async_resolve_host(["example.local"], 6052)
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = addr_infos
-    ret = await hr.async_resolve_host("example.com", 6052)
+    ret = await hr.async_resolve_host(["example.local"], 6052)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)
@@ -187,7 +187,7 @@ async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = []
     with pytest.raises(APIConnectionError):
-        await hr.async_resolve_host("example.com", 6052)
+        await hr.async_resolve_host(["example.local"], 6052)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_called_once_with("example.com", 6052)
@@ -199,7 +199,7 @@ async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos)
 async def test_resolve_host_with_address(resolve_addr, resolve_zc):
     resolve_zc.return_value = []
     resolve_addr.return_value = addr_infos
-    ret = await hr.async_resolve_host("127.0.0.1", 6052)
+    ret = await hr.async_resolve_host(["127.0.0.1"], 6052)
 
     resolve_zc.assert_not_called()
     resolve_addr.assert_not_called()


### PR DESCRIPTION
If we have multiple IP addresses for the ESPHome device, and we do not know which one we should connect to, they should be passed as `addresses` when creating the `APIClient`

Tweaks Happy Eyeballs delay to 0.1s since we expect its local