### PR TITLE
remove extraneous dependency on old "mock"

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,4 @@ mypy==1.11.1
 types-protobuf==5.27.0.20240626
 pytest>=6.2.4,<9
 pytest-asyncio==0.23.8
-mock>=4.0.3,<6
 pytest-cov>=4.1.0


### PR DESCRIPTION
this project uses unittest.mock from the standard library