### PR TITLE
Remove zeroconf listener removal workaround

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -413,16 +413,11 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 self._cli.log_name,
                 record_update.new,
             )
-            # We can't stop the zeroconf listener here because we are in the middle of
-            # a zeroconf callback which is iterating the listeners.
-            #
-            # So we schedule a stop for the next event loop iteration as well as the
-            # connect attempt.
             #
             # If we scheduled the connect attempt immediately, the listener could fire
             # again before the connect attempt and we cancel and reschedule the connect
             # attempt again.
             #
-            self.loop.call_soon(self._connect_from_zeroconf)
+            self._connect_from_zeroconf()
             self._accept_zeroconf_records = False
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohappyeyeballs>=2.3.0
 async-interrupt>=1.1.1
 protobuf>=3.19.0
-zeroconf>=0.132.1,<1.0
+zeroconf>=0.132.2,<1.0
 chacha20poly1305-reuseable>=0.12.1
 cryptography>=42.0.2
 noiseprotocol>=0.3.1,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohappyeyeballs>=2.3.0
 async-interrupt>=1.1.1
 protobuf>=3.19.0
-zeroconf>=0.128.4,<1.0
+zeroconf>=0.132.1,<1.0
 chacha20poly1305-reuseable>=0.12.1
 cryptography>=42.0.2
 noiseprotocol>=0.3.1,<1.0

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -441,8 +441,6 @@ async def test_reconnect_zeroconf(
             "Triggering connect because of received mDNS record" in caplog.text
         ) is should_trigger_zeroconf
         assert rl._accept_zeroconf_records is not should_trigger_zeroconf
-        assert rl._zc_listening is True  # should change after one iteration of the loop
-        await asyncio.sleep(0)
         assert rl._zc_listening is not should_trigger_zeroconf
 
         # The reconnect is scheduled to run in the next loop iteration


### PR DESCRIPTION
[0.132.1 fixes the problem with removing a listener from inside a listener](https://github.com/python-zeroconf/python-zeroconf/pull/1370)

HA has already bumped zeroconf. [Should wait to merge for esphome to bump it as well](https://github.com/esphome/esphome/pull/6548)