### PR TITLE
Bump zeroconf requirement to 0.143.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 aiohappyeyeballs>=2.3.0
 async-interrupt>=1.2.0
 protobuf>=4
-zeroconf>=0.132.2,<1.0
+zeroconf>=0.143.0,<1.0
 chacha20poly1305-reuseable>=0.13.2
 cryptography>=43.0.0
 noiseprotocol>=0.3.1,<1.0


### PR DESCRIPTION
Significant bug fixes for the cache that will reduce the dashboard mDNS traffic

changelog: https://github.com/python-zeroconf/python-zeroconf/compare/0.132.2...0.143.0