### PR TITLE
Improve buffer read performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ repos:
     - id: pyupgrade
       args: [--py39-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.9.10
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
     - id: python-typing-update
       stages: [manual]

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -21,7 +21,11 @@ cdef class APIFrameHelper:
 
     cpdef set_log_name(self, str log_name)
 
-    @cython.locals(original_pos="unsigned int", new_pos="unsigned int")
+    @cython.locals(
+        original_pos="unsigned int",
+        new_pos="unsigned int",
+        view="const char *"
+    )
     cdef bytes _read(self, int length)
 
     @cython.locals(

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -24,7 +24,7 @@ cdef class APIFrameHelper:
     @cython.locals(
         original_pos="unsigned int",
         new_pos="unsigned int",
-        cstr="const char *"
+        cstr="const unsigned char *"
     )
     cdef bytes _read(self, int length)
 

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -39,7 +39,7 @@ cdef class APIFrameHelper:
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data)
 
-    @cython.locals(end_of_frame_pos="unsigned int")
+    @cython.locals(end_of_frame_pos="unsigned int", cstr="const unsigned char *")
     cdef void _remove_from_buffer(self)
 
     cpdef void write_packets(self, list packets, bint debug_enabled)

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -24,7 +24,7 @@ cdef class APIFrameHelper:
     @cython.locals(
         original_pos="unsigned int",
         new_pos="unsigned int",
-        view="const char *"
+        cstr="const char *"
     )
     cdef bytes _read(self, int length)
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -107,7 +107,7 @@ class APIFrameHelper:
         # when we read multiple frames at once because the event loop
         # is blocked and we cannot pull the data out of the buffer fast enough.
         cstr = self._buffer
-        self._buffer = cstr[end_of_frame_pos:]
+        self._buffer = cstr[end_of_frame_pos : self._buffer_len]
 
     def _read(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -117,8 +117,8 @@ class APIFrameHelper:
         self._pos = new_pos
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"
-        view = self._buffer
-        return view[original_pos:new_pos]
+        cstr = self._buffer
+        return cstr[original_pos:new_pos]
 
     def _read_varuint(self) -> _int:
         """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -107,6 +107,8 @@ class APIFrameHelper:
         # when we read multiple frames at once because the event loop
         # is blocked and we cannot pull the data out of the buffer fast enough.
         cstr = self._buffer
+        # Important: we must use the explicit length for the slice
+        # since Cython will stop at any '\0' character if we don't
         self._buffer = cstr[end_of_frame_pos : self._buffer_len]
 
     def _read(self, length: _int) -> bytes | None:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -118,6 +118,8 @@ class APIFrameHelper:
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"
         cstr = self._buffer
+        # Important: we must keep the bounds check (self._buffer_len < new_pos)
+        # above to verify we never try to read past the end of the buffer
         return cstr[original_pos:new_pos]
 
     def _read_varuint(self) -> _int:

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -109,7 +109,7 @@ class APIFrameHelper:
         cstr = self._buffer
         # Important: we must use the explicit length for the slice
         # since Cython will stop at any '\0' character if we don't
-        self._buffer = cstr[end_of_frame_pos : len(self._buffer)]
+        self._buffer = cstr[end_of_frame_pos : self._buffer_len + end_of_frame_pos]
 
     def _read(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -110,10 +110,10 @@ class APIFrameHelper:
 
     def _read(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""
-        original_pos = self._pos
-        new_pos = original_pos + length
+        new_pos = self._pos + length
         if self._buffer_len < new_pos:
             return None
+        original_pos = self._pos
         self._pos = new_pos
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -106,7 +106,8 @@ class APIFrameHelper:
         # and can't just use the buffer directly. This should only happen
         # when we read multiple frames at once because the event loop
         # is blocked and we cannot pull the data out of the buffer fast enough.
-        self._buffer = self._buffer[end_of_frame_pos:]
+        cstr = self._buffer
+        self._buffer = cstr[end_of_frame_pos:]
 
     def _read(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -109,7 +109,7 @@ class APIFrameHelper:
         cstr = self._buffer
         # Important: we must use the explicit length for the slice
         # since Cython will stop at any '\0' character if we don't
-        self._buffer = cstr[end_of_frame_pos : self._buffer_len]
+        self._buffer = cstr[end_of_frame_pos : len(self._buffer)]
 
     def _read(self, length: _int) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -117,7 +117,8 @@ class APIFrameHelper:
         self._pos = new_pos
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"
-        return self._buffer[original_pos:new_pos]
+        view = self._buffer
+        return view[original_pos:new_pos]
 
     def _read_varuint(self) -> _int:
         """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""


### PR DESCRIPTION
`__Pyx_PyBytes_AsString` -> `__Pyx_PyBytes_FromStringAndSize` is significantly faster than `PySequence_GetSlice` and since we already have a bounds check with `if self._buffer_len < new_pos:` we don't need to worry about reading past the buffer.

Note that we have no benchmark for noise protocol so we need to add some before merging this PR to validate the improvement

The speaker buffer looks to be about 16KiB from `esphome/components/voice_assistant/voice_assistant.cpp` so it should help that as well

<img width="369" alt="Screenshot 2025-03-10 at 7 59 33 PM" src="https://github.com/user-attachments/assets/7efba27b-3802-4395-bfe8-21ac802ceb0a" />
