### PR TITLE
Try to set TCP_QUICKACK where support for that option is available

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -372,6 +372,13 @@ class APIConnection:
         self._socket = sock
         sock.setblocking(False)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
+        except AttributeError:
+            _LOGGER.debug(
+                "%s: TCP_QUICKACK not supported",
+                self.log_name,
+            )
         self._increase_recv_buffer_size()
         self.connected_address = sock.getpeername()[0]
 


### PR DESCRIPTION
Looking at network traces (on windows), the ESP responds with more data within 20ms to every TCP ACK of an API packet, but the python API consumer doesn't set the proper socket option to disable delayed ack and so windows delays for 40-50ms before sending an ack back.

Delayed ack waits for more data so multiple packets can be acked at the same time, which in most circumstances would be more efficient, except the esp has limited buffer space and must retain the tcp send buffer in case a retry is required if the packet doesn't get acked at all, so by disabling delayed ack on the other side of the API connection, packets can be acked immediately and this loop can be reduced to 1/2 to 1/3rd of it's current latency allowing 2-3x the send buffers to be dispatched over the TCP connection

This will result in less dropped states/events over the API 

In testing on a HAOS virtualbox, I found that TCP_QUICKACK is already set system-wide and so this change is redundant there, but it is helpful for anywhere else the service might run which doesn't have that same default.  It is also useful for the esphome commandline tool which uses the API to get logs after an OTA push. 

Turns out this setting isn't supported in python on windows, only on linux, so I went ahead and fixed that too: https://github.com/python/cpython/pull/123478 