### PR TITLE
Resolve hosts in parallel

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -38,7 +38,6 @@ cdef object partial
 
 cdef object hr
 
-cdef object RESOLVE_TIMEOUT
 cdef object CONNECT_AND_SETUP_TIMEOUT, CONNECT_REQUEST_TIMEOUT
 
 cdef object APIConnectionError

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -52,13 +52,8 @@ from .core import (
     UnhandledAPIConnectionError,
 )
 from .model import APIVersion, message_types_to_names
+from .util import asyncio_timeout
 from .zeroconf import ZeroconfManager
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout
-else:
-    from asyncio import timeout as asyncio_timeout
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -589,8 +589,12 @@ class APIConnection:
 
     async def _do_connect(self) -> None:
         """Do the actual connect process."""
+        addrs = self._params.addresses
+        port = self._params.port
+        zc_manager = self._params.zeroconf_manager
         await self._connect_socket_connect(
-            hr.async_addrinfos_from_ips(self._params.addresses, self._params.port)
+            hr.async_addrinfos_from_ips(addrs, port)
+            or hr.async_addrinfos_from_zeroconf_cache(zc_manager, addrs, port)
             or await self._connect_resolve_host()
         )
 

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 
 from aioesphomeapi.model import BluetoothGATTError
@@ -193,7 +194,11 @@ class InvalidAuthAPIError(APIConnectionError):
 
 
 class ResolveAPIError(APIConnectionError):
