### PR TITLE
Add check for unexpected MAC address for noise protocol

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -21,6 +21,7 @@ from .core import (
     ResolveAPIError,
     EncryptionHelloAPIError,
     SocketAPIError,
+    BadMACAddressAPIError,
 )
 from .model import *
 from .reconnect_logic import ReconnectLogic

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -34,7 +34,8 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
     cdef object _noise_psk
     cdef str _expected_name
     cdef unsigned int _state
-    cdef object _server_name
+    cdef str _server_mac
+    cdef str _server_name
     cdef object _proto
     cdef EncryptCipher _encrypt_cipher
     cdef DecryptCipher _decrypt_cipher

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -59,7 +59,8 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
 
     @cython.locals(
         chosen_proto=char,
-        server_name_i=int
+        server_name_i=int,
+        mac_address_i=int,
     )
     cdef void _handle_hello(self, bytes server_hello) except *
 

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -33,6 +33,7 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef object _noise_psk
     cdef str _expected_name
+    cdef str _expected_mac
     cdef unsigned int _state
     cdef str _server_mac
     cdef str _server_name

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -61,6 +61,8 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         chosen_proto=char,
         server_name_i=int,
         mac_address_i=int,
+        mac_address=str,
+        server_name=str,
     )
     cdef void _handle_hello(self, bytes server_hello) except *
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -290,6 +290,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         """Decode the given noise psk from base64 format to raw bytes."""
         psk = self._noise_psk
         server_name = self._server_name
+        server_mac = self._server_mac
         try:
             psk_bytes = binascii.a2b_base64(psk)
         except ValueError:
@@ -297,12 +298,14 @@ class APINoiseFrameHelper(APIFrameHelper):
                 f"{self._log_name}: Malformed PSK `{psk}`, expected "
                 "base64-encoded value",
                 server_name,
+                server_mac,
             )
         if len(psk_bytes) != 32:
             raise InvalidEncryptionKeyAPIError(
                 f"{self._log_name}:Malformed PSK `{psk}`, expected"
                 f" 32-bytes of base64 data",
                 server_name,
+                server_mac,
             )
         return psk_bytes
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -272,8 +272,7 @@ class APINoiseFrameHelper(APIFrameHelper):
             mac_address_i = server_hello.find(b"\0", server_name_i + 1)
             if mac_address_i != -1:
                 # mac address found, this extension was added in 2025.4
-                mac_bytes = server_hello[server_name_i + 1 : mac_address_i]
-                mac_address = ":".join(f"{b:02x}" for b in mac_bytes)
+                mac_address = server_hello[server_name_i + 1 : mac_address_i].decode()
                 self._server_mac = mac_address
                 if self._expected_mac is not None and self._expected_mac != mac_address:
                     self._handle_error_and_close(

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -121,6 +121,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         "_expected_name",
         "_noise_psk",
         "_proto",
+        "_server_mac",
         "_server_name",
         "_state",
     )
@@ -141,6 +142,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._expected_name = expected_name
         self._state = NOISE_STATE_HELLO
         self._server_name: str | None = None
+        self._server_mac: str | None = None
         self._encrypt_cipher: EncryptCipher | None = None
         self._decrypt_cipher: DecryptCipher | None = None
         self._setup_proto()
@@ -272,6 +274,7 @@ class APINoiseFrameHelper(APIFrameHelper):
                 # mac address found, this extension was added in 2025.4
                 mac_bytes = server_hello[server_name_i + 1 : mac_address_i]
                 mac_address = ":".join(f"{b:02x}" for b in mac_bytes)
+                self._server_mac = mac_address
                 if self._expected_mac is not None and self._expected_mac != mac_address:
                     self._handle_error_and_close(
                         BadMACAddressAPIError(
@@ -324,7 +327,9 @@ class APINoiseFrameHelper(APIFrameHelper):
             )
         else:
             exc = InvalidEncryptionKeyAPIError(
-                f"{self._log_name}: Invalid encryption key", self._server_name
+                f"{self._log_name}: Invalid encryption key",
+                self._server_name,
+                self._server_mac,
             )
         self._handle_error_and_close(exc)
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -235,6 +235,7 @@ class APIClient:
         noise_psk: str | None = None,
         expected_name: str | None = None,
         addresses: list[str] | None = None,
+        expected_mac: str | None = None,
     ) -> None:
         """Create a client, this object is shared across sessions.
 
@@ -254,6 +255,7 @@ class APIClient:
             precedence over the address parameter. This is most commonly used when
             the device has dual stack IPv4 and IPv6 addresses and you do not know
             which one to connect to.
+        :param expected_mac: Optional MAC address to check against the device.
         """
         self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(
@@ -266,6 +268,7 @@ class APIClient:
             # treat empty '' psk string as missing (like password)
             noise_psk=_stringify_or_none(noise_psk) or None,
             expected_name=_stringify_or_none(expected_name) or None,
+            expected_mac=_stringify_or_none(expected_mac) or None,
         )
         self._connection: APIConnection | None = None
         self.cached_name: str | None = None

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -256,6 +256,8 @@ class APIClient:
             the device has dual stack IPv4 and IPv6 addresses and you do not know
             which one to connect to.
         :param expected_mac: Optional MAC address to check against the device.
