### PR TITLE
Refactor raw Bluetooth advs subscriptions

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -31,7 +31,6 @@ from .api_pb2 import (  # type: ignore
     BluetoothGATTWriteRequest,
     BluetoothGATTWriteResponse,
     BluetoothLEAdvertisementResponse,
-    BluetoothLERawAdvertisement,
     BluetoothLERawAdvertisementsResponse,
     ButtonCommandRequest,
     CameraImageRequest,
@@ -72,7 +71,6 @@ from .api_pb2 import (  # type: ignore
     VoiceAssistantResponse,
 )
 from .client_callbacks import (
-    on_ble_raw_advertisement_response,
     on_bluetooth_connections_free_response,
     on_bluetooth_device_connection_response,
     on_bluetooth_gatt_notify_data_response,
@@ -495,13 +493,13 @@ class APIClient:
         return partial(self._unsub_bluetooth_advertisements, unsub_callback)
 
     async def subscribe_bluetooth_le_raw_advertisements(
-        self, on_advertisements: Callable[[list[BluetoothLERawAdvertisement]], None]
+        self, on_advertisements: Callable[[BluetoothLERawAdvertisementsResponse], None]
     ) -> Callable[[], None]:
         unsub_callback = self._get_connection().send_message_callback_response(
             SubscribeBluetoothLEAdvertisementsRequest(
                 flags=BluetoothProxySubscriptionFlag.RAW_ADVERTISEMENTS
             ),
-            partial(on_ble_raw_advertisement_response, on_advertisements),
+            on_advertisements,
             (BluetoothLERawAdvertisementsResponse,),
         )
         return partial(self._unsub_bluetooth_advertisements, unsub_callback)

--- a/aioesphomeapi/client_callbacks.py
+++ b/aioesphomeapi/client_callbacks.py
@@ -17,8 +17,6 @@ from .api_pb2 import (  # type: ignore
     BluetoothGATTReadResponse,
     BluetoothGATTWriteResponse,
     BluetoothLEAdvertisementResponse,
-    BluetoothLERawAdvertisement,
-    BluetoothLERawAdvertisementsResponse,
     CameraImageResponse,
     HomeassistantServiceResponse,
     SubscribeHomeAssistantStateResponse,
@@ -70,13 +68,6 @@ def on_bluetooth_le_advertising_response(
     msg: BluetoothLEAdvertisementResponse,
 ) -> None:
     on_bluetooth_le_advertisement(BluetoothLEAdvertisement.from_pb(msg))  # type: ignore[misc]
-
-
-def on_ble_raw_advertisement_response(
-    on_advertisements: Callable[[list[BluetoothLERawAdvertisement]], None],
-    msg: BluetoothLERawAdvertisementsResponse,
-) -> None:
-    on_advertisements(msg.advertisements)
 
 
 def on_bluetooth_connections_free_response(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1641,9 +1641,9 @@ async def test_subscribe_bluetooth_le_raw_advertisements(
     adv_groups = []
 
     def on_raw_bluetooth_le_advertisements(
-        advs: list[BluetoothLERawAdvertisementsResponse],
+        advs: BluetoothLERawAdvertisementsResponse,
     ) -> None:
-        adv_groups.append(advs)
+        adv_groups.append(advs.advertisements)
 
     unsub = await client.subscribe_bluetooth_le_raw_advertisements(
         on_raw_bluetooth_le_advertisements


### PR DESCRIPTION
Currently we only pass a `list` of `BluetoothLERawAdvertisement` back to the callback, which makes it difficult to change without a breaking change later when we need to add more information about the adv (such as BLE version, etc). 

Instead we now pass the `BluetoothLERawAdvertisementsResponse` object. 

This means we leak the abstraction a bit more, but considering how tightly coupled this all is, that seems like a good trade off to avoid a future breaking change (which is very likely coming with esp-idf 5.x at some point if we add support for extended advertising) now that we will use this in `bleak-esphome` and likely more places.

