### PR TITLE
Reduce buffer extraction overhead

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -14,33 +14,20 @@ cdef class APIFrameHelper:
     cdef public object _writelines
     cdef public object ready_future
     cdef bytes _buffer
-    cdef unsigned int _buffer_len
-    cdef unsigned int _pos
+    cdef Py_ssize_t _buffer_len
+    cdef Py_ssize_t _pos
     cdef object _client_info
     cdef str _log_name
 
     cpdef set_log_name(self, str log_name)
 
-    @cython.locals(
-        original_pos="unsigned int",
-        new_pos="unsigned int",
-        cstr="const unsigned char *"
-    )
-    cdef bytes _read(self, int length)
-
-    @cython.locals(
-        result="unsigned int",
-        bitpos="unsigned int",
-        cstr="const unsigned char *",
-        val="unsigned char",
-        current_pos="unsigned int"
-    )
-    cdef int _read_varuint(self)
+    @cython.locals(original_pos=Py_ssize_t, new_pos=Py_ssize_t)
+    cdef bytes _read(self, int length, const unsigned char * cbuffer)
 
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data) except *
 
-    @cython.locals(end_of_frame_pos="unsigned int", cstr="const unsigned char *")
+    @cython.locals(end_of_frame_pos=Py_ssize_t, cstr="const unsigned char *")
     cdef void _remove_from_buffer(self) except *
 
     cpdef void write_packets(self, list packets, bint debug_enabled) except *

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -111,35 +111,16 @@ class APIFrameHelper:
         # since Cython will stop at any '\0' character if we don't
         self._buffer = cstr[end_of_frame_pos : self._buffer_len + end_of_frame_pos]
 
-    def _read(self, length: _int) -> bytes | None:
+    def _read(self, length: _int, cbuffer: _bytes) -> bytes | None:
         """Read exactly length bytes from the buffer or None if all the bytes are not yet available."""
         new_pos = self._pos + length
         if self._buffer_len < new_pos:
             return None
         original_pos = self._pos
         self._pos = new_pos
-        if TYPE_CHECKING:
-            assert self._buffer is not None, "Buffer should be set"
-        cstr = self._buffer
         # Important: we must keep the bounds check (self._buffer_len < new_pos)
         # above to verify we never try to read past the end of the buffer
-        return cstr[original_pos:new_pos]
-
-    def _read_varuint(self) -> _int:
-        """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""
-        if TYPE_CHECKING:
-            assert self._buffer is not None, "Buffer should be set"
-        result = 0
-        bitpos = 0
-        cstr = self._buffer
-        while self._buffer_len > self._pos:
-            val = cstr[self._pos]
-            self._pos += 1
-            result |= (val & 0x7F) << bitpos
-            if (val & 0x80) == 0:
-                return result
-            bitpos += 7
-        return -1
+        return cbuffer[original_pos:new_pos]
 
     @abstractmethod
     def write_packets(

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -42,7 +42,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     @cython.locals(
         header=bytes,
         preamble="unsigned char",
-        header="const unsigned char *"
+        cbuffer="const unsigned char *"
     )
     cpdef void data_received(self, object data) except *
 
@@ -65,7 +65,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef void _handle_closed(self, bytes frame) except *
 
-    @cython.locals(handshake_frame=bytearray, frame_len="unsigned int")
+    @cython.locals(handshake_frame=bytearray, frame_len=Py_ssize_t)
     cdef void _send_hello_handshake(self) except *
 
     cdef void _setup_proto(self) except *
@@ -78,9 +78,9 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         data=bytes,
         data_header=bytes,
         packet=tuple,
-        data_len=cython.uint,
+        data_len=Py_ssize_t,
         frame=bytes,
-        frame_len=cython.uint,
+        frame_len=Py_ssize_t,
     )
     cpdef void write_packets(self, list packets, bint debug_enabled) except *
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -176,8 +176,8 @@ class APINoiseFrameHelper(APIFrameHelper):
             if TYPE_CHECKING:
                 assert self._buffer is not None, "Buffer should be set"
             self._pos = 3
-            header = self._buffer
-            preamble = header[0]
+            cbuffer = self._buffer
+            preamble = cbuffer[0]
             if preamble != 0x01:
                 if preamble == 0x00:
                     self._handle_error_and_close(
@@ -194,7 +194,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                         )
                     )
                 return
-            if (frame := self._read((header[1] << 8) | header[2])) is None:
+            if (frame := self._read((cbuffer[1] << 8) | cbuffer[2], cbuffer)) is None:
                 # The complete frame is not yet available, wait for more data
                 # to arrive before continuing, since callback_packet has not
                 # been called yet the buffer will not be cleared and the next

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -11,6 +11,7 @@ cpdef _varuint_to_bytes(cython.int value)
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
+    @cython.locals(cbuffer="const unsigned char *")
     cpdef void data_received(self, object data) except *
 
     cdef void _error_on_incorrect_preamble(self, int preamble) except *
@@ -22,3 +23,11 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
         type_=object
     )
     cpdef void write_packets(self, list packets, bint debug_enabled) except *
+
+    @cython.locals(
+        result="unsigned int",
+        bitpos=Py_ssize_t,
+        val="unsigned char",
+        current_pos=Py_ssize_t
+    )
+    cdef int _read_varuint(self, const unsigned char * cbuffer)


### PR DESCRIPTION
Safer version of #1139 which does not store the
unsafe C derivative of temporary Python reference
in the object
