### PR TITLE
Adjust `subscribe_home_assistant_states` to allow separate callback

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -910,11 +910,17 @@ class APIClient:
         return stop_notify, remove_callback
 
     def subscribe_home_assistant_states(
-        self, on_state_sub: Callable[[str, str | None], None]
+        self,
+        on_state_sub: Callable[[str, str | None], None],
+        on_state_request: Callable[[str, str | None], None] | None = None,
     ) -> None:
         self._get_connection().send_message_callback_response(
             SubscribeHomeAssistantStatesRequest(),
-            partial(on_subscribe_home_assistant_state_response, on_state_sub),
+            partial(
+                on_subscribe_home_assistant_state_response,
+                on_state_sub,
+                on_state_request,
+            ),
             (SubscribeHomeAssistantStateResponse,),
         )
 

--- a/aioesphomeapi/client_callbacks.py
+++ b/aioesphomeapi/client_callbacks.py
@@ -90,8 +90,11 @@ def on_bluetooth_gatt_notify_data_response(
 
 def on_subscribe_home_assistant_state_response(
     on_state_sub: Callable[[str, str | None], None],
+    on_state_request: Callable[[str, str | None], None] | None,
     msg: SubscribeHomeAssistantStateResponse,
 ) -> None:
+    if on_state_request and msg.once:
+        on_state_request(msg.entity_id, msg.attribute)
     on_state_sub(msg.entity_id, msg.attribute)
 
 


### PR DESCRIPTION
Added in #923 was the once flag, but I forgot to make a way for the clients using this library to be notified about this as the message itself is not passed outside the library.