### PR TITLE
Also catch OSError when trying to set TCP_QUICKACK

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -358,7 +358,7 @@ class APIConnection:
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         try:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)  # type: ignore[attr-defined, unused-ignore]
-        except (AttributeError, OSError):
+        except (AttributeError, OSError):  # On FreeBSD this may throw OSError
             _LOGGER.debug(
                 "%s: TCP_QUICKACK not supported",
                 self.log_name,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -358,7 +358,7 @@ class APIConnection:
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         try:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)  # type: ignore[attr-defined, unused-ignore]
-        except AttributeError:
+        except (AttributeError, OSError):
             _LOGGER.debug(
                 "%s: TCP_QUICKACK not supported",
                 self.log_name,


### PR DESCRIPTION
When running on FreeBSD in Linux compatibility mode `sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)` throws `OSError`, not `AttributeError`.