### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+# What does this implement/fix?
+
+<!-- Quick description and explanation of changes -->
+
+## Types of changes
+
+<!--
+If the change relies on change in the main esphome repo
+(https://github.com/esphome/esphome), please be sure to link
+to the pull request in that repo.
+
+If you change api.proto, the change must be done first in the main esphome repo.
+-->
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Code quality improvements to existing code or addition of tests
+- [ ] Other
+
+**Related issue or feature (if applicable):**
+
+- fixes <link to issue>
+
+**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**
+
+- esphome/esphome#<esphome PR number goes here>
+
+## Checklist:
+  - [ ] The code change is tested and works locally.
+  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
+  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).


### PR DESCRIPTION
We frequently get PRs here with no linked PR to the ESPHome repo. We need to make sure `api.proto` changes get made here and in the main repo and the files stay in sync. Make it a bit more clear that a PR is required for both repos.