### PR TITLE
Wrap PACK_NONCE in staticmethod

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -38,7 +38,7 @@ _bytes = bytes
 class ChaCha20CipherReuseable(ChaCha20Cipher):  # type: ignore[misc]
     """ChaCha20 cipher that can be reused."""
 
-    format_nonce = PACK_NONCE
+    format_nonce = staticmethod(PACK_NONCE)
 
     @property
     def klass(self) -> type[ChaCha20Poly1305Reusable]:


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/131769

`2024-11-27 22:07:37.884 WARNING (MainThread) [py.warnings] /usr/local/lib/python3.13/site-packages/noise/backends/default/ciphers.py:13: FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior `