### PR TITLE
Convert functions that no longer await to be normal functions

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -410,7 +410,7 @@ class APIClient:
                 entities.append(cls.from_pb(msg))
         return entities, services
 
-    async def subscribe_states(self, on_state: Callable[[EntityState], None]) -> None:
+    def subscribe_states(self, on_state: Callable[[EntityState], None]) -> None:
         """Subscribe to state updates."""
         self._get_connection().send_message_callback_response(
             SubscribeStatesRequest(),
@@ -418,7 +418,7 @@ class APIClient:
             SUBSCRIBE_STATES_MSG_TYPES,
         )
 
-    async def subscribe_logs(
+    def subscribe_logs(
         self,
         on_log: Callable[[SubscribeLogsResponse], None],
         log_level: LogLevel | None = None,
@@ -433,7 +433,7 @@ class APIClient:
             req, on_log, (SubscribeLogsResponse,)
         )
 
-    async def subscribe_service_calls(
+    def subscribe_service_calls(
         self, on_service_call: Callable[[HomeassistantServiceCall], None]
     ) -> None:
         self._get_connection().send_message_callback_response(
@@ -479,7 +479,7 @@ class APIClient:
             unsub_callback()
             self._connection.send_message(UnsubscribeBluetoothLEAdvertisementsRequest())
 
-    async def subscribe_bluetooth_le_advertisements(
+    def subscribe_bluetooth_le_advertisements(
         self, on_bluetooth_le_advertisement: Callable[[BluetoothLEAdvertisement], None]
     ) -> Callable[[], None]:
         unsub_callback = self._get_connection().send_message_callback_response(
@@ -492,7 +492,7 @@ class APIClient:
         )
         return partial(self._unsub_bluetooth_advertisements, unsub_callback)
 
-    async def subscribe_bluetooth_le_raw_advertisements(
+    def subscribe_bluetooth_le_raw_advertisements(
         self, on_advertisements: Callable[[BluetoothLERawAdvertisementsResponse], None]
     ) -> Callable[[], None]:
         unsub_callback = self._get_connection().send_message_callback_response(
@@ -504,7 +504,7 @@ class APIClient:
         )
         return partial(self._unsub_bluetooth_advertisements, unsub_callback)
 
-    async def subscribe_bluetooth_connections_free(
+    def subscribe_bluetooth_connections_free(
         self, on_bluetooth_connections_free_update: Callable[[int, int], None]
     ) -> Callable[[], None]:
         return self._get_connection().send_message_callback_response(
@@ -900,7 +900,7 @@ class APIClient:
 
         return stop_notify, remove_callback
 
-    async def subscribe_home_assistant_states(
+    def subscribe_home_assistant_states(
         self, on_state_sub: Callable[[str, str | None], None]
     ) -> None:
         self._get_connection().send_message_callback_response(
@@ -909,7 +909,7 @@ class APIClient:
             (SubscribeHomeAssistantStateResponse,),
         )
 
-    async def send_home_assistant_state(
+    def send_home_assistant_state(
         self, entity_id: str, attribute: str | None, state: str
     ) -> None:
         self._get_connection().send_message(
@@ -920,7 +920,7 @@ class APIClient:
             )
         )
 
-    async def cover_command(
+    def cover_command(
         self,
         key: int,
         position: float | None = None,
@@ -952,7 +952,7 @@ class APIClient:
                 req.has_legacy_command = True
         self._get_connection().send_message(req)
 
-    async def fan_command(
+    def fan_command(
         self,
         key: int,
         state: bool | None = None,
@@ -983,7 +983,7 @@ class APIClient:
             req.preset_mode = preset_mode
         self._get_connection().send_message(req)
 
-    async def light_command(  # pylint: disable=too-many-branches
+    def light_command(  # pylint: disable=too-many-branches
         self,
         key: int,
         state: bool | None = None,
@@ -1040,10 +1040,10 @@ class APIClient:
             req.effect = effect
         self._get_connection().send_message(req)
 
-    async def switch_command(self, key: int, state: bool) -> None:
+    def switch_command(self, key: int, state: bool) -> None:
         self._get_connection().send_message(SwitchCommandRequest(key=key, state=state))
 
-    async def climate_command(  # pylint: disable=too-many-branches
+    def climate_command(  # pylint: disable=too-many-branches
         self,
         key: int,
         mode: ClimateMode | None = None,
@@ -1097,13 +1097,13 @@ class APIClient:
             req.target_humidity = target_humidity
         self._get_connection().send_message(req)
 
-    async def number_command(self, key: int, state: float) -> None:
+    def number_command(self, key: int, state: float) -> None:
         self._get_connection().send_message(NumberCommandRequest(key=key, state=state))
 
-    async def select_command(self, key: int, state: str) -> None:
+    def select_command(self, key: int, state: str) -> None:
         self._get_connection().send_message(SelectCommandRequest(key=key, state=state))
 
-    async def siren_command(
+    def siren_command(
         self,
         key: int,
         state: bool | None = None,
@@ -1126,10 +1126,10 @@ class APIClient:
             req.has_duration = True
         self._get_connection().send_message(req)
 
-    async def button_command(self, key: int) -> None:
+    def button_command(self, key: int) -> None:
         self._get_connection().send_message(ButtonCommandRequest(key=key))
 
-    async def lock_command(
+    def lock_command(
         self,
         key: int,
         command: LockCommand,
@@ -1140,7 +1140,7 @@ class APIClient:
             req.code = code
         self._get_connection().send_message(req)
 
-    async def media_player_command(
+    def media_player_command(
         self,
         key: int,
         *,
@@ -1160,10 +1160,10 @@ class APIClient:
             req.has_media_url = True
         self._get_connection().send_message(req)
 
-    async def text_command(self, key: int, state: str) -> None:
+    def text_command(self, key: int, state: str) -> None:
         self._get_connection().send_message(TextCommandRequest(key=key, state=state))
 
-    async def execute_service(
+    def execute_service(
         self, service: UserService, data: ExecuteServiceDataType
     ) -> None:
         req = ExecuteServiceRequest(key=service.key)
@@ -1192,18 +1192,16 @@ class APIClient:
 
         self._get_connection().send_message(req)
 
-    async def _request_image(
-        self, *, single: bool = False, stream: bool = False
-    ) -> None:
+    def _request_image(self, *, single: bool = False, stream: bool = False) -> None:
         self._get_connection().send_message(
             CameraImageRequest(single=single, stream=stream)
         )
 
-    async def request_single_image(self) -> None:
-        await self._request_image(single=True)
+    def request_single_image(self) -> None:
+        self._request_image(single=True)
 
-    async def request_image_stream(self) -> None:
-        await self._request_image(stream=True)
+    def request_image_stream(self) -> None:
+        self._request_image(stream=True)
 
     @property
     def api_version(self) -> APIVersion | None:
@@ -1211,7 +1209,7 @@ class APIClient:
             return None
         return self._connection.api_version
 
-    async def subscribe_voice_assistant(
+    def subscribe_voice_assistant(
         self,
         handle_start: Callable[
             [str, int, VoiceAssistantAudioSettingsModel],
@@ -1297,7 +1295,7 @@ class APIClient:
             )
         self._get_connection().send_message(req)
 
-    async def alarm_control_panel_command(
+    def alarm_control_panel_command(
         self,
         key: int,
         command: AlarmControlPanelCommand,

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -33,7 +33,7 @@ async def async_run(
         """Handle a connection."""
         nonlocal dumped_config
         try:
-            await cli.subscribe_logs(
+            cli.subscribe_logs(
                 on_log,
                 log_level=log_level,
                 dump_config=not dumped_config,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -324,7 +324,7 @@ async def test_list_entities(
 async def test_subscribe_states(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_state = MagicMock()
-    await auth_client.subscribe_states(on_state)
+    auth_client.subscribe_states(on_state)
     on_state.assert_not_called()
 
     await send(BinarySensorStateResponse())
@@ -335,7 +335,7 @@ async def test_subscribe_states(auth_client: APIClient) -> None:
 async def test_subscribe_states_camera(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_state = MagicMock()
-    await auth_client.subscribe_states(on_state)
+    auth_client.subscribe_states(on_state)
     await send(CameraImageResponse(key=1, data=b"asdf"))
     on_state.assert_not_called()
 
@@ -374,7 +374,7 @@ async def test_cover_command_legacy(
     send = patch_send(auth_client)
     patch_api_version(auth_client, APIVersion(1, 0))
 
-    await auth_client.cover_command(**cmd)
+    auth_client.cover_command(**cmd)
     send.assert_called_once_with(CoverCommandRequest(**req))
 
 
@@ -398,7 +398,7 @@ async def test_cover_command(
     send = patch_send(auth_client)
     patch_api_version(auth_client, APIVersion(1, 1))
 
-    await auth_client.cover_command(**cmd)
+    auth_client.cover_command(**cmd)
     send.assert_called_once_with(CoverCommandRequest(**req))
 
 
@@ -435,7 +435,7 @@ async def test_fan_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.fan_command(**cmd)
+    auth_client.fan_command(**cmd)
     send.assert_called_once_with(FanCommandRequest(**req))
 
 
@@ -499,7 +499,7 @@ async def test_light_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.light_command(**cmd)
+    auth_client.light_command(**cmd)
     send.assert_called_once_with(LightCommandRequest(**req))
 
 
@@ -516,7 +516,7 @@ async def test_switch_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.switch_command(**cmd)
+    auth_client.switch_command(**cmd)
     send.assert_called_once_with(SwitchCommandRequest(**req))
 
 
@@ -540,7 +540,7 @@ async def test_climate_command_legacy(
     send = patch_send(auth_client)
     patch_api_version(auth_client, APIVersion(1, 4))
 
-    await auth_client.climate_command(**cmd)
+    auth_client.climate_command(**cmd)
     send.assert_called_once_with(ClimateCommandRequest(**req))
 
 
@@ -596,7 +596,7 @@ async def test_climate_command(
     send = patch_send(auth_client)
     patch_api_version(auth_client, APIVersion(1, 5))
 
-    await auth_client.climate_command(**cmd)
+    auth_client.climate_command(**cmd)
     send.assert_called_once_with(ClimateCommandRequest(**req))
 
 
@@ -613,7 +613,7 @@ async def test_number_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.number_command(**cmd)
+    auth_client.number_command(**cmd)
     send.assert_called_once_with(NumberCommandRequest(**req))
 
 
@@ -638,7 +638,7 @@ async def test_lock_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.lock_command(**cmd)
+    auth_client.lock_command(**cmd)
     send.assert_called_once_with(LockCommandRequest(**req))
 
 
@@ -655,7 +655,7 @@ async def test_select_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.select_command(**cmd)
+    auth_client.select_command(**cmd)
     send.assert_called_once_with(SelectCommandRequest(**req))
 
 
@@ -682,7 +682,7 @@ async def test_media_player_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.media_player_command(**cmd)
+    auth_client.media_player_command(**cmd)
     send.assert_called_once_with(MediaPlayerCommandRequest(**req))
 
 
@@ -698,7 +698,7 @@ async def test_button_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.button_command(**cmd)
+    auth_client.button_command(**cmd)
     send.assert_called_once_with(ButtonCommandRequest(**req))
 
 
@@ -732,7 +732,7 @@ async def test_siren_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.siren_command(**cmd)
+    auth_client.siren_command(**cmd)
     send.assert_called_once_with(SirenCommandRequest(**req))
 
 
@@ -757,9 +757,9 @@ async def test_execute_service(auth_client: APIClient) -> None:
     )
 
     with pytest.raises(KeyError):
-        await auth_client.execute_service(service, data={})
+        auth_client.execute_service(service, data={})
 
-    await auth_client.execute_service(
+    auth_client.execute_service(
         service,
         data={
             "arg1": False,
@@ -800,7 +800,7 @@ async def test_execute_service(auth_client: APIClient) -> None:
     )
 
     # Test legacy_int
-    await auth_client.execute_service(
+    auth_client.execute_service(
         service,
         data={
             "arg1": False,
@@ -819,7 +819,7 @@ async def test_execute_service(auth_client: APIClient) -> None:
     send.reset_mock()
 
     # Test arg order
-    await auth_client.execute_service(
+    auth_client.execute_service(
         service,
         data={
             "arg2": 42,
@@ -842,7 +842,7 @@ async def test_execute_service(auth_client: APIClient) -> None:
 async def test_request_single_image(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.request_single_image()
+    auth_client.request_single_image()
     send.assert_called_once_with(CameraImageRequest(single=True, stream=False))
 
 
@@ -850,7 +850,7 @@ async def test_request_single_image(auth_client: APIClient) -> None:
 async def test_request_image_stream(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.request_image_stream()
+    auth_client.request_image_stream()
     send.assert_called_once_with(CameraImageRequest(single=False, stream=True))
 
 
@@ -877,7 +877,7 @@ async def test_alarm_panel_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.alarm_control_panel_command(**cmd)
+    auth_client.alarm_control_panel_command(**cmd)
     send.assert_called_once_with(AlarmControlPanelCommandRequest(**req))
 
 
@@ -894,7 +894,7 @@ async def test_text_command(
 ) -> None:
     send = patch_send(auth_client)
 
-    await auth_client.text_command(**cmd)
+    auth_client.text_command(**cmd)
     send.assert_called_once_with(TextCommandRequest(**req))
 
 
@@ -1536,9 +1536,7 @@ async def test_subscribe_bluetooth_le_advertisements(
     def on_bluetooth_le_advertisements(adv: BluetoothLEAdvertisement) -> None:
         advs.append(adv)
 
-    unsub = await client.subscribe_bluetooth_le_advertisements(
-        on_bluetooth_le_advertisements
-    )
+    unsub = client.subscribe_bluetooth_le_advertisements(on_bluetooth_le_advertisements)
     await asyncio.sleep(0)
     response: message.Message = BluetoothLEAdvertisementResponse(
         address=1234,
@@ -1654,7 +1652,7 @@ async def test_subscribe_bluetooth_le_raw_advertisements(
     ) -> None:
         adv_groups.append(advs.advertisements)
 
-    unsub = await client.subscribe_bluetooth_le_raw_advertisements(
+    unsub = client.subscribe_bluetooth_le_raw_advertisements(
         on_raw_bluetooth_le_advertisements
     )
     await asyncio.sleep(0)
@@ -1692,9 +1690,7 @@ async def test_subscribe_bluetooth_connections_free(
     def on_bluetooth_connections_free(free: int, limit: int) -> None:
         connections.append((free, limit))
 
-    unsub = await client.subscribe_bluetooth_connections_free(
-        on_bluetooth_connections_free
-    )
+    unsub = client.subscribe_bluetooth_connections_free(on_bluetooth_connections_free)
     await asyncio.sleep(0)
     response: message.Message = BluetoothConnectionsFreeResponse(free=2, limit=3)
     mock_data_received(protocol, generate_plaintext_packet(response))
@@ -1718,7 +1714,7 @@ async def test_subscribe_home_assistant_states(
     ) -> None:
         states.append((entity_id, attribute))
 
-    await client.subscribe_home_assistant_states(on_subscribe_home_assistant_states)
+    client.subscribe_home_assistant_states(on_subscribe_home_assistant_states)
     await asyncio.sleep(0)
 
     response: message.Message = SubscribeHomeAssistantStateResponse(
@@ -1733,7 +1729,7 @@ async def test_subscribe_home_assistant_states(
 async def test_subscribe_logs(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_logs = MagicMock()
-    await auth_client.subscribe_logs(on_logs)
+    auth_client.subscribe_logs(on_logs)
     log_msg = SubscribeLogsResponse(level=1, message=b"asdf")
     await send(log_msg)
     on_logs.assert_called_with(log_msg)
@@ -1742,7 +1738,7 @@ async def test_subscribe_logs(auth_client: APIClient) -> None:
 @pytest.mark.asyncio
 async def test_send_home_assistant_state(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
-    await auth_client.send_home_assistant_state("binary_sensor.bla", None, "on")
+    auth_client.send_home_assistant_state("binary_sensor.bla", None, "on")
     send.assert_called_once_with(
         HomeAssistantStateResponse(
             entity_id="binary_sensor.bla", state="on", attribute=None
@@ -1754,7 +1750,7 @@ async def test_send_home_assistant_state(auth_client: APIClient) -> None:
 async def test_subscribe_service_calls(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_service_call = MagicMock()
-    await auth_client.subscribe_service_calls(on_service_call)
+    auth_client.subscribe_service_calls(on_service_call)
     service_msg = HomeassistantServiceResponse(service="bob")
     await send(service_msg)
     on_service_call.assert_called_with(HomeassistantServiceCall.from_pb(service_msg))
@@ -2059,7 +2055,7 @@ async def test_subscribe_voice_assistant(
     async def handle_stop() -> None:
         stops.append(True)
 
-    unsub = await client.subscribe_voice_assistant(handle_start, handle_stop)
+    unsub = client.subscribe_voice_assistant(handle_start, handle_stop)
     send.assert_called_once_with(SubscribeVoiceAssistantRequest(subscribe=True))
     send.reset_mock()
     audio_settings = VoiceAssistantAudioSettings(
@@ -2130,7 +2126,7 @@ async def test_subscribe_voice_assistant_failure(
     async def handle_stop() -> None:
         stops.append(True)
 
-    unsub = await client.subscribe_voice_assistant(handle_start, handle_stop)
+    unsub = client.subscribe_voice_assistant(handle_start, handle_stop)
     send.assert_called_once_with(SubscribeVoiceAssistantRequest(subscribe=True))
     send.reset_mock()
     audio_settings = VoiceAssistantAudioSettings(
@@ -2203,7 +2199,7 @@ async def test_subscribe_voice_assistant_cancels_long_running_handle_start(
     async def handle_stop() -> None:
         stops.append(True)
 
-    unsub = await client.subscribe_voice_assistant(handle_start, handle_stop)
+    unsub = client.subscribe_voice_assistant(handle_start, handle_stop)
     send.assert_called_once_with(SubscribeVoiceAssistantRequest(subscribe=True))
     send.reset_mock()
     audio_settings = VoiceAssistantAudioSettings(

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -68,8 +68,8 @@ async def test_log_runner(
     subscribed = asyncio.Event()
     original_subscribe_logs = cli.subscribe_logs
 
-    async def _wait_subscribe_cli(*args, **kwargs):
-        await original_subscribe_logs(*args, **kwargs)
+    def _wait_subscribe_cli(*args, **kwargs):
+        original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
     with (
@@ -137,8 +137,8 @@ async def test_log_runner_reconnects_on_disconnect(
     subscribed = asyncio.Event()
     original_subscribe_logs = cli.subscribe_logs
 
-    async def _wait_subscribe_cli(*args, **kwargs):
-        await original_subscribe_logs(*args, **kwargs)
+    def _wait_subscribe_cli(*args, **kwargs):
+        original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
     with (
@@ -216,7 +216,7 @@ async def test_log_runner_reconnects_on_subscribe_failure(
 
     subscribed = asyncio.Event()
 
-    async def _wait_and_fail_subscribe_cli(*args, **kwargs):
+    def _wait_and_fail_subscribe_cli(*args, **kwargs):
         subscribed.set()
         raise APIConnectionError("subscribed force to fail")
 


### PR DESCRIPTION
These functions no longer need to be coroutines since there is nothing to be awaited. The protocol does not ACK any of these requests (the connection will drop if there is a failure) so there is no need to make them awaitables