### PR TITLE
Raise EncryptionHelloAPIError when connection drops during encrypted hello

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -18,6 +18,7 @@ from .core import (
     ProtocolAPIError,
     RequiresEncryptionAPIError,
     ResolveAPIError,
+    EncryptionHelloAPIError,
     SocketAPIError,
 )
 from .model import *

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -18,6 +18,7 @@ from ..core import (
     APIConnectionError,
     BadNameAPIError,
     EncryptionErrorAPIError,
+    EncryptionHelloAPIError,
     HandshakeAPIError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
@@ -154,7 +155,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Handle an error, and provide a good message when during hello."""
         if self._state == NOISE_STATE_HELLO and isinstance(exc, ConnectionResetError):
             original_exc: Exception = exc
-            exc = HandshakeAPIError(
+            exc = EncryptionHelloAPIError(
                 f"{self._log_name}: The connection dropped immediately after encrypted hello; "
                 "Try enabling encryption on the device or turning off "
                 f"encryption on the client ({self._client_info})."

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -245,6 +245,10 @@ class EncryptionErrorAPIError(InvalidEncryptionKeyAPIError):
     """Raised when an encryption error occurs after handshake."""
 
 
+class EncryptionHelloAPIError(HandshakeAPIError):
+    """Raised when an encryption error occurs during hello."""
+
+
 class PingFailedAPIError(APIConnectionError):
     """Raised when a ping fails."""
 

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -19,6 +19,7 @@ from aioesphomeapi.connection import ConnectionState
 from aioesphomeapi.core import (
     APIConnectionError,
     BadNameAPIError,
+    EncryptionHelloAPIError,
     HandshakeAPIError,
     InvalidEncryptionKeyAPIError,
     ProtocolAPIError,
@@ -669,7 +670,7 @@ async def test_init_noise_attempted_when_esp_uses_plaintext(
         protocol.connection_lost(ConnectionResetError())
 
         with pytest.raises(
-            APIConnectionError, match="The connection dropped immediately"
+            EncryptionHelloAPIError, match="The connection dropped immediately"
         ):
             await task
 


### PR DESCRIPTION
# What does this implement/fix?


We need a way to tell when encryption is no longer being used
in Home Assistant


## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
https://github.com/home-assistant/core/issues/121442