### PR TITLE
Improve performance of reading varuints

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -31,6 +31,7 @@ cdef class APIFrameHelper:
     @cython.locals(
         result="unsigned int",
         bitpos="unsigned int",
+        cstr="const unsigned char *",
         val="unsigned char",
         current_pos="unsigned int"
     )

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -131,8 +131,9 @@ class APIFrameHelper:
             assert self._buffer is not None, "Buffer should be set"
         result = 0
         bitpos = 0
+        cstr = self._buffer
         while self._buffer_len > self._pos:
-            val = self._buffer[self._pos]
+            val = cstr[self._pos]
             self._pos += 1
             result |= (val & 0x7F) << bitpos
             if (val & 0x80) == 0:


### PR DESCRIPTION
Only convert the bytes object to a cstr once before the loop.