### PR TITLE
Avoid creating tasks for starting/finishing the connection

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -98,8 +98,8 @@ cdef class APIConnection:
     cdef object _pong_timer
     cdef float _keep_alive_interval
     cdef float _keep_alive_timeout
-    cdef object _start_connect_task
-    cdef object _finish_connect_task
+    cdef object _start_connect_future
+    cdef object _finish_connect_future
     cdef public Exception _fatal_exception
     cdef bint _expected_disconnect
     cdef object _loop

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -154,3 +154,7 @@ cdef class APIConnection:
     cdef void _register_internal_message_handlers(self)
 
     cdef void _increase_recv_buffer_size(self)
+
+    cdef void _set_start_connect_future(self)
+
+    cdef void _set_finish_connect_future(self)

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -627,7 +627,7 @@ class APIConnection:
         if isinstance(ex, APIConnectionError):
             return ex
         cause: BaseException | None = None
-        if isinstance(ex, CancelledError):
+        if isinstance(ex, (ConnectionInterruptedError, CancelledError)):
             err_str = f"{action.title()} connection cancelled"
             if self._fatal_exception:
                 err_str += f" due to fatal exception: {self._fatal_exception}"

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -286,19 +286,8 @@ class APIConnection:
                 fut.set_exception(new_exc)
         self._read_exception_futures.clear()
 
-        if (
-            self._start_connect_future is not None
-            and not self._start_connect_future.done()
-        ):
-            self._start_connect_future.set_result(None)
-            self._start_connect_future = None
-
-        if (
-            self._finish_connect_future is not None
-            and not self._finish_connect_future.done()
-        ):
-            self._finish_connect_future.set_result(None)
-            self._finish_connect_future = None
+        self._set_start_connect_future()
+        self._set_finish_connect_future()
 
         if self._frame_helper is not None:
             self._frame_helper.close()
@@ -620,13 +609,16 @@ class APIConnection:
             self._cleanup()
             raise self._wrap_fatal_connection_exception("starting", ex)
         finally:
-            if (
-                self._start_connect_future is not None
-                and not self._start_connect_future.done()
-            ):
-                self._start_connect_future.set_result(None)
-                self._start_connect_future = None
+            self._set_start_connect_future()
         self._set_connection_state(CONNECTION_STATE_SOCKET_OPENED)
+
+    def _set_start_connect_future(self) -> None:
+        if (
+            self._start_connect_future is not None
+            and not self._start_connect_future.done()
+        ):
+            self._start_connect_future.set_result(None)
+            self._start_connect_future = None
 
     def _wrap_fatal_connection_exception(
         self, action: str, ex: BaseException
@@ -684,13 +676,16 @@ class APIConnection:
             self._cleanup()
             raise self._wrap_fatal_connection_exception("finishing", ex)
         finally:
-            if (
-                self._finish_connect_future is not None
-                and not self._finish_connect_future.done()
-            ):
-                self._finish_connect_future.set_result(None)
-                self._finish_connect_future = None
+            self._set_finish_connect_future()
         self._set_connection_state(CONNECTION_STATE_CONNECTED)
+
+    def _set_finish_connect_future(self) -> None:
+        if (
+            self._finish_connect_future is not None
+            and not self._finish_connect_future.done()
+        ):
+            self._finish_connect_future.set_result(None)
+            self._finish_connect_future = None
 
     def _set_connection_state(self, state: ConnectionState) -> None:
         """Set the connection state and log the change."""

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -467,19 +467,14 @@ class APIConnection:
             messages.append(self._make_connect_request())
             msg_types.append(ConnectResponse)
 
-        try:
-            responses = await self.send_messages_await_response_complex(
-                tuple(messages),
-                None,
-                lambda resp: type(resp)  # pylint: disable=unidiomatic-typecheck
-                is msg_types[-1],
-                tuple(msg_types),
-                CONNECT_REQUEST_TIMEOUT,
-            )
-        except TimeoutAPIError as err:
-            self.report_fatal_error(err)
-            raise
-
+        responses = await self.send_messages_await_response_complex(
+            tuple(messages),
+            None,
+            lambda resp: type(resp)  # pylint: disable=unidiomatic-typecheck
+            is msg_types[-1],
+            tuple(msg_types),
+            CONNECT_REQUEST_TIMEOUT,
+        )
         resp = responses.pop(0)
         self._process_hello_resp(resp)
         if login:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -281,7 +281,7 @@ class APIConnection:
                 err = self._fatal_exception or APIConnectionError("Connection closed")
                 new_exc = err
                 if not isinstance(err, APIConnectionError):
-                    new_exc = ReadFailedAPIError("Read failed")
+                    new_exc = ReadFailedAPIError(str(err) or "Read failed")
                     new_exc.__cause__ = err
                 fut.set_exception(new_exc)
         self._read_exception_futures.clear()
@@ -461,7 +461,9 @@ class APIConnection:
         try:
             await self._frame_helper.ready_future
         except asyncio_TimeoutError as err:
-            raise TimeoutAPIError("Handshake timed out") from err
+            raise TimeoutAPIError(
+                f"Handshake timed out after {HANDSHAKE_TIMEOUT}s"
+            ) from err
         except OSError as err:
             raise HandshakeAPIError(f"Handshake failed: {err}") from err
         finally:
@@ -487,7 +489,7 @@ class APIConnection:
             )
         except TimeoutAPIError as err:
             self.report_fatal_error(err)
