### PR TITLE
Add helper to get the txt record

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -24,3 +24,8 @@ from .core import (
 )
 from .model import *
 from .reconnect_logic import ReconnectLogic
+from .host_resolver import (
+    ESPHomeDeviceInfo,
+    async_info_for_name,
+    async_info_for_address,
+)


### PR DESCRIPTION
# What does this implement/fix?

Add helper to get the txt record for an ESPHome device

`async_info_for_address`
`async_info_for_name`

Returns something like
`ESPHomeDeviceInfo(name='mydevice', network='ethernet', board='esp32-evb', version='2025.3.3', platform='ESP32', mac='acdec2a2a54a', project_name=None, project_version=None, friendly_name=None, api_encryption=None, package_import_url=None, addresses=[ZeroconfIPv4Address('192.168.88.84')])`

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
