### PR TITLE
Test against loopback address

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -287,7 +287,7 @@ async def test_request_while_handshaking() -> None:
     class PatchableApiClient(APIClient):
         pass
 
-    cli = PatchableApiClient("1.2.3.4", 1234, None)
+    cli = PatchableApiClient("127.0.0.1", 1234, None)
     with (
         patch(
             "aioesphomeapi.connection.aiohappyeyeballs.start_connection",


### PR DESCRIPTION
When running the tests in an environment that uses network sandboxing using a random IP address causes issues, because it causes routing errors.

Same as #841 