### PR TITLE
Ensure all void functions that can raise are properly marked

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -42,6 +42,6 @@ cdef class APIFrameHelper:
     @cython.locals(end_of_frame_pos="unsigned int", cstr="const unsigned char *")
     cdef void _remove_from_buffer(self)
 
-    cpdef void write_packets(self, list packets, bint debug_enabled)
+    cpdef void write_packets(self, list packets, bint debug_enabled) except *
 
-    cdef void _write_bytes(self, object data, bint debug_enabled)
+    cdef void _write_bytes(self, object data, bint debug_enabled) except *

--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -37,10 +37,10 @@ cdef class APIFrameHelper:
     cdef int _read_varuint(self)
 
     @cython.locals(bytes_data=bytes)
-    cdef void _add_to_buffer(self, object data)
+    cdef void _add_to_buffer(self, object data) except *
 
     @cython.locals(end_of_frame_pos="unsigned int", cstr="const unsigned char *")
-    cdef void _remove_from_buffer(self)
+    cdef void _remove_from_buffer(self) except *
 
     cpdef void write_packets(self, list packets, bint debug_enabled) except *
 

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -44,7 +44,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         preamble="unsigned char",
         header="const unsigned char *"
     )
-    cpdef void data_received(self, object data)
+    cpdef void data_received(self, object data) except *
 
     @cython.locals(
         msg=bytes,
@@ -53,22 +53,22 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         msg_length=Py_ssize_t,
         msg_cstr="const unsigned char *",
     )
-    cdef void _handle_frame(self, bytes frame)
+    cdef void _handle_frame(self, bytes frame) except *
 
     @cython.locals(
         chosen_proto=char,
         server_name_i=int
     )
-    cdef void _handle_hello(self, bytes server_hello)
+    cdef void _handle_hello(self, bytes server_hello) except *
 
-    cdef void _handle_handshake(self, bytes msg)
+    cdef void _handle_handshake(self, bytes msg) except *
 
-    cdef void _handle_closed(self, bytes frame)
+    cdef void _handle_closed(self, bytes frame) except *
 
     @cython.locals(handshake_frame=bytearray, frame_len="unsigned int")
-    cdef void _send_hello_handshake(self)
+    cdef void _send_hello_handshake(self) except *
 
-    cdef void _setup_proto(self)
+    cdef void _setup_proto(self) except *
 
     @cython.locals(psk_bytes=bytes)
     cdef _decode_noise_psk(self)
@@ -82,6 +82,6 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         frame=bytes,
         frame_len=cython.uint,
     )
-    cpdef void write_packets(self, list packets, bint debug_enabled)
+    cpdef void write_packets(self, list packets, bint debug_enabled) except *
 
     cdef _error_on_incorrect_preamble(self, bytes msg)

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -12,9 +12,9 @@ cpdef _varuint_to_bytes(cython.int value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
-    cpdef void data_received(self, object data)
+    cpdef void data_received(self, object data) except *
 
-    cdef void _error_on_incorrect_preamble(self, int preamble)
+    cdef void _error_on_incorrect_preamble(self, int preamble) except *
 
     @cython.locals(
         type_="unsigned int",
@@ -22,4 +22,4 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
         packet=tuple,
         type_=object
     )
-    cpdef void write_packets(self, list packets, bint debug_enabled)
+    cpdef void write_packets(self, list packets, bint debug_enabled) except *

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -115,55 +115,59 @@ cdef class APIConnection:
     cdef public str received_name
     cdef public str connected_address
 
-    cpdef void send_message(self, object msg)
+    cpdef void send_message(self, object msg) except *
 
-    cdef void send_messages(self, tuple messages)
+    cdef void send_messages(self, tuple messages) except *
 
     @cython.locals(handlers=set, handlers_copy=set, klass_merge=tuple)
     cpdef void process_packet(self, unsigned int msg_type_proto, object data)
 
-    cdef void _async_cancel_pong_timer(self)
+    cdef void _async_cancel_pong_timer(self) except *
 
-    cdef void _async_schedule_keep_alive(self, object now)
+    cdef void _async_schedule_keep_alive(self, object now) except *
 
-    cdef void _cleanup(self)
+    cdef void _cleanup(self) except *
 
     cpdef set_log_name(self, str name)
 
     cdef _make_connect_request(self)
 
-    cdef void _process_hello_resp(self, object resp)
+    cdef void _process_hello_resp(self, object resp) except *
 
-    cdef void _process_login_response(self, object hello_response)
+    cdef void _process_login_response(self, object hello_response) except *
 
-    cdef void _set_connection_state(self, object state)
+    cdef void _set_connection_state(self, object state) except *
 
-    cpdef void report_fatal_error(self, Exception err)
+    cpdef void report_fatal_error(self, Exception err) except *
 
     @cython.locals(handlers=set)
     cdef void _add_message_callback_without_remove(
         self,
         object on_message,
         tuple msg_types
-    )
+    ) except *
 
     cpdef add_message_callback(self, object on_message, tuple msg_types)
 
     @cython.locals(handlers=set)
-    cpdef void _remove_message_callback(self, object on_message, tuple msg_types)
+    cpdef void _remove_message_callback(
+        self,
+        object on_message,
+        tuple msg_types
+    ) except *
 
-    cpdef void _handle_disconnect_request_internal(self, object msg)
+    cpdef void _handle_disconnect_request_internal(self, object msg) except *
 
-    cpdef void _handle_ping_request_internal(self, object msg)
+    cpdef void _handle_ping_request_internal(self, object msg) except *
 
-    cpdef void _handle_get_time_request_internal(self, object msg)
+    cpdef void _handle_get_time_request_internal(self, object msg) except *
 
-    cdef void _set_fatal_exception_if_unset(self, Exception err)
+    cdef void _set_fatal_exception_if_unset(self, Exception err) except *
 
-    cdef void _register_internal_message_handlers(self)
+    cdef void _register_internal_message_handlers(self) except *
 
-    cdef void _increase_recv_buffer_size(self)
+    cdef void _increase_recv_buffer_size(self) except *
 
-    cdef void _set_start_connect_future(self)
+    cdef void _set_start_connect_future(self) except *
 
-    cdef void _set_finish_connect_future(self)
+    cdef void _set_finish_connect_future(self) except *

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -120,7 +120,11 @@ cdef class APIConnection:
     cdef void send_messages(self, tuple messages) except *
 
     @cython.locals(handlers=set, handlers_copy=set, klass_merge=tuple)
-    cpdef void process_packet(self, unsigned int msg_type_proto, object data)
+    cpdef void process_packet(
+        self,
+        unsigned int msg_type_proto,
+        object data
+    ) except *
 
     cdef void _async_cancel_pong_timer(self) except *
 


### PR DESCRIPTION

# What does this implement/fix?

`except *` should be added to the pxd for Cython void functions that can raise an exception


## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
