### PR TITLE
Fix crash on Windows when debug logging is enabled

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import aiohappyeyeballs
 from async_interrupt import interrupt
 from google.protobuf import message
+from google.protobuf.json_format import MessageToDict
 
 import aioesphomeapi.host_resolver as hr
 
@@ -712,7 +713,13 @@ class APIConnection:
         if debug_enabled := self._debug_enabled:
             for msg in msgs:
                 _LOGGER.debug(
-                    "%s: Sending %s: %s", self.log_name, type(msg).__name__, msg
+                    "%s: Sending %s: %s",
+                    self.log_name,
+                    type(msg).__name__,
+                    # calling __str__ on the message may crash on
+                    # Windows systems due to a bug in the protobuf library
+                    # so we call MessageToDict instead
+                    MessageToDict(msg),
                 )
 
         if TYPE_CHECKING:
@@ -911,7 +918,10 @@ class APIConnection:
                 "%s: Got message of type %s: %s",
                 self.log_name,
                 msg_type.__name__,
-                msg,
+                # calling __str__ on the message may crash on
+                # Windows systems due to a bug in the protobuf library
+                # so we call MessageToDict instead
+                MessageToDict(msg),
             )
 
         if self._pong_timer is not None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import timedelta
 from functools import partial
 import logging
@@ -268,7 +269,11 @@ async def test_start_connection_cannot_increase_recv_buffer(
     mock_socket.fileno.return_value = 1
     mock_socket.getpeername.return_value = ("10.0.0.512", 323)
     mock_socket.setsockopt = _setsockopt
-    mock_socket.sendmsg.side_effect = OSError("Socket error")
+    with suppress(AttributeError):
+        mock_socket.sendmsg.side_effect = OSError("Socket error")
+    mock_socket.send.side_effect = OSError("Socket error")
+    mock_socket.sendto.side_effect = OSError("Socket error")
+
     aiohappyeyeballs_start_connection.return_value = mock_socket
 
     with patch.object(
@@ -317,7 +322,10 @@ async def test_start_connection_can_only_increase_buffer_size_to_262144(
     mock_socket.fileno.return_value = 1
     mock_socket.getpeername.return_value = ("10.0.0.512", 323)
     mock_socket.setsockopt = _setsockopt
-    mock_socket.sendmsg.side_effect = OSError("Socket error")
+    with suppress(AttributeError):
+        mock_socket.sendmsg.side_effect = OSError("Socket error")
+    mock_socket.send.side_effect = OSError("Socket error")
+    mock_socket.sendto.side_effect = OSError("Socket error")
     aiohappyeyeballs_start_connection.return_value = mock_socket
 
     with patch.object(


### PR DESCRIPTION
There is a bug in protobuf with __str__ on a msg that can cause a crash