### PR TITLE
Update subscribe_states example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Subscribe to state changes of an ESPHome device.
            print(state)
 
        # Subscribe to the state changes
-       await cli.subscribe_states(change_callback)
+       cli.subscribe_states(change_callback)
 
    loop = asyncio.get_event_loop()
    try:


### PR DESCRIPTION
The readme code for  `subscribe_states` causes error `TypeError: Object nontype can't be used in 'await' expression` because it is no longer [async](https://github.com/esphome/aioesphomeapi/commit/23a2f402fafa795aa1695592485662c9f6376e6b#diff-753f76689d07a39d2daa897bd6416dcb0546b60d15c3a944768fa4b8a75fd869R413-R423).

I updated the example code by removing `await`