### PR TITLE
Raise EncryptionPlaintextAPIError when noise is selected but remote protocol is plaintext

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     ESPHOME_GATT_ERRORS,
     MESSAGE_TYPE_TO_PROTO,
     APIConnectionError,
+    EncryptionPlaintextAPIError,
     BadNameAPIError,
     BluetoothConnectionDroppedError,
     HandshakeAPIError,

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -249,6 +249,10 @@ class EncryptionHelloAPIError(HandshakeAPIError):
     """Raised when an encryption error occurs during hello."""
 
 
+class EncryptionPlaintextAPIError(HandshakeAPIError):
+    """Raised when the ESP is using plaintext during noise handshake."""
+
+
 class PingFailedAPIError(APIConnectionError):
     """Raised when a ping fails."""
 


### PR DESCRIPTION
# What does this implement/fix?

related issue https://github.com/home-assistant/core/issues/142381



## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#https://github.com/esphome/esphome/pull/8521

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
