### PR TITLE
Add support for creating eager tasks to reduce connect latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,16 @@ jobs:
 
       - run: flake8 aioesphomeapi
         name: Lint with flake8
-        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' }}
       - run: pylint aioesphomeapi
         name: Lint with pylint
-        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' }}
       - run: black --check --diff --color aioesphomeapi tests
         name: Check formatting with black
-        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' }}
       - run: mypy aioesphomeapi
         name: Check typing with mypy
-        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' }}
       - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --tb=native tests
         name: Run tests with pytest
       - name: Upload coverage to Codecov
@@ -98,4 +98,4 @@ jobs:
             exit 1
           fi
         name: Check protobuf files match
-        if: ${{ matrix.python-version == '3.11' && matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' }}

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -139,7 +139,7 @@ from .model_conversions import (
     LIST_ENTITIES_SERVICES_RESPONSE_TYPES,
     SUBSCRIBE_STATES_RESPONSE_TYPES,
 )
-from .util import build_log_name
+from .util import build_log_name, create_eager_task
 from .zeroconf import ZeroconfInstanceType, ZeroconfManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -1311,7 +1311,7 @@ class APIClient:
                 wake_word_phrase: str | None = command.wake_word_phrase
                 if wake_word_phrase == "":
                     wake_word_phrase = None
-                start_task = asyncio.create_task(
+                start_task = create_eager_task(
                     handle_start(
                         command.conversation_id,
                         command.flags,
@@ -1370,7 +1370,7 @@ class APIClient:
 
     def _create_background_task(self, coro: Coroutine[Any, Any, None]) -> None:
         """Create a background task and add it to the background tasks set."""
-        task = asyncio.create_task(coro)
+        task = create_eager_task(coro)
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -18,7 +18,7 @@ from .core import (
     RequiresEncryptionAPIError,
     UnhandledAPIConnectionError,
 )
-from .util import address_is_local, host_is_name_part
+from .util import address_is_local, create_eager_task, host_is_name_part
 from .zeroconf import ZeroconfInstanceType
 
 _LOGGER = logging.getLogger(__name__)
@@ -259,7 +259,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 ReconnectLogicState.DISCONNECTED
             )
 
-        self._connect_task = asyncio.create_task(
+        self._connect_task = create_eager_task(
             self._connect_once_or_reschedule(),
             name=f"{self._cli.log_name}: aioesphomeapi connect",
         )
@@ -318,7 +318,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     def stop_callback(self) -> None:
         """Stop the connect logic."""
-        self._stop_task = asyncio.create_task(
+        self._stop_task = create_eager_task(
             self.stop(),
             name=f"{self._cli.log_name}: aioesphomeapi reconnect_logic stop_callback",
         )

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -4,10 +4,9 @@ from asyncio import AbstractEventLoop, Task, get_running_loop
 from collections.abc import Coroutine
 import math
 import sys
-from typing import Any, TypeVar, TypeVarTuple
+from typing import Any, TypeVar
 
 _T = TypeVar("_T")
-_Ts = TypeVarTuple("_Ts")
 
 
 def fix_float_single_double_conversion(value: float) -> float:

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -72,7 +72,12 @@ if sys.version_info >= (3, 12, 0):
         loop: AbstractEventLoop | None = None,
     ) -> Task[_T]:
         """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(coro, loop=loop or get_running_loop(), name=name, eager_start=True)
+        return Task(
+            coro,
+            loop=loop or get_running_loop(),
+            name=name,
+            eager_start=True,  # type: ignore[call-arg]
+        )
 
 else:
 

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -83,9 +83,5 @@ else:
         name: str | None = None,
         loop: AbstractEventLoop | None = None,
     ) -> Task[_T]:
-        """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(
-            coro,
-            loop=loop or get_running_loop(),
-            name=name,
-        )
+        """Create a task from a coroutine."""
+        return Task(coro, loop=loop or get_running_loop(), name=name)

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from asyncio import AbstractEventLoop, Task, get_running_loop
+from collections.abc import Coroutine
 import math
+import sys
+from typing import Any, TypeVar, TypeVarTuple
+
+_T = TypeVar("_T")
+_Ts = TypeVarTuple("_Ts")
 
 
 def fix_float_single_double_conversion(value: float) -> float:
@@ -55,3 +62,30 @@ def build_log_name(
     ):
         return f"{name} @ {preferred_address}"
     return preferred_address
+
+
+if sys.version_info >= (3, 12, 0):
+
+    def create_eager_task(
+        coro: Coroutine[Any, Any, _T],
+        *,
+        name: str | None = None,
+        loop: AbstractEventLoop | None = None,
+    ) -> Task[_T]:
+        """Create a task from a coroutine and schedule it to run immediately."""
+        return Task(coro, loop=loop or get_running_loop(), name=name, eager_start=True)
+
+else:
+
+    def create_eager_task(
+        coro: Coroutine[Any, Any, _T],
+        *,
+        name: str | None = None,
+        loop: AbstractEventLoop | None = None,
+    ) -> Task[_T]:
+        """Create a task from a coroutine and schedule it to run immediately."""
+        return Task(
+            coro,
+            loop=loop or get_running_loop(),
+            name=name,
+        )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import asyncio
 import math
+import sys
 
 import pytest
 
@@ -32,6 +33,7 @@ def test_fix_float_single_double_conversion_nan():
     assert math.isnan(util.fix_float_single_double_conversion(float("nan")))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test requires Python 3.12+")
 async def test_create_eager_task_312() -> None:
     """Test create_eager_task schedules a task eagerly in the event loop.
 
@@ -49,6 +51,31 @@ async def test_create_eager_task_312() -> None:
     task2 = asyncio.create_task(_normal_task())
 
     assert events == ["eager"]
+
+    await asyncio.sleep(0)
+    assert events == ["eager", "normal"]
+    await task1
+    await task2
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Test requires < Python 3.12")
+async def test_create_eager_task_pre_312() -> None:
+    """Test create_eager_task schedules a task in the event loop.
+
+    For older python versions, the task is scheduled normally.
+    """
+    events = []
+
+    async def _normal_task():
+        events.append("normal")
+
+    async def _eager_task():
+        events.append("eager")
+
+    task1 = util.create_eager_task(_eager_task())
+    task2 = asyncio.create_task(_normal_task())
+
+    assert events == []
 
     await asyncio.sleep(0)
     assert events == ["eager", "normal"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+import asyncio
 import math
 
 import pytest
@@ -29,3 +30,27 @@ def test_fix_float_single_double_conversion(input, output):
 
 def test_fix_float_single_double_conversion_nan():
     assert math.isnan(util.fix_float_single_double_conversion(float("nan")))
+
+
+async def test_create_eager_task_312() -> None:
+    """Test create_eager_task schedules a task eagerly in the event loop.
+
+    For Python 3.12+, the task is scheduled eagerly in the event loop.
+    """
+    events = []
+
+    async def _normal_task():
+        events.append("normal")
+
+    async def _eager_task():
+        events.append("eager")
+
+    task1 = util.create_eager_task(_eager_task())
+    task2 = asyncio.create_task(_normal_task())
+
+    assert events == ["eager"]
+
+    await asyncio.sleep(0)
+    assert events == ["eager", "normal"]
+    await task1
+    await task2


### PR DESCRIPTION
We create tasks within tasks to connect which adds a bit of latency. We can avoid this with eager tasks. We still end up with the happyeyeballs overhead but that can be improved once cpython fixes some of the bugs in `asyncio.staggered` (See https://github.com/aio-libs/aiohttp/issues/8599)