-            raise TimeoutAPIError("Hello timed out") from err
+            raise
 
         resp = responses.pop(0)
         self._process_hello_resp(resp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohappyeyeballs>=2.3.0
+async-interrupt>=1.1.1
 protobuf>=3.19.0
 zeroconf>=0.128.4,<1.0
 chacha20poly1305-reuseable>=0.12.1

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -732,7 +732,6 @@ async def test_eof_received_closes_connection(
         (OSError("original message"), ReadFailedAPIError),
         (APIConnectionError("original message"), APIConnectionError),
         (SocketClosedAPIError("original message"), SocketClosedAPIError),
-        (asyncio.CancelledError("original message"), APIConnectionError),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -748,7 +748,7 @@ async def test_connection_lost_closes_connection_and_logs(
     protocol.connection_lost(exception)
     assert conn.is_connected is False
     assert "original message" in caplog.text
-    with pytest.raises(raised_exception):
+    with pytest.raises(raised_exception, match="original message"):
         await connect_task
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -651,7 +651,7 @@ async def test_force_disconnect_fails(
     ],
 )
 @pytest.mark.asyncio
-async def test_connect_lost_while_connecting(
+async def test_connection_lost_while_connecting(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
     ],

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -30,6 +30,7 @@ from aioesphomeapi.core import (
     InvalidAuthAPIError,
     RequiresEncryptionAPIError,
     ResolveAPIError,
+    SocketClosedAPIError,
     TimeoutAPIError,
 )
 
@@ -461,6 +462,7 @@ async def test_finish_connection_times_out(
     [
         (OSError("Socket error"), HandshakeAPIError),
         (APIConnectionError, APIConnectionError),
+        (SocketClosedAPIError, SocketClosedAPIError),
         (asyncio.TimeoutError, TimeoutAPIError),
         (asyncio.CancelledError, APIConnectionError),
     ],

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -460,6 +460,7 @@ async def test_finish_connection_times_out(
     ("exception_map"),
     [
         (OSError("Socket error"), HandshakeAPIError),
+        (APIConnectionError, APIConnectionError),
         (asyncio.TimeoutError, TimeoutAPIError),
         (asyncio.CancelledError, APIConnectionError),
     ],

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -252,6 +252,11 @@ async def test_log_runner_reconnects_on_subscribe_failure(
 
     stop_task = asyncio.create_task(stop())
     await asyncio.sleep(0)
+
+    send_plaintext_connect_response(protocol, False)
+    send_plaintext_hello(protocol)
+
     disconnect_response = DisconnectResponse()
     mock_data_received(protocol, generate_plaintext_packet(disconnect_response))
+
     await stop_task


### PR DESCRIPTION
We end up creating a lot of tasks when the device is in deep sleep since its trying to reconnect.  We can replace them with `async_interrupt` and futures. This simplifies the connection process and reduces the chance for races.

This also speeds up connections because we don't end up with 3 tasks to make a connection anymore, only 1