### PR TITLE
Add the ability to cancel subscribe_logs

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -444,7 +444,7 @@ class APIClient:
 
         Returns a callable that can be called to stop
         the callbacks. Calling the callable only
-        stops the callbacks, the device will still
+        stops the callbacks. The device will still
         send logs until the logging level is set to
         LogLevel.LOG_LEVEL_NONE.
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -442,7 +442,11 @@ class APIClient:
     ) -> Callable[[], None]:
         """Subscribe to logs.
 
-        Returns a callable that can be called to unsubscribe.
+        Returns a callable that can be called to stop
+        the callbacks. Calling the callable only
+        stops the callbacks, the device will still
+        send logs until the logging level is set to
+        LogLevel.LOG_LEVEL_NONE.
 
         To stop the device sending logs completely, call
         with log_level=LogLevel.LOG_LEVEL_NONE, and call the returned

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -439,13 +439,21 @@ class APIClient:
         on_log: Callable[[SubscribeLogsResponse], None],
         log_level: LogLevel | None = None,
         dump_config: bool | None = None,
-    ) -> None:
+    ) -> Callable[[], None]:
+        """Subscribe to logs.
+
+        Returns a callable that can be called to unsubscribe.
+
+        To stop the device sending logs completely, call
+        with log_level=LogLevel.LOG_LEVEL_NONE, and call the returned
+        callable to unsubscribe.
+        """
         req = SubscribeLogsRequest()
         if log_level is not None:
             req.level = log_level
         if dump_config is not None:
             req.dump_config = dump_config
-        self._get_connection().send_message_callback_response(
+        return self._get_connection().send_message_callback_response(
             req, on_log, (SubscribeLogsResponse,)
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,9 +163,17 @@ def patch_response_complex(client: APIClient, messages):
 def patch_response_callback(client: APIClient):
     on_message = None
 
+    def cancelled_on_message(_):
+        """A callback that does nothing."""
+
+    def cancel_callable():
+        nonlocal on_message
+        on_message = cancelled_on_message
+
     def patched(req, callback, msg_types):
         nonlocal on_message
         on_message = callback
+        return cancel_callable
 
     client._connection.send_message_callback_response = patched
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1930,10 +1930,16 @@ async def test_subscribe_home_assistant_states(
 async def test_subscribe_logs(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_logs = MagicMock()
-    auth_client.subscribe_logs(on_logs)
+    cancel = auth_client.subscribe_logs(on_logs)
     log_msg = SubscribeLogsResponse(level=1, message=b"asdf")
     await send(log_msg)
     on_logs.assert_called_with(log_msg)
+    on_logs.reset_mock()
+    cancel()
+    log_msg = SubscribeLogsResponse(level=1, message=b"asdf")
+    await send(log_msg)
+    on_logs.assert_not_called()
+    on_logs.reset_mock()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`subscribe_logs` calls did not have a way to cancel the subscription.
