### PR TITLE
Speed up decrypting frames

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
       - --force
       - --keep-updates
       files: ^(aioesphomeapi)/.+\.py$
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.16.2
+    hooks:
+    - id: cython-lint
+    - id: double-quote-cython-strings

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -16,7 +16,6 @@ cdef bytes NOISE_HELLO
 
 cdef class EncryptCipher:
 
-    cdef object _key
     cdef object _nonce
     cdef object _encrypt
 
@@ -24,7 +23,6 @@ cdef class EncryptCipher:
 
 cdef class DecryptCipher:
 
-    cdef object _key
     cdef object _nonce
     cdef object _decrypt
 

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -13,6 +13,23 @@ cdef unsigned int NOISE_STATE_CLOSED
 
 cdef bytes NOISE_HELLO
 
+
+cdef class EncryptCipher:
+
+    cdef object _key
+    cdef object _nonce
+    cdef object _encrypt
+
+    cdef bytes encrypt(self, object frame)
+
+cdef class DecryptCipher:
+
+    cdef object _key
+    cdef object _nonce
+    cdef object _decrypt
+
+    cdef bytes decrypt(self, object frame)
+
 cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef object _noise_psk
@@ -20,8 +37,8 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef unsigned int _state
     cdef object _server_name
     cdef object _proto
