### PR TITLE
Add IPv6 support to the reconnect logic zeroconf listener

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -27,6 +27,8 @@ from .zeroconf import ZeroconfInstanceType
 
 _LOGGER = logging.getLogger(__name__)
 
+ADDRESS_RECORD_TYPES = {TYPE_A, TYPE_AAAA}
+
 EXPECTED_DISCONNECT_COOLDOWN = 5.0
 MAXIMUM_BACKOFF_TRIES = 100
 
@@ -406,8 +408,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             new_record = record_update.new
             if not (
                 (new_record.type == TYPE_PTR and new_record.alias == self._ptr_alias)  # type: ignore[attr-defined]
-                or (new_record.type == TYPE_A and new_record.name == self._a_name)
-                or (new_record.type == TYPE_AAAA and new_record.name == self._a_name)
+                or (
+                    new_record.type in ADDRESS_RECORD_TYPES
+                    and new_record.name == self._a_name
+                )
             ):
                 continue
 

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -8,7 +8,11 @@ import time
 from typing import Callable
 
 import zeroconf
-from zeroconf.const import _TYPE_A as TYPE_A, _TYPE_PTR as TYPE_PTR
+from zeroconf.const import (
+    _TYPE_A as TYPE_A,
+    _TYPE_AAAA as TYPE_AAAA,
+    _TYPE_PTR as TYPE_PTR,
+)
 
 from .client import APIClient
 from .core import (
@@ -398,11 +402,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             return
 
         for record_update in records:
-            # We only consider PTR records and match using the alias name
+            # We only consider A, AAAA, and PTR records and match using the alias name
             new_record = record_update.new
             if not (
                 (new_record.type == TYPE_PTR and new_record.alias == self._ptr_alias)  # type: ignore[attr-defined]
                 or (new_record.type == TYPE_A and new_record.name == self._a_name)
+                or (new_record.type == TYPE_AAAA and new_record.name == self._a_name)
             ):
                 continue
 

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -16,7 +16,7 @@ from zeroconf import (
     current_time_millis,
 )
 from zeroconf.asyncio import AsyncZeroconf
-from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_PTR
+from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR
 
 from aioesphomeapi import APIConnectionError, RequiresEncryptionAPIError
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
@@ -373,6 +373,18 @@ DNS_POINTER = DNSPointer(
                 _CLASS_IN,
                 1000,
                 ip_address("127.0.0.1").packed,
+            ),
+            True,
+            ReconnectLogicState.READY,
+            "received mDNS record",
+        ),
+        (
+            DNSAddress(
+                "mydevice.local.",
+                _TYPE_AAAA,
+                _CLASS_IN,
+                1000,
+                ip_address("::1").packed,
             ),
             True,
             ReconnectLogicState.READY,


### PR DESCRIPTION

# What does this implement/fix?

We should kick start the reconnect logic when getting an AAAA record in addition to the existing A and PTR logic


## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
