### PR TITLE
Relocate _read_varuint from base to plaintext framehelper

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -28,15 +28,6 @@ cdef class APIFrameHelper:
     )
     cdef bytes _read(self, int length)
 
-    @cython.locals(
-        result="unsigned int",
-        bitpos="unsigned int",
-        cstr="const unsigned char *",
-        val="unsigned char",
-        current_pos="unsigned int"
-    )
-    cdef int _read_varuint(self)
-
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data) except *
 

--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -125,22 +125,6 @@ class APIFrameHelper:
         # above to verify we never try to read past the end of the buffer
         return cstr[original_pos:new_pos]
 
-    def _read_varuint(self) -> _int:
-        """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""
-        if TYPE_CHECKING:
-            assert self._buffer is not None, "Buffer should be set"
-        result = 0
-        bitpos = 0
-        cstr = self._buffer
-        while self._buffer_len > self._pos:
-            val = cstr[self._pos]
-            self._pos += 1
-            result |= (val & 0x7F) << bitpos
-            if (val & 0x80) == 0:
-                return result
-            bitpos += 7
-        return -1
-
     @abstractmethod
     def write_packets(
         self, packets: list[tuple[int, bytes]], debug_enabled: bool

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -16,6 +16,15 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
     cdef void _error_on_incorrect_preamble(self, int preamble) except *
 
     @cython.locals(
+        result="unsigned int",
+        bitpos="unsigned int",
+        cstr="const unsigned char *",
+        val="unsigned char",
+        current_pos="unsigned int"
+    )
+    cdef int _read_varuint(self)
+
+    @cython.locals(
         type_="unsigned int",
         data=bytes,
         packet=tuple,


### PR DESCRIPTION
Only plaintext reads varuints on the wire, this should be in plaintext and not base