-    cdef object _decrypt
-    cdef object _encrypt
+    cdef EncryptCipher _encrypt_cipher
+    cdef DecryptCipher _decrypt_cipher
 
     @cython.locals(
         header=bytes,
@@ -59,6 +76,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     @cython.locals(
         type_="unsigned int",
         data=bytes,
+        data_header=bytes,
         packet=tuple,
         data_len=cython.uint,
         frame=bytes,

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -12,7 +12,7 @@ cdef unsigned int NOISE_STATE_READY
 cdef unsigned int NOISE_STATE_CLOSED
 
 cdef bytes NOISE_HELLO
-
+cdef object PACK_NONCE
 
 cdef class EncryptCipher:
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -15,7 +15,7 @@ from noise.backends.default.ciphers import (  # type: ignore[import-untyped]
     CryptographyCipher,
 )
 from noise.connection import NoiseConnection  # type: ignore[import-untyped]
-from noise.state import CipherState
+from noise.state import CipherState  # type: ignore[import-untyped]
 
 from ..core import (
     APIConnectionError,

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -5,7 +5,7 @@ import binascii
 from functools import partial
 import logging
 from struct import Struct
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from chacha20poly1305_reuseable import ChaCha20Poly1305Reusable
 from cryptography.exceptions import InvalidTag
@@ -14,6 +14,7 @@ from noise.backends.default.ciphers import (  # type: ignore[import-untyped]
     ChaCha20Cipher,
 )
 from noise.connection import NoiseConnection  # type: ignore[import-untyped]
+from noise.state import CipherState
 
 from ..core import (
     APIConnectionError,
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
 
 
 PACK_NONCE = partial(Struct("<LQ").pack, 0)
+
+_bytes = bytes
 
 
 class ChaCha20CipherReuseable(ChaCha20Cipher):  # type: ignore[misc]
@@ -68,6 +71,44 @@ NOISE_HELLO = b"\x01\x00\x00"
 int_ = int
 
 
+class EncryptCipher:
+    """Wrapper around the ChaCha20Poly1305 cipher for encryption."""
+
+    __slots__ = ("_key", "_nonce", "_encrypt")
+
+    def __init__(self, cipher_state: CipherState) -> None:
+        """Initialize the cipher wrapper."""
+        cipher: ChaCha20Poly1305Reusable = cipher_state.cipher
+        self._key: bytes = cipher_state.k
+        self._nonce: int = cipher_state.n
+        self._encrypt = cipher.encrypt
+
+    def encrypt(self, data: _bytes) -> bytes:
+        """Encrypt a frame."""
+        ciphertext = self._encrypt(self._key, self._nonce, data, None)
+        self._nonce += 1
+        return ciphertext
+
+
+class DecryptCipher:
+    """Wrapper around the ChaCha20Poly1305 cipher for decryption."""
+
+    __slots__ = ("_key", "_nonce", "_decrypt")
+
+    def __init__(self, cipher_state: CipherState) -> None:
+        """Initialize the cipher wrapper."""
+        cipher: ChaCha20Poly1305Reusable = cipher_state.cipher
+        self._key: bytes = cipher_state.k
+        self._nonce: int = cipher_state.n
+        self._decrypt = cipher.decrypt
+
+    def decrypt(self, data: _bytes) -> bytes:
+        """Decrypt a frame."""
+        plaintext = self._decrypt(self._key, self._nonce, data, None)
+        self._nonce += 1
+        return plaintext
+
+
 class APINoiseFrameHelper(APIFrameHelper):
     """Frame helper for noise encrypted connections."""
 
@@ -77,8 +118,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         "_state",
         "_server_name",
         "_proto",
-        "_decrypt",
-        "_encrypt",
+        "_encrypt_cipher",
+        "_decrypt_cipher",
     )
 
     def __init__(
@@ -95,8 +136,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._expected_name = expected_name
         self._state = NOISE_STATE_HELLO
         self._server_name: str | None = None
-        self._decrypt: Callable[[bytes], bytes] | None = None
-        self._encrypt: Callable[[bytes], bytes] | None = None
+        self._encrypt_cipher: EncryptCipher | None = None
+        self._decrypt_cipher: DecryptCipher | None = None
         self._setup_proto()
 
     def close(self) -> None:
@@ -271,14 +312,8 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._proto.read_message(msg[1:])
         self._state = NOISE_STATE_READY
         noise_protocol = self._proto.noise_protocol
-        self._decrypt = partial(
-            noise_protocol.cipher_state_decrypt.decrypt_with_ad,  # pylint: disable=no-member
-            None,
-        )
-        self._encrypt = partial(
-            noise_protocol.cipher_state_encrypt.encrypt_with_ad,  # pylint: disable=no-member
-            None,
-        )
+        self._decrypt_cipher = DecryptCipher(noise_protocol.cipher_state_decrypt)  # pylint: disable=no-member
+        self._encrypt_cipher = EncryptCipher(noise_protocol.cipher_state_encrypt)  # pylint: disable=no-member
         self.ready_future.set_result(None)
 
     def write_packets(
@@ -289,7 +324,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         Packets are in the format of tuple[protobuf_type, protobuf_data]
         """
         if TYPE_CHECKING:
-            assert self._encrypt is not None, "Handshake should be complete"
+            assert self._encrypt_cipher is not None, "Handshake should be complete"
 
         out: list[bytes] = []
         for packet in packets:
@@ -304,7 +339,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                     data_len & 0xFF,
                 )
             )
-            frame = self._encrypt(data_header + data)
+            frame = self._encrypt_cipher.encrypt(data_header + data)
             frame_len = len(frame)
             header = bytes((0x01, (frame_len >> 8) & 0xFF, frame_len & 0xFF))
             out.append(header)
@@ -315,8 +350,8 @@ class APINoiseFrameHelper(APIFrameHelper):
     def _handle_frame(self, frame: bytes) -> None:
         """Handle an incoming frame."""
         if TYPE_CHECKING:
-            assert self._decrypt is not None, "Handshake should be complete"
-        msg = self._decrypt(frame)
+            assert self._decrypt_cipher is not None, "Handshake should be complete"
+        msg = self._decrypt_cipher.decrypt(frame)
         # Message layout is
         # 2 bytes: message type
         # 2 bytes: message length


### PR DESCRIPTION
Wrap the rust object in a cython wrapper to avoid multiple levels of useless checks to see if there is a key for every packet since we know there always well be.