-    pass
+    """Raised when a resolve error occurs."""
+
+
+class ResolveTimeoutAPIError(ResolveAPIError, asyncio.TimeoutError):
+    """Raised when a resolve timeout occurs."""
 
 
 class ProtocolAPIError(APIConnectionError):

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -108,14 +108,9 @@ async def _async_resolve_host_zeroconf(
         timeout,
     )
     return [
-        *(
             _async_ip_address_to_addrinfo(ip, port)
-            for ip in info.ip_addresses_by_version(IPVersion.V6Only)
-        ),
-        *(
-            _async_ip_address_to_addrinfo(ip, port)
-            for ip in info.ip_addresses_by_version(IPVersion.V4Only)
-        ),
+            for version in (IPVersion.V6Only, IPVersion.V4Only)
+            for ip in info.ip_addresses_by_version(version)
     ]
 
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -259,13 +259,13 @@ async def _async_resolve_host(
     if manager:
         try:
             aiozc = manager.get_async_zeroconf()
-        except Exception as exc:
-            ex = ResolveAPIError(
-                f"Cannot start mDNS sockets: {exc}, is this a docker container without "
-                "host network mode?"
+        except Exception as original_exc:
+            new_exc = ResolveAPIError(
+                f"Cannot start mDNS sockets: {original_exc}, is this a docker container "
+                "without host network mode?"
             )
-            ex.__cause__ = exc
-            exceptions.append(ex)
+            new_exc.__cause__ = original_exc
+            exceptions.append(new_exc)
 
     for host in hosts:
         coros: list[Coroutine[Any, Any, list[AddrInfo]]] = []

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -108,9 +108,14 @@ async def _async_resolve_host_zeroconf(
         timeout,
     )
     return [
+        *(
             _async_ip_address_to_addrinfo(ip, port)
-            for version in (IPVersion.V6Only, IPVersion.V4Only)
-            for ip in info.ip_addresses_by_version(version)
+            for ip in info.ip_addresses_by_version(IPVersion.V6Only)
+        ),
+        *(
+            _async_ip_address_to_addrinfo(ip, port)
+            for ip in info.ip_addresses_by_version(IPVersion.V4Only)
+        ),
     ]
 
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -281,9 +281,8 @@ async def _async_resolve_host(
     for host in hosts:
         coros: list[Coroutine[Any, Any, list[AddrInfo]]] = []
         if aiozc and host_is_local_name(host):
-            coros.append(
-                _async_resolve_short_host_zeroconf(aiozc, host.partition(".")[0], port)
-            )
+            short_host = host.partition(".")[0]
+            coros.append(_async_resolve_short_host_zeroconf(aiozc, short_host, port))
 
         coros.append(_async_resolve_host_getaddrinfo(host, port))
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -260,8 +260,11 @@ async def async_resolve_host(
 
         for coro in coros:
             task = create_eager_task(coro)
-            if task.done() and not task.exception():
-                resolve_results[host].extend(task.result())
+            if task.done():
+                if exc := task.exception():
+                    exceptions.append(exc)
+                elif result := task.result():
+                    resolve_results[host].extend(result)
             else:
                 resolve_task_to_host[task] = host
                 host_tasks[host].add(task)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -75,7 +75,7 @@ async def _async_zeroconf_get_service_info(
         ) from exc
     finally:
         if not had_instance:
-            await zeroconf_manager.async_close()
+            await asyncio.shield(create_eager_task(zeroconf_manager.async_close()))
     return info
 
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -108,9 +108,9 @@ async def _async_resolve_host_zeroconf(
         timeout,
     )
     return [
-            _async_ip_address_to_addrinfo(ip, port)
-            for version in (IPVersion.V6Only, IPVersion.V4Only)
-            for ip in info.ip_addresses_by_version(version)
+        _async_ip_address_to_addrinfo(ip, port)
+        for version in (IPVersion.V6Only, IPVersion.V4Only)
+        for ip in info.ip_addresses_by_version(version)
     ]
 
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -210,7 +210,7 @@ async def async_resolve_host(
     #   we can return that as well
     for host in hosts:
         try:
-            resolve_results[host].extend(
+            resolve_results[host].append(
                 _async_ip_address_to_addrinfo(ip_address(host), port)
             )
         except ValueError:

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -212,12 +212,12 @@ async def async_resolve_host(
         # If its an IP address, we can convert it to an AddrInfo
         # and we are done with this host
         try:
-            resolve_results[host].append(
-                _async_ip_address_to_addrinfo(ip_address(host), port)
-            )
+            ip_addr_info = _async_ip_address_to_addrinfo(ip_address(host), port)
         except ValueError:
             pass
         else:
+            if ip_addr_info:
+                resolve_results[host].append(ip_addr_info)
             continue
 
         if not host_is_local_name(host):
@@ -241,10 +241,10 @@ async def async_resolve_host(
         if aiozc:
             short_host = host.partition(".")[0]
             service_info = _make_service_info_for_short_host(short_host)
-            if service_info.load_from_cache(aiozc.zeroconf):
-                resolve_results[host].extend(
-                    service_info_to_addr_info(service_info, port)
-                )
+            if service_info.load_from_cache(aiozc.zeroconf) and (
+                addr_infos := service_info_to_addr_info(service_info, port)
+            ):
+                resolve_results[host].extend(addr_infos)
 
     if len(resolve_results) != len(hosts):
         # If we have not resolved all hosts yet, we need to do some network calls

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -254,9 +254,6 @@ async def async_resolve_host(
             itertools.chain.from_iterable(host_tasks.values()),
             return_when=asyncio.FIRST_COMPLETED,
         )
-        import pprint
-
-        pprint.pprint(["done", done])
         finished_hosts: set[str] = set()
         for task in done:
             host = resolve_task_to_host[task]

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -332,6 +332,8 @@ async def _async_resolve_host(
                     with suppress(asyncio.CancelledError):
                         await task
     finally:
+        # We likely get here if we get cancelled
+        # because of a timeout
         for task in resolve_task_to_host:
             task.cancel()
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -209,6 +209,8 @@ async def async_resolve_host(
     # - If we have a zeroconf manager and the host is in the cache
     #   we can return that as well
     for host in hosts:
+        # If its an IP address, we can convert it to an AddrInfo
+        # and we are done with this host
         try:
             resolve_results[host].append(
                 _async_ip_address_to_addrinfo(ip_address(host), port)
@@ -221,6 +223,7 @@ async def async_resolve_host(
         if not host_is_local_name(host):
             continue
 
+        # If its a local name, we can try to fetch it from the zeroconf cache
         if not tried_to_create_zeroconf:
             tried_to_create_zeroconf = True
             manager = zeroconf_manager or ZeroconfManager()

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -110,7 +110,7 @@ async def _async_resolve_short_host_zeroconf(
     return service_info_to_addr_info(service_info, port)
 
 
-def service_info_to_addr_info(info: AsyncServiceInfo, port: int) -> None:
+def service_info_to_addr_info(info: AsyncServiceInfo, port: int) -> list[AddrInfo]:
     return [
         _async_ip_address_to_addrinfo(ip, port)
         for version in (IPVersion.V6Only, IPVersion.V4Only)
@@ -176,7 +176,7 @@ def async_addrinfos_from_zeroconf_cache(
             # If any host is not in the cache, return None
             # so we can take teh slow path
             return None
-        addrs.append(service_info_to_addr_info(service_info, port))
+        addrs.extend(service_info_to_addr_info(service_info, port))
     return addrs
 
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -218,7 +218,8 @@ async def async_resolve_host(
     result we get for each host.
     """
     aiozc: AsyncZeroconf | None = None
-    had_instance = False
+    manager: ZeroconfManager | None = None
+    had_instance: bool = False
     if any(host_is_local_name(host) and host.partition(".")[0] for host in hosts):
         manager = zeroconf_manager or ZeroconfManager()
         had_instance = manager.has_instance
@@ -233,8 +234,8 @@ async def async_resolve_host(
     try:
         return await _async_resolve_host(hosts, port, aiozc)
     finally:
-        if aiozc and not had_instance:
-            await asyncio.shield(create_eager_task(zeroconf_manager.async_close()))
+        if manager and not had_instance:
+            await asyncio.shield(create_eager_task(manager.async_close()))
 
 
 async def _async_resolve_host(

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -263,8 +263,8 @@ async def async_resolve_host(
             if task.done():
                 if exc := task.exception():
                     exceptions.append(exc)
-                elif result := task.result():
-                    resolve_results[host].extend(result)
+                else:
+                    resolve_results[host].extend(task.result())
             else:
                 resolve_task_to_host[task] = host
                 host_tasks[host].add(task)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -121,7 +121,7 @@ async def _async_resolve_host_getaddrinfo(host: str, port: int) -> list[AddrInfo
             host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
         )
     except OSError as err:
-        raise ResolveAPIError(f"Error resolving IP address: {err}")
+        raise ResolveAPIError(f"Error resolving {host} to IP address: {err}")
 
     addrs: list[AddrInfo] = []
     for family, type_, proto, _, raw in res:
@@ -233,8 +233,9 @@ async def async_resolve_host(
                 aiozc = manager.get_async_zeroconf()
             except Exception as original_exc:
                 new_exc = ResolveAPIError(
-                    f"Cannot start mDNS sockets: {original_exc}, is this a docker container "
-                    "without host network mode?"
+                    f"Cannot start mDNS sockets while resolving {host}: "
+                    f"{original_exc}, is this a docker container "
+                    "without host network mode? "
                 )
                 new_exc.__cause__ = original_exc
                 exceptions.append(new_exc)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -114,9 +114,10 @@ def service_info_to_addr_info(info: AsyncServiceInfo, port: int) -> list[AddrInf
 
 
 async def _async_resolve_host_getaddrinfo(host: str, port: int) -> list[AddrInfo]:
+    loop = asyncio.get_running_loop()
     try:
         # Limit to TCP IP protocol and SOCK_STREAM
-        res = await asyncio.get_event_loop().getaddrinfo(
+        res = await loop.getaddrinfo(
             host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
         )
     except OSError as err:

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -232,7 +232,7 @@ async def async_resolve_host(
     resolution runs in parallel and we will return the first
     result we get for each host.
     """
-    exceptions: list[Exception] = []
+    exceptions: list[BaseException] = []
     resolve_task_to_host: dict[asyncio.Task[list[AddrInfo]], str] = {}
     host_tasks: defaultdict[str, set[asyncio.Task[list[AddrInfo]]]] = defaultdict(set)
     resolve_results: defaultdict[str, list[AddrInfo]] = defaultdict(list)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -220,7 +220,7 @@ async def async_resolve_host(
     aiozc: AsyncZeroconf | None = None
     manager: ZeroconfManager | None = None
     had_instance: bool = False
-    if any(host_is_local_name(host) and host.partition(".")[0] for host in hosts):
+    if any(host_is_local_name(host) for host in hosts):
         manager = zeroconf_manager or ZeroconfManager()
         had_instance = manager.has_instance
         try:
@@ -257,10 +257,12 @@ async def _async_resolve_host(
             continue
 
         coros: list[Coroutine[Any, Any, list[AddrInfo]]] = []
-        if host_is_local_name(host) and (short_host := host.partition(".")[0]):
+        if host_is_local_name(host):
             if TYPE_CHECKING:
                 assert aiozc is not None
-            coros.append(_async_resolve_short_host_zeroconf(aiozc, short_host, port))
+            coros.append(
+                _async_resolve_short_host_zeroconf(aiozc, host.partition(".")[0], port)
+            )
 
         coros.append(_async_resolve_host_getaddrinfo(host, port))
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -252,7 +252,7 @@ async def async_resolve_host(
             try:
                 async with asyncio_timeout(timeout):
                     await _async_resolve_host(
-                        hosts, port, resolve_results, exceptions, aiozc
+                        hosts, port, resolve_results, exceptions, aiozc, timeout
                     )
             except asyncio.TimeoutError as err:
                 raise ResolveTimeoutAPIError(
@@ -276,6 +276,7 @@ async def _async_resolve_host(
     resolve_results: defaultdict[str, list[AddrInfo]],
     exceptions: list[BaseException],
     aiozc: AsyncZeroconf | None,
+    timeout: float,
 ) -> None:
     """Resolve hosts in parallel."""
     resolve_task_to_host: dict[asyncio.Task[list[AddrInfo]], str] = {}
@@ -285,7 +286,11 @@ async def _async_resolve_host(
         coros: list[Coroutine[Any, Any, list[AddrInfo]]] = []
         if aiozc and host_is_local_name(host):
             short_host = host.partition(".")[0]
-            coros.append(_async_resolve_short_host_zeroconf(aiozc, short_host, port))
+            coros.append(
+                _async_resolve_short_host_zeroconf(
+                    aiozc, short_host, port, timeout=timeout
+                )
+            )
 
         coros.append(_async_resolve_host_getaddrinfo(host, port))
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -279,7 +279,18 @@ async def _async_resolve_host(
     aiozc: AsyncZeroconf | None,
     timeout: float,
 ) -> None:
-    """Resolve hosts in parallel."""
+    """Resolve hosts in parallel.
+
+    As soon as we get a result for a host, we will cancel
+    all other tasks trying to resolve that host.
+
+    This function will resolve hosts in parallel using
+    both mDNS and getaddrinfo.
+
+    This function is also designed to be cancellable, so
+    if we get cancelled, we will cancel all tasks, and
+    clean up after ourselves.
+    """
     resolve_task_to_host: dict[asyncio.Task[list[AddrInfo]], str] = {}
     host_tasks: defaultdict[str, set[asyncio.Task[list[AddrInfo]]]] = defaultdict(set)
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -254,6 +254,7 @@ async def _async_resolve_host(
     resolve_task_to_host: dict[asyncio.Task[list[AddrInfo]], str] = {}
     host_tasks: defaultdict[str, set[asyncio.Task[list[AddrInfo]]]] = defaultdict(set)
     exceptions: list[BaseException] = []
+    aiozc: AsyncZeroconf | None = None
 
     if manager:
         try:

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -247,9 +247,9 @@ async def async_resolve_host(
             ):
                 resolve_results[host].extend(addr_infos)
 
-    if len(resolve_results) != len(hosts):
-        # If we have not resolved all hosts yet, we need to do some network calls
-        try:
+    try:
+        if len(resolve_results) != len(hosts):
+            # If we have not resolved all hosts yet, we need to do some network calls
             try:
                 async with asyncio_timeout(timeout):
                     await _async_resolve_host(
@@ -259,9 +259,9 @@ async def async_resolve_host(
                 raise ResolveTimeoutAPIError(
                     f"Timeout while resolving IP address for {hosts}"
                 ) from err
-        finally:
-            if manager and not had_zeroconf_instance:
-                await asyncio.shield(create_eager_task(manager.async_close()))
+    finally:
+        if manager and not had_zeroconf_instance:
+            await asyncio.shield(create_eager_task(manager.async_close()))
 
     if addrs := list(itertools.chain.from_iterable(resolve_results.values())):
         return addrs

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -258,6 +258,8 @@ async def _async_resolve_host(
 
         coros: list[Coroutine[Any, Any, list[AddrInfo]]] = []
         if host_is_local_name(host) and (short_host := host.partition(".")[0]):
+            if TYPE_CHECKING:
+                assert aiozc is not None
             coros.append(_async_resolve_short_host_zeroconf(aiozc, short_host, port))
 
         coros.append(_async_resolve_host_getaddrinfo(host, port))

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -256,9 +256,7 @@ async def async_resolve_host(
         for task in done:
             host = resolve_task_to_host.pop(task)
             host_tasks[host].discard(task)
-            if task.cancelled():
-                continue
-            elif exc := task.exception():
+            if exc := task.exception():
                 exceptions.append(exc)
             elif result := task.result():
                 resolve_results[host].extend(result)
@@ -269,6 +267,7 @@ async def async_resolve_host(
         # it as we are done with that host
         for host in finished_hosts:
             for task in host_tasks.pop(host, ()):
+                resolve_task_to_host.pop(task, None)
                 task.cancel()
                 with suppress(asyncio.CancelledError):
                     await task

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -9,14 +9,18 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 import itertools
 import logging
 import socket
-import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from zeroconf import IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from .core import ResolveAPIError, ResolveTimeoutAPIError
-from .util import address_is_local, create_eager_task, host_is_name_part
+from .util import (
+    address_is_local,
+    asyncio_timeout,
+    create_eager_task,
+    host_is_name_part,
+)
 from .zeroconf import ZeroconfManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,12 +28,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_TYPE = "_esphomelib._tcp.local."
 RESOLVE_TIMEOUT = 30.0
-
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout
-else:
-    from asyncio import timeout as asyncio_timeout
 
 
 @dataclass(frozen=True)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -219,6 +219,19 @@ async def async_resolve_host(
     port: int,
     zeroconf_manager: ZeroconfManager | None = None,
 ) -> list[AddrInfo]:
+    """Resolve hosts in parallel.
+
+    We will try to resolve the host in the following order:
+    - If the host is an IP address, we will return that and skip
+      trying to resolve it at all.
+
+    - If the host is a local name, we will try to resolve it via mDNS
+    - Otherwise, we will use getaddrinfo to resolve it as well
+
+    Once we know which hosts to resolve and which methods, all
+    resolution runs in parallel and we will return the first
+    result we get for each host.
+    """
     exceptions: list[Exception] = []
     resolve_task_to_host: dict[asyncio.Task[list[AddrInfo]], str] = {}
     host_tasks: defaultdict[str, set[asyncio.Task[list[AddrInfo]]]] = defaultdict(set)

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -108,9 +108,9 @@ async def _async_resolve_host_zeroconf(
         timeout,
     )
     return [
-        _async_ip_address_to_addrinfo(ip, port)
-        for version in (IPVersion.V6Only, IPVersion.V4Only)
-        for ip in info.ip_addresses_by_version(version)
+            _async_ip_address_to_addrinfo(ip, port)
+            for version in (IPVersion.V6Only, IPVersion.V4Only)
+            for ip in info.ip_addresses_by_version(version)
     ]
 
 

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -9,6 +9,12 @@ from typing import Any, TypeVar
 _T = TypeVar("_T")
 
 
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout
+else:
+    from asyncio import timeout as asyncio_timeout  # noqa: F401
+
+
 def fix_float_single_double_conversion(value: float) -> float:
     """Fix precision for single-precision floats and return what was probably
     meant as a float.

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -12,7 +12,7 @@ _T = TypeVar("_T")
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout
 else:
-    from asyncio import timeout as asyncio_timeout  # noqa: F401
+    from asyncio import timeout as asyncio_timeout
 
 
 def fix_float_single_double_conversion(value: float) -> float:
@@ -95,3 +95,13 @@ else:
     ) -> Task[_T]:
         """Create a task from a coroutine."""
         return Task(coro, loop=loop or get_running_loop(), name=name)
+
+
+__all__ = (
+    "address_is_local",
+    "asyncio_timeout",
+    "build_log_name",
+    "create_eager_task",
+    "fix_float_single_double_conversion",
+    "host_is_name_part",
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,7 @@ def get_scheduled_timer_handles(
 
 
 @contextmanager
-def long_repr_strings() -> Generator[None, None, None]:
+def long_repr_strings() -> Generator[None]:
     """Increase reprlib maxstring and maxother to 300."""
     arepr = reprlib.aRepr
     original_maxstring = arepr.maxstring
@@ -277,7 +277,7 @@ def long_repr_strings() -> Generator[None, None, None]:
 @pytest.fixture(autouse=False)  # In the future make this true
 def verify_no_lingering_tasks(
     event_loop: asyncio.AbstractEventLoop,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Verify that all tasks are cleaned up."""
     tasks_before = asyncio.all_tasks(event_loop)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,13 +57,6 @@ def resolve_host() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def convert_ips_addr_info() -> Generator[AsyncMock, None, None]:
-    with patch("aioesphomeapi.host_resolver.async_addrinfos_from_ips") as func:
-        func.return_value = _MOCK_RESOLVE_RESULT
-        yield func
-
-
-@pytest.fixture
 def patchable_api_client() -> APIClient:
     class PatchableAPIClient(APIClient):
         pass
@@ -158,7 +151,6 @@ def _create_mock_transport_protocol(
 async def plaintext_connect_task_no_login(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     loop = asyncio.get_event_loop()
@@ -179,7 +171,6 @@ async def plaintext_connect_task_no_login(
 async def plaintext_connect_task_no_login_with_expected_name(
     conn_with_expected_name: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     event_loop = asyncio.get_running_loop()
@@ -207,7 +198,6 @@ async def plaintext_connect_task_no_login_with_expected_name(
 async def plaintext_connect_task_with_login(
     conn_with_password: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     transport = MagicMock()
@@ -231,7 +221,7 @@ async def plaintext_connect_task_with_login(
 
 @pytest_asyncio.fixture(name="api_client")
 async def api_client(
-    resolve_host, convert_ips_addr_info, aiohappyeyeballs_start_connection
+    resolve_host, aiohappyeyeballs_start_connection
 ) -> tuple[APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
     event_loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,7 +284,7 @@ def long_repr_strings() -> Generator[None, None, None]:
         arepr.maxother = original_maxother
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)  # In the future make this true
 def verify_no_lingering_tasks(
     event_loop: asyncio.AbstractEventLoop,
 ) -> Generator[None, None, None]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -287,7 +287,7 @@ async def test_request_while_handshaking() -> None:
     class PatchableApiClient(APIClient):
         pass
 
-    cli = PatchableApiClient("host", 1234, None)
+    cli = PatchableApiClient("1.2.3.4", 1234, None)
     with (
         patch(
             "aioesphomeapi.connection.aiohappyeyeballs.start_connection",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -230,7 +230,6 @@ async def test_plaintext_connection(
 async def test_start_connection_socket_error(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of socket error during start connection."""
@@ -250,7 +249,6 @@ async def test_start_connection_socket_error(
 async def test_start_connection_cannot_increase_recv_buffer(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ):
@@ -303,7 +301,6 @@ async def test_start_connection_cannot_increase_recv_buffer(
 async def test_start_connection_can_only_increase_buffer_size_to_262144(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ):
@@ -356,7 +353,6 @@ async def test_start_connection_can_only_increase_buffer_size_to_262144(
 async def test_start_connection_times_out(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of start connection timing out."""
@@ -386,9 +382,7 @@ async def test_start_connection_times_out(
 
 
 @pytest.mark.asyncio
-async def test_start_connection_os_error(
-    conn: APIConnection, resolve_host, convert_ips_addr_info
-):
+async def test_start_connection_os_error(conn: APIConnection, resolve_host):
     """Test handling of start connection has an OSError."""
     asyncio.get_event_loop()
 
@@ -406,9 +400,7 @@ async def test_start_connection_os_error(
 
 
 @pytest.mark.asyncio
-async def test_start_connection_is_cancelled(
-    conn: APIConnection, resolve_host, convert_ips_addr_info
-):
+async def test_start_connection_is_cancelled(conn: APIConnection, resolve_host):
     """Test handling of start connection is cancelled."""
     asyncio.get_event_loop()
 
@@ -429,7 +421,6 @@ async def test_start_connection_is_cancelled(
 async def test_finish_connection_is_cancelled(
     conn: APIConnection,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of finishing connection being cancelled."""
@@ -497,7 +488,6 @@ async def test_finish_connection_times_out(
 async def test_plaintext_connection_fails_handshake(
     conn: APIConnection,
     resolve_host: AsyncMock,
-    convert_ips_addr_info: AsyncMock,
     aiohappyeyeballs_start_connection: MagicMock,
     exception_map: tuple[Exception, Exception],
 ) -> None:
@@ -785,11 +775,9 @@ async def test_connect_resolver_times_out(
     with (
         patch(
             "aioesphomeapi.host_resolver.async_resolve_host",
-            side_effect=asyncio.TimeoutError,
-        ),
-        patch(
-            "aioesphomeapi.host_resolver.async_addrinfos_from_ips",
-            return_value=None,
+            side_effect=ResolveAPIError(
+                "Timeout while resolving IP address for fake.address"
+            ),
         ),
         patch.object(
             event_loop,
@@ -808,7 +796,6 @@ async def test_connect_resolver_times_out(
 async def test_disconnect_fails_to_send_response(
     connection_params: ConnectionParams,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_event_loop()
@@ -858,7 +845,6 @@ async def test_disconnect_fails_to_send_response(
 async def test_disconnect_success_case(
     connection_params: ConnectionParams,
     resolve_host,
-    convert_ips_addr_info,
     aiohappyeyeballs_start_connection,
 ) -> None:
     loop = asyncio.get_running_loop()

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -182,6 +182,8 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
     with pytest.raises(ResolveAPIError):
         await hr.async_resolve_host(["example.local"], 6052)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -212,9 +212,10 @@ async def test_resolve_host_mdns_and_dns_slow_mdns_wins(
         await asyncio.sleep(0.1)
         return []
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", slow_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", slow_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -244,9 +245,10 @@ async def test_resolve_host_mdns_and_dns_exception_mdns_wins(
     ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
         raise OSError(None, "DNS exception")
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", slow_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", slow_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -276,9 +278,10 @@ async def test_resolve_host_mdns_and_dns_fast_mdns_wins(
         await asyncio.sleep(0.1)
         return []
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", slow_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", slow_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -310,9 +313,10 @@ async def test_resolve_host_mdns_and_dns_slow_dns_wins(
         await asyncio.sleep(0)
         return mock_getaddrinfo
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", slow_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", slow_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -342,9 +346,10 @@ async def test_resolve_host_mdns_and_mdns_exception_dns_wins(
         await asyncio.sleep(0)
         return mock_getaddrinfo
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", fast_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", fast_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -368,9 +373,10 @@ async def test_resolve_host_mdns_and_mdns_no_results_dns_wins(
         await asyncio.sleep(0)
         return mock_getaddrinfo
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", fast_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", fast_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -398,9 +404,10 @@ async def test_resolve_host_mdns_and_dns_fast_dns_wins(
     ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
         return mock_getaddrinfo
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", fast_getaddrinfo):
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", fast_getaddrinfo),
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert ret == addr_infos
@@ -417,9 +424,10 @@ async def test_resolve_host_mdns_cache(addr_infos: list[AddrInfo]) -> None:
         [TEST_IPv6],
     ]
     info.async_request = AsyncMock(return_value=False)
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo") as mock_getaddrinfo:
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo") as mock_getaddrinfo,
+    ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
 
     assert not mock_getaddrinfo.called
@@ -444,10 +452,10 @@ async def test_resolve_host_mdns_and_mdns_both_fail(
     ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
         raise OSError(None, "DNS exception")
 
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info
-    ), patch.object(loop, "getaddrinfo", fast_fail_getaddrinfo), pytest.raises(
-        ResolveAPIError, match="DNS exception"
+    with (
+        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch.object(loop, "getaddrinfo", fast_fail_getaddrinfo),
+        pytest.raises(ResolveAPIError, match="DNS exception"),
     ):
         await hr.async_resolve_host(["example.local"], 6052)
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -249,8 +249,9 @@ async def test_resolve_host_zeroconf_service_info_oserror(
 
 
 @pytest.mark.asyncio
+@patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_create_zeroconf_oserror(
-    async_zeroconf: AsyncZeroconf, addr_infos
+    resolve_addr, async_zeroconf: AsyncZeroconf, addr_infos
 ):
     info = MagicMock(auto_spec=AsyncServiceInfo)
     info.ip_addresses_by_version.return_value = [

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -518,7 +518,6 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
     with pytest.raises(ResolveAPIError):
         await hr.async_resolve_host(["example.local"], 6052)
-    await asyncio.sleep(0.1)  # give time for close to finish
 
 
 @pytest.mark.asyncio

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -148,12 +148,12 @@ async def test_resolve_host_getaddrinfo_oserror():
 @pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
-async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
+async def test_resolve_host_mdns_and_dns(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = addr_infos
     ret = await hr.async_resolve_host(["example.local"], 6052)
 
     resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
-    resolve_addr.assert_not_called()
+    resolve_addr.assert_called_once_with("example.local", 6052)
     assert ret == addr_infos
 
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -13,6 +13,11 @@ import aioesphomeapi.host_resolver as hr
 from aioesphomeapi.zeroconf import ZeroconfManager
 
 
+@pytest.fixture(autouse=True)
+def enable_verify_no_lingering_tasks(verify_no_lingering_tasks: None) -> None:
+    """Enable verify_no_lingering_tasks."""
+
+
 @pytest.fixture
 def addr_infos():
     return [

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -4,7 +4,7 @@ import asyncio
 from ipaddress import IPv4Address, IPv6Address, ip_address
 import socket
 from typing import Any
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from zeroconf import Zeroconf
@@ -170,6 +170,7 @@ async def test_resolve_host_mdns_and_dns(resolve_addr, resolve_zc, addr_infos):
 async def test_resolve_host_mdns_and_dns_slow(addr_infos: list[AddrInfo]) -> None:
     loop = asyncio.get_running_loop()
     info = MagicMock(auto_spec=AsyncServiceInfo)
+    info.load_from_cache = Mock(return_value=True)
     info.ip_addresses_by_version.side_effect = [
         [TEST_IPv4],
         [TEST_IPv6],

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -182,8 +182,7 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
     with pytest.raises(ResolveAPIError):
         await hr.async_resolve_host(["example.local"], 6052)
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.1)  # give time for close to finish
 
 
 @pytest.mark.asyncio

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -201,7 +201,7 @@ async def test_resolve_host_mdns_and_dns_slow_mdns_wins(
     ]
 
     async def slow_async_request(self, zc: Zeroconf, *args: Any, **kwargs: Any) -> bool:
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0)
         return True
 
     info.async_request = slow_async_request
@@ -239,7 +239,7 @@ async def test_resolve_host_mdns_and_dns_slow_dns_wins(
     info.async_request = slow_async_request
 
     def slow_getaddrinfo() -> list[tuple[int, int, int, str, tuple[str, int]]]:
-        asyncio.sleep(0.1)
+        asyncio.sleep(0)
         return mock_getaddrinfo
 
     with patch(

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -54,7 +54,7 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
         patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
         patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
     ):
-        ret = await hr._async_resolve_short_host_zeroconf("asdf", 6052)
+        ret = await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
     info.async_request.assert_called_once()
     async_zeroconf.async_close.assert_called_once_with()
@@ -73,7 +73,7 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     info.async_request = AsyncMock(return_value=True)
     with patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info):
         ret = await hr._async_resolve_short_host_zeroconf(
-            "asdf", 6052, zeroconf_manager=zeroconf_manager
+            zeroconf_manager.get_async_zeroconf(), "asdf", 6052
         )
 
     info.async_request.assert_called_once()
@@ -85,7 +85,9 @@ async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
     with patch(
         "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request"
     ) as mock_async_request:
-        ret = await hr._async_resolve_short_host_zeroconf("asdf.local", 6052)
+        ret = await hr._async_resolve_short_host_zeroconf(
+            async_zeroconf, "asdf.local", 6052
+        )
     assert mock_async_request.call_count == 1
     assert ret == []
 
@@ -99,7 +101,7 @@ async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
         ),
         pytest.raises(ResolveAPIError, match="no buffers"),
     ):
-        await hr._async_resolve_short_host_zeroconf("asdf.local", 6052)
+        await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf.local", 6052)
 
 
 @pytest.mark.asyncio
@@ -247,7 +249,7 @@ async def test_resolve_host_zeroconf_service_info_oserror(
         patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
         pytest.raises(ResolveAPIError, match="out of buffers"),
     ):
-        await hr._async_resolve_short_host_zeroconf("asdf", 6052)
+        await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
 
 @pytest.mark.asyncio
@@ -267,7 +269,7 @@ async def test_resolve_host_create_zeroconf_oserror(
         ),
         pytest.raises(ResolveAPIError, match="out of buffers"),
     ):
-        await hr._async_resolve_short_host_zeroconf("asdf", 6052)
+        await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
 
 def test_scope_id_to_int():

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -105,7 +105,7 @@ async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
 async def test_resolve_host_zeroconf_fails_end_to_end(async_zeroconf: AsyncZeroconf):
     with (
         patch(
-            "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
+            "aioesphomeapi.host_resolver.ZeroconfManager.get_async_zeroconf",
             side_effect=Exception("no buffers"),
         ),
         pytest.raises(ResolveAPIError, match="no buffers"),

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -10,6 +10,7 @@ from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from aioesphomeapi.core import APIConnectionError, ResolveAPIError
 import aioesphomeapi.host_resolver as hr
+from aioesphomeapi.host_resolver import RESOLVE_TIMEOUT
 
 
 @pytest.fixture(autouse=True)
@@ -155,7 +156,7 @@ async def test_resolve_host_mdns_and_dns(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = addr_infos
     ret = await hr.async_resolve_host(["example.local"], 6052)
 
-    resolve_zc.assert_called_once_with(ANY, "example", 6052)
+    resolve_zc.assert_called_once_with(ANY, "example", 6052, timeout=RESOLVE_TIMEOUT)
     resolve_addr.assert_called_once_with("example.local", 6052)
     assert ret == addr_infos
 
@@ -168,7 +169,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = addr_infos
     ret = await hr.async_resolve_host(["example.local"], 6052)
 
-    resolve_zc.assert_called_once_with(ANY, "example", 6052)
+    resolve_zc.assert_called_once_with(ANY, "example", 6052, timeout=RESOLVE_TIMEOUT)
     resolve_addr.assert_called_once_with("example.local", 6052)
     assert ret == addr_infos
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -49,7 +49,7 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
         patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
         patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
     ):
-        ret = await hr._async_resolve_host_zeroconf("asdf", 6052)
+        ret = await hr._async_resolve_short_host_zeroconf("asdf", 6052)
 
     info.async_request.assert_called_once()
     async_zeroconf.async_close.assert_called_once_with()
@@ -67,7 +67,7 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     ]
     info.async_request = AsyncMock(return_value=True)
     with patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info):
-        ret = await hr._async_resolve_host_zeroconf(
+        ret = await hr._async_resolve_short_host_zeroconf(
             "asdf", 6052, zeroconf_manager=zeroconf_manager
         )
 
@@ -80,7 +80,7 @@ async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
     with patch(
         "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request"
     ) as mock_async_request:
-        ret = await hr._async_resolve_host_zeroconf("asdf.local", 6052)
+        ret = await hr._async_resolve_short_host_zeroconf("asdf.local", 6052)
     assert mock_async_request.call_count == 1
     assert ret == []
 
@@ -94,7 +94,7 @@ async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
         ),
         pytest.raises(ResolveAPIError, match="no buffers"),
     ):
-        await hr._async_resolve_host_zeroconf("asdf.local", 6052)
+        await hr._async_resolve_short_host_zeroconf("asdf.local", 6052)
 
 
 @pytest.mark.asyncio
@@ -146,7 +146,7 @@ async def test_resolve_host_getaddrinfo_oserror():
 
 
 @pytest.mark.asyncio
-@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = addr_infos
@@ -158,7 +158,7 @@ async def test_resolve_host_mdns(resolve_addr, resolve_zc, addr_infos):
 
 
 @pytest.mark.asyncio
-@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_zc.return_value = []
@@ -180,7 +180,7 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
 
 
 @pytest.mark.asyncio
-@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = addr_infos
@@ -192,7 +192,7 @@ async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
 
 
 @pytest.mark.asyncio
-@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = []
@@ -204,7 +204,7 @@ async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos)
 
 
 @pytest.mark.asyncio
-@patch("aioesphomeapi.host_resolver._async_resolve_host_zeroconf")
+@patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_with_address(resolve_addr, resolve_zc):
     resolve_zc.return_value = []
@@ -241,7 +241,7 @@ async def test_resolve_host_zeroconf_service_info_oserror(
         patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
         pytest.raises(ResolveAPIError, match="out of buffers"),
     ):
-        await hr._async_resolve_host_zeroconf("asdf", 6052)
+        await hr._async_resolve_short_host_zeroconf("asdf", 6052)
 
 
 @pytest.mark.asyncio
@@ -261,7 +261,7 @@ async def test_resolve_host_create_zeroconf_oserror(
         ),
         pytest.raises(ResolveAPIError, match="out of buffers"),
     ):
-        await hr._async_resolve_host_zeroconf("asdf", 6052)
+        await hr._async_resolve_short_host_zeroconf("asdf", 6052)
 
 
 def test_scope_id_to_int():

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from ipaddress import IPv6Address, ip_address
 import socket
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
@@ -57,7 +57,6 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
         ret = await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
     info.async_request.assert_called_once()
-    async_zeroconf.async_close.assert_called_once_with()
     assert ret == addr_infos
 
 
@@ -172,7 +171,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     resolve_addr.return_value = addr_infos
     ret = await hr.async_resolve_host(["example.local"], 6052)
 
-    resolve_zc.assert_called_once_with("example", 6052, zeroconf_manager=None)
+    resolve_zc.assert_called_once_with(ANY, "example", 6052)
     resolve_addr.assert_called_once_with("example.local", 6052)
     assert ret == addr_infos
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -58,6 +58,7 @@ async def test_create_eager_task_312() -> None:
     await task2
 
 
+@pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="Test requires < Python 3.12")
 async def test_create_eager_task_pre_312() -> None:
     """Test create_eager_task schedules a task in the event loop.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,6 +33,7 @@ def test_fix_float_single_double_conversion_nan():
     assert math.isnan(util.fix_float_single_double_conversion(float("nan")))
 
 
+@pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test requires Python 3.12+")
 async def test_create_eager_task_312() -> None:
     """Test create_eager_task schedules a task eagerly in the event loop.


### PR DESCRIPTION
If the system doesn't support mDNS, or mDNS will take more time than the timeout to respond, we would never try DNS.  Instead we now resolve mDNS and DNS in parallel.

Additionally we had a 30s timeout to resolve, but the mDNS timeout was only 3s so we would end up timing out too quickly.

Sadly this is a lot more complex than I would like because we support resolving any number of host names at the same time so we can potentially have `X hosts` * `X IPs` results.