### PR TITLE
Add esphome user to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     && unzip /tmp/protoc.zip -d /usr -x readme.txt \
     && rm /tmp/protoc.zip
 
+RUN useradd -ms /bin/bash esphome
+
+USER esphome
+
 WORKDIR /aioesphomeapi
 
 COPY requirements_test.txt ./


### PR DESCRIPTION
A small development improvement when using devcontainers so that the files are not saved by root, but your local user id correctly.