### PR TITLE
Handle late encryption error

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -13,6 +13,7 @@ cdef unsigned int NOISE_STATE_CLOSED
 
 cdef bytes NOISE_HELLO
 cdef object PACK_NONCE
+cdef object InvalidTag
 
 cdef class EncryptCipher:
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -162,12 +162,6 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"encryption on the client ({self._client_info})."
             )
             exc.__cause__ = original_exc
-        elif isinstance(exc, InvalidTag):
-            original_exc = exc
-            exc = InvalidEncryptionKeyAPIError(
-                f"{self._log_name}: Invalid encryption key", self._server_name
-            )
-            exc.__cause__ = original_exc
         super()._handle_error(exc)
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -20,6 +20,7 @@ from noise.state import CipherState  # type: ignore[import-untyped]
 from ..core import (
     APIConnectionError,
     BadNameAPIError,
+    EncryptionErrorAPIError,
     HandshakeAPIError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
@@ -353,7 +354,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             # but it could happen if the server sends a bad frame see
             # issue https://github.com/esphome/aioesphomeapi/issues/1044
             self._handle_error_and_close(
-                InvalidEncryptionKeyAPIError(
+                EncryptionErrorAPIError(
                     f"{self._log_name}: Encryption error", self._server_name
                 )
             )

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -236,20 +236,24 @@ class InvalidEncryptionKeyAPIError(HandshakeAPIError):
         self.received_name = received_name
 
 
+class EncryptionErrorAPIError(InvalidEncryptionKeyAPIError):
+    """Raised when an encryption error occurs after handshake."""
+
+
 class PingFailedAPIError(APIConnectionError):
-    pass
+    """Raised when a ping fails."""
 
 
 class TimeoutAPIError(APIConnectionError):
-    pass
+    """Raised when a timeout occurs."""
 
 
 class ReadFailedAPIError(APIConnectionError):
-    pass
+    """Raised when a read fails."""
 
 
 class UnhandledAPIConnectionError(APIConnectionError):
-    pass
+    """Raised when an unhandled error occurs."""
 
 
 class BluetoothConnectionDroppedError(APIConnectionError):

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -598,7 +598,7 @@ async def test_noise_frame_helper_bad_encryption(
 
     assert packets == []
     assert connection.is_connected is False
-    assert "Invalid encryption key" in caplog.text
+    assert "Encryption error" in caplog.text
     helper.close()
 
 


### PR DESCRIPTION
We should not see an encryption error after unless the data is corrupted on the wire or there is memory corruption on the ESP, apparently this can happen.  While everything worked OK, the exception reached all the way into asyncio internals so its better to handle it internally.

fixes #1044