### PR TITLE
Remove unneeded EMPTY_PACKET constant in plain_text frame helper

### DIFF
--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -5,7 +5,6 @@ from .base cimport APIFrameHelper
 
 
 cdef object varuint_to_bytes
-cdef bytes EMPTY_PACKET
 cdef bint TYPE_CHECKING
 
 cpdef _varuint_to_bytes(cython.int value)

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -8,8 +8,6 @@ from .base import APIFrameHelper
 
 _int = int
 
-EMPTY_PACKET = b""
-
 
 def _varuint_to_bytes(value: _int) -> bytes:
     """Convert a varuint to bytes."""
@@ -77,7 +75,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
 
             if length == 0:
                 self._remove_from_buffer()
-                self._connection.process_packet(msg_type, EMPTY_PACKET)
+                self._connection.process_packet(msg_type, b"")
                 continue
 
             # The packet data is not yet available, wait for more data


### PR DESCRIPTION
# What does this implement/fix?

Cython can better optimize `b""` since it doesn't have to ref count it

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
