### PR TITLE
Bump protobuf requirement to >=4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs>=2.3.0
 async-interrupt>=1.2.0
-protobuf>=3.19.0
+protobuf>=4
 zeroconf>=0.132.2,<1.0
 chacha20poly1305-reuseable>=0.13.2
 cryptography>=43.0.0


### PR DESCRIPTION
Most downstream is using protobuf 5 and protobuf only supports one version behind.

As a result we see broken cases like https://github.com/home-assistant/core/issues/129052 https://github.com/home-assistant/core/issues/130169
