### PR TITLE
Avoid protobuf lookup to find MergeFromString

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -119,7 +119,7 @@ cdef class APIConnection:
 
     cdef void send_messages(self, tuple messages)
 
-    @cython.locals(handlers=set, handlers_copy=set)
+    @cython.locals(handlers=set, handlers_copy=set, klass_merge=tuple)
     cpdef void process_packet(self, unsigned int msg_type_proto, object data)
 
     cdef void _async_cancel_pong_timer(self)

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -6,6 +6,8 @@ from ._frame_helper.base cimport APIFrameHelper
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
 
+cdef object MERGE_FROM_STRING
+
 cdef set OPEN_STATES
 
 cdef float KEEP_ALIVE_TIMEOUT_RATIO

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -75,6 +75,7 @@ cdef object _handle_timeout
 cdef object _handle_complex_message
 
 cdef tuple MESSAGE_NUMBER_TO_PROTO
+cdef tuple MESSAGE_NUMBER_TO_MAKER
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -73,7 +73,6 @@ cdef object _handle_timeout
 cdef object _handle_complex_message
 
 cdef tuple MESSAGE_NUMBER_TO_PROTO
-cdef tuple MESSAGE_NUMBER_TO_MAKER
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -883,7 +883,7 @@ class APIConnection:
             # but the message type is 1-indexed
             klass = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
             msg: message.Message = klass()
-            MERGE_FROM_STRING(msg, data)
+            klass.MergeFromString(msg, data)
         except Exception as e:
             # IndexError will be very rare so we check for it
             # after the broad exception catch to avoid having

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -60,6 +60,7 @@ MERGE_FROM_STRING = message.Message.MergeFromString
 _LOGGER = logging.getLogger(__name__)
 
 MESSAGE_NUMBER_TO_PROTO = tuple(MESSAGE_TYPE_TO_PROTO.values())
+MESSAGE_NUMBER_TO_MAKER = tuple(msg.MergeFromString for msg in MESSAGE_NUMBER_TO_PROTO)
 
 
 PREFERRED_BUFFER_SIZE = 2097152  # Set buffer limit to 2MB
@@ -883,7 +884,7 @@ class APIConnection:
             # but the message type is 1-indexed
             klass = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
             msg: message.Message = klass()
-            klass.MergeFromString(msg, data)
+            MESSAGE_NUMBER_TO_MAKER[msg_type_proto - 1](msg, data)
         except Exception as e:
             # IndexError will be very rare so we check for it
             # after the broad exception catch to avoid having

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -882,8 +882,7 @@ class APIConnection:
             # MESSAGE_NUMBER_TO_PROTO is 0-indexed
             # but the message type is 1-indexed
             klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
-            klass = klass_merge[0]
-            merge = klass_merge[1]
+            klass, merge = klass_merge
             msg = klass()
             merge(msg, data)
         except Exception as e:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -881,7 +881,8 @@ class APIConnection:
         try:
             # MESSAGE_NUMBER_TO_PROTO is 0-indexed
             # but the message type is 1-indexed
-            klass, merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
+            klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
+            klass, merge = klass_merge
             msg = klass()
             merge(msg, data)
         except Exception as e:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -881,8 +881,7 @@ class APIConnection:
         try:
             # MESSAGE_NUMBER_TO_PROTO is 0-indexed
             # but the message type is 1-indexed
-            klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
-            klass, merge = klass_merge
+            klass, merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
             msg = klass()
             merge(msg, data)
         except Exception as e:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -881,7 +881,9 @@ class APIConnection:
         try:
             # MESSAGE_NUMBER_TO_PROTO is 0-indexed
             # but the message type is 1-indexed
-            klass, merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
+            klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
+            klass = klass_merge[0]
+            merge = klass_merge[1]
             msg = klass()
             merge(msg, data)
         except Exception as e:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -55,6 +55,8 @@ from .model import APIVersion, message_types_to_names
 from .util import asyncio_timeout
 from .zeroconf import ZeroconfManager
 
+MERGE_FROM_STRING = message.Message.MergeFromString
+
 _LOGGER = logging.getLogger(__name__)
 
 MESSAGE_NUMBER_TO_PROTO = tuple(MESSAGE_TYPE_TO_PROTO.values())
@@ -881,10 +883,7 @@ class APIConnection:
             # but the message type is 1-indexed
             klass = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
             msg: message.Message = klass()
-            # MergeFromString instead of ParseFromString since
-            # ParseFromString will clear the message first and
-            # the msg is already empty.
-            msg.MergeFromString(data)
+            MERGE_FROM_STRING(msg, data)
         except Exception as e:
             # IndexError will be very rare so we check for it
             # after the broad exception catch to avoid having


### PR DESCRIPTION
The `PyUpb_Message_GetAttr` looks a bit heavy because it looks in the message first and falls back to finding `MergeFromString`. It make sense to do it only once per message type. Its a bit unexpected that protobuf implemented this as a lookup for a known method.