+            The format should be lower case without : or - separators.
+            Example: 00:aa:22:33:44:55 -> 00aa22334455
         """
         self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -86,6 +86,7 @@ cdef class ConnectionParams:
     cdef public object zeroconf_manager
     cdef public object noise_psk
     cdef public object expected_name
+    cdef public object expected_mac
 
 
 cdef class APIConnection:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -120,6 +120,7 @@ class ConnectionParams:
     zeroconf_manager: ZeroconfManager
     noise_psk: str | None
     expected_name: str | None
+    expected_mac: str | None
 
 
 class ConnectionState(enum.Enum):
@@ -423,6 +424,7 @@ class APIConnection:
                 lambda: APINoiseFrameHelper(
                     noise_psk=noise_psk,
                     expected_name=self._params.expected_name,
+                    expected_mac=self._params.expected_mac,
                     connection=self,
                     client_info=self._params.client_info,
                     log_name=self.log_name,

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -234,6 +234,8 @@ class BadNameAPIError(APIConnectionError):
 
 
 class BadMACAddressAPIError(APIConnectionError):
+    """Raised when a MAC address received from the remote but does not much the expected MAC address."""
+
     def __init__(self, msg: str, received_name: str, received_mac: str) -> None:
         super().__init__(
             f"{msg}: received_name={received_name}, received_mac={received_mac}"
@@ -243,6 +245,8 @@ class BadMACAddressAPIError(APIConnectionError):
 
 
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
+    """Raised when the encryption key is invalid."""
+
     def __init__(
         self,
         msg: str | None = None,

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -236,7 +236,7 @@ class BadNameAPIError(APIConnectionError):
 class BadMACAddressAPIError(APIConnectionError):
     def __init__(self, msg: str, received_name: str, received_mac: str) -> None:
         super().__init__(
-            f"{msg}: received_name={received_name} received_mac={received_mac}"
+            f"{msg}: received_name={received_name}, received_mac={received_mac}"
         )
         self.received_name = received_name
         self.received_mac = received_mac
@@ -244,10 +244,16 @@ class BadMACAddressAPIError(APIConnectionError):
 
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
     def __init__(
-        self, msg: str | None = None, received_name: str | None = None
+        self,
+        msg: str | None = None,
+        received_name: str | None = None,
+        received_mac: str | None = None,
     ) -> None:
-        super().__init__(f"{msg}: received_name={received_name}")
+        super().__init__(
+            f"{msg}: received_name={received_name}, received_mac={received_mac}"
+        )
         self.received_name = received_name
+        self.received_mac = received_mac
 
 
 class EncryptionErrorAPIError(InvalidEncryptionKeyAPIError):

--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -233,6 +233,15 @@ class BadNameAPIError(APIConnectionError):
         self.received_name = received_name
 
 
+class BadMACAddressAPIError(APIConnectionError):
+    def __init__(self, msg: str, received_name: str, received_mac: str) -> None:
+        super().__init__(
+            f"{msg}: received_name={received_name} received_mac={received_mac}"
+        )
+        self.received_name = received_name
+        self.received_mac = received_mac
+
+
 class InvalidEncryptionKeyAPIError(HandshakeAPIError):
     def __init__(
         self, msg: str | None = None, received_name: str | None = None

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -36,6 +36,7 @@ async def test_noise_messages(benchmark: BenchmarkFixture, payload_size: int) ->
         connection=connection,
         noise_psk=noise_psk,
         expected_name="servicetest",
+        expected_mac=None,
         client_info="my client",
         log_name="test",
         writer=_writelines,

--- a/tests/common.py
+++ b/tests/common.py
@@ -53,6 +53,7 @@ def get_mock_connection_params() -> ConnectionParams:
         zeroconf_manager=ZeroconfManager(),
         noise_psk=None,
         expected_name=None,
+        expected_mac=None,
     )
 
 

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -229,6 +229,7 @@ async def test_noise_protector_event_loop(byte_type: Any) -> None:
         expected_name="servicetest",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     for pkt in outgoing_packets:
@@ -260,6 +261,7 @@ async def test_noise_frame_helper_incorrect_key():
         expected_name="servicetest",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     for pkt in outgoing_packets:
@@ -291,6 +293,7 @@ async def test_noise_frame_helper_incorrect_key_fragments():
         expected_name="servicetest",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     for pkt in outgoing_packets:
@@ -324,6 +327,7 @@ async def test_noise_incorrect_name():
         expected_name="wrongname",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     for pkt in outgoing_packets:
@@ -371,6 +375,7 @@ async def test_noise_frame_helper_handshake_failure():
         client_info="my client",
         log_name="test",
         writer=_writelines,
+        expected_mac=None,
     )
 
     proto = _mock_responder_proto(psk_bytes)
@@ -420,6 +425,7 @@ async def test_noise_frame_helper_handshake_success_with_single_packet():
         client_info="my client",
         log_name="test",
         writer=_writelines,
+        expected_mac=None,
     )
 
     proto = _mock_responder_proto(psk_bytes)
@@ -482,6 +488,7 @@ async def test_noise_valid_encryption_invalid_payload(
         client_info="my client",
         log_name="test",
         writer=_writelines,
+        expected_mac=None,
     )
 
     proto = _mock_responder_proto(psk_bytes)
@@ -549,6 +556,7 @@ async def test_noise_valid_encryption_payload_short(
         client_info="my client",
         log_name="test",
         writer=_writelines,
+        expected_mac=None,
     )
 
     proto = _mock_responder_proto(psk_bytes)
@@ -627,6 +635,7 @@ async def test_noise_frame_helper_bad_encryption(
         client_info="my client",
         log_name="test",
         writer=_writelines,
+        expected_mac=None,
     )
 
     proto = _mock_responder_proto(psk_bytes)
@@ -753,6 +762,7 @@ async def test_noise_frame_helper_empty_hello():
         expected_name="servicetest",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     hello_pkt_with_header = _make_noise_hello_pkt(b"")
@@ -773,6 +783,7 @@ async def test_noise_frame_helper_wrong_protocol():
         expected_name="servicetest",
         client_info="my client",
         log_name="test",
+        expected_mac=None,
     )
 
     # wrong protocol 5 instead of 1
@@ -871,4 +882,5 @@ async def test_noise_bad_psks(bad_psk: str, error: str) -> None:
             expected_name="wrongname",
             client_info="my client",
             log_name="test",
+            expected_mac=None,
         )

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -376,6 +376,40 @@ async def test_noise_incorrect_mac():
     assert exc_info.value.received_mac == "244cab06499c"
 
 
+@pytest.mark.asyncio
+async def test_noise_mac_in_exception():
+    """Test the mac is in the exception when the key is wrong if available."""
+    outgoing_packets = [
+        "010000",  # hello packet
+        "010031001ed7f7bb0b74085418258ed5928931bc36ade7cf06937fcff089044d4ab142643f1b2c9935bb77696f23d930836737a4",
+    ]
+    incoming_packets = [
+        "01001f01706f6f6c686f757365383170726f78790032343463616230363439396300",
+        "0100160148616e647368616b65204d4143206661696c757265",
+    ]
+    connection, _ = _make_mock_connection()
+
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="poolhouse81proxy",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    for pkt in outgoing_packets:
+        helper.mock_write_frame(bytes.fromhex(pkt))
+
+    for pkt in incoming_packets:
+        mock_data_received(helper, bytes.fromhex(pkt))
+
+    with pytest.raises(InvalidEncryptionKeyAPIError) as exc_info:
+        await helper.ready_future
+    assert exc_info.value.received_name == "poolhouse81proxy"
+    assert exc_info.value.received_mac == "244cab06499c"
+
+
 VARUINT_TESTCASES = [
     (0, b"\x00"),
     (42, b"\x2a"),


### PR DESCRIPTION
needs https://github.com/esphome/esphome/pull/8551


# What does this implement/fix?

We currently only have the ability to check for an expected name, but we need to be able to check for an expected mac as well to know we are talking to the expected device.

related issue https://github.com/home-assistant/core/issues/133956

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#8551

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
