### PR TITLE
Remove redundant casts to int from round

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1082,10 +1082,10 @@ class APIClient:
             req.warm_white = warm_white
         if transition_length is not None:
             req.has_transition_length = True
-            req.transition_length = int(round(transition_length * 1000))
+            req.transition_length = round(transition_length * 1000)
         if flash_length is not None:
             req.has_flash_length = True
-            req.flash_length = int(round(flash_length * 1000))
+            req.flash_length = round(flash_length * 1000)
         if effect is not None:
             req.has_effect = True
             req.effect = effect

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -297,7 +297,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             if await self._try_connect():
                 return
             tries = min(self._tries, 10)  # prevent OverflowError
-            wait_time = int(round(min(1.8**tries, 60.0)))
+            wait_time = round(min(1.8**tries, 60.0))
             if tries == 1:
                 _LOGGER.info(
                     "Trying to connect to %s in the background", self._cli.log_name


### PR DESCRIPTION


# What does this implement/fix?

Remove redundant casts to int from round
Found by ruff 0.1.0

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
