### PR TITLE
Add cdef for _handle_error_and_close in the frame helper

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -45,3 +45,5 @@ cdef class APIFrameHelper:
     cpdef void write_packets(self, list packets, bint debug_enabled) except *
 
     cdef void _write_bytes(self, object data, bint debug_enabled) except *
+
+    cdef void _handle_error_and_close(self, Exception exc) except *

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -155,10 +155,18 @@ class APIFrameHelper:
         self._writelines = self._transport.writelines
 
     def _handle_error_and_close(self, exc: Exception) -> None:
+        """Handle an error and close the connection.
+
+        May not be overridden by subclasses.
+        """
         self._handle_error(exc)
         self.close()
 
     def _handle_error(self, exc: Exception) -> None:
+        """Handle an error.
+
+        May be overridden by subclasses.
+        """
         self._set_ready_future_exception(exc)
         self._connection.report_fatal_error(exc)
 


### PR DESCRIPTION

# What does this implement/fix?

Add cdef for _handle_error_and_close in the frame helper

Subclasses never need to override this so it can be a cdef

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
