### PR TITLE
Replace get_event_loop with get_running_loop

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -48,7 +48,7 @@ class APIFrameHelper:
         log_name: str,
     ) -> None:
         """Initialize the API frame helper."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self._loop = loop
         self._connection = connection
         self._transport: asyncio.Transport | None = None

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -253,7 +253,7 @@ class APIClientBase:
         self._connection: APIConnection | None = None
         self.cached_name: str | None = None
         self._background_tasks: set[asyncio.Task[Any]] = set()
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self._set_log_name()
 
     def set_debug(self, enabled: bool) -> None:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -252,7 +252,7 @@ class APIConnection:
         self._fatal_exception: Exception | None = None
         self._expected_disconnect = False
         self._send_pending_ping = False
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self.is_connected = False
         self._handshake_complete = False
         self._debug_enabled = debug_enabled

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -79,7 +79,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         :param on_connect: Coroutine Function to call when connected.
         :param on_disconnect: Coroutine Function to call when disconnected.
         """
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
         self._cli = client
         self.name: str | None = None
         if name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,6 @@ split-on-trailing-comma = false
 
 [build-system]
 requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.2']
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/benchmarks/test_bluetooth.py
+++ b/tests/benchmarks/test_bluetooth.py
@@ -14,7 +14,7 @@ from aioesphomeapi.api_pb2 import (
 from aioesphomeapi.client import APIClient
 
 
-def test_raw_ble_plain_text_with_callback(benchmark: BenchmarkFixture) -> None:
+async def test_raw_ble_plain_text_with_callback(benchmark: BenchmarkFixture) -> None:
     """Benchmark raw BLE plaintext with callback."""
 
     class MockConnection(APIConnection):
@@ -56,7 +56,7 @@ def test_raw_ble_plain_text_with_callback(benchmark: BenchmarkFixture) -> None:
     benchmark(process_incoming_msg)
 
 
-def test_raw_ble_plain_text(benchmark: BenchmarkFixture) -> None:
+async def test_raw_ble_plain_text(benchmark: BenchmarkFixture) -> None:
     """Benchmark raw BLE plaintext."""
     adv = BluetoothLERawAdvertisementsResponse()
     fake_adv = BluetoothLERawAdvertisement(
@@ -102,7 +102,7 @@ def test_raw_ble_plain_text(benchmark: BenchmarkFixture) -> None:
     benchmark(process_incoming_msg)
 
 
-def test_raw_ble_plain_text_different_advs(benchmark: BenchmarkFixture) -> None:
+async def test_raw_ble_plain_text_different_advs(benchmark: BenchmarkFixture) -> None:
     """Benchmark raw BLE plaintext with different advertisements."""
     data = (
         b"\x01\x01\x07\x98\xaa7\xd7\xc5s\xe2\xdd\xc2\x96aG\xb1\xac:\xd3\xde"
@@ -148,7 +148,9 @@ def test_raw_ble_plain_text_different_advs(benchmark: BenchmarkFixture) -> None:
     benchmark(process_incoming_msg)
 
 
-def test_multiple_ble_adv_messages_single_read(benchmark: BenchmarkFixture) -> None:
+async def test_multiple_ble_adv_messages_single_read(
+    benchmark: BenchmarkFixture,
+) -> None:
     """Benchmark multiple raw ble advertisement messages in a single read."""
     data = (
         b"\x01\x01\x07\x98\xaa7\xd7\xc5s\xe2\xdd\xc2\x96aG\xb1\xac:\xd3\xde"

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -19,7 +19,6 @@ from ..common import (
 )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("payload_size", [0, 1024, 16 * 1024])
 async def test_noise_messages(benchmark: BenchmarkFixture, payload_size: int) -> None:
     """Benchmark raw noise protocol."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def resolve_host() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def patchable_api_client() -> APIClient:
+async def patchable_api_client() -> APIClient:
     cli = PatchableAPIClient(
         address="127.0.0.1",
         port=6052,
@@ -69,7 +69,7 @@ def patchable_api_client() -> APIClient:
 
 
 @pytest.fixture
-def auth_client():
+async def auth_client():
     client = PatchableAPIClient(
         address="fake.address",
         port=6052,
@@ -96,24 +96,18 @@ def mock_on_stop(expected_disconnect: bool) -> None:
 
 
 @pytest.fixture
-def conn(
-    event_loop: asyncio.AbstractEventLoop, connection_params: ConnectionParams
-) -> APIConnection:
+async def conn(connection_params: ConnectionParams) -> APIConnection:
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 
 @pytest.fixture
-def conn_with_password(
-    event_loop: asyncio.AbstractEventLoop, connection_params: ConnectionParams
-) -> APIConnection:
+async def conn_with_password(connection_params: ConnectionParams) -> APIConnection:
     connection_params = replace(connection_params, password="password")
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 
 @pytest.fixture
-def noise_conn(
-    event_loop: asyncio.AbstractEventLoop, connection_params: ConnectionParams
-) -> APIConnection:
+async def noise_conn(connection_params: ConnectionParams) -> APIConnection:
     connection_params = replace(
         connection_params, noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     )
@@ -121,15 +115,13 @@ def noise_conn(
 
 
 @pytest.fixture
-def conn_with_expected_name(
-    event_loop: asyncio.AbstractEventLoop, connection_params: ConnectionParams
-) -> APIConnection:
+async def conn_with_expected_name(connection_params: ConnectionParams) -> APIConnection:
     connection_params = replace(connection_params, expected_name="test")
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 
 @pytest.fixture()
-def aiohappyeyeballs_start_connection(event_loop: asyncio.AbstractEventLoop):
+async def aiohappyeyeballs_start_connection():
     with patch("aioesphomeapi.connection.aiohappyeyeballs.start_connection") as func:
         mock_socket = create_autospec(socket.socket, spec_set=True, instance=True)
         mock_socket.type = socket.SOCK_STREAM

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,7 @@ async def plaintext_connect_task_no_login(
     resolve_host,
     aiohappyeyeballs_start_connection,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
 

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -97,7 +97,6 @@ if sys.platform != "win32":
     "in_bytes, pkt_data, pkt_type",
     _PLAINTEXT_TESTS,
 )
-@pytest.mark.asyncio
 async def test_plaintext_frame_helper(
     in_bytes: bytes, pkt_data: bytes, pkt_type: int
 ) -> None:
@@ -131,7 +130,6 @@ async def test_plaintext_frame_helper(
     "in_bytes, pkt_data, pkt_type",
     _PLAINTEXT_TESTS,
 )
-@pytest.mark.asyncio
 async def test_plaintext_frame_helper_multiple_payloads_single_packet(
     in_bytes: bytes, pkt_data: bytes, pkt_type: int
 ) -> None:
@@ -166,7 +164,7 @@ async def test_plaintext_frame_helper_multiple_payloads_single_packet(
     "byte_type",
     (bytes, bytearray, memoryview),
 )
-def test_plaintext_frame_helper_protractor_event_loop(byte_type: Any) -> None:
+async def test_plaintext_frame_helper_protractor_event_loop(byte_type: Any) -> None:
     """Test the plaintext frame helper with the protractor event loop.
 
     With the protractor event loop, data_received is called with a bytearray
@@ -202,7 +200,6 @@ def test_plaintext_frame_helper_protractor_event_loop(byte_type: Any) -> None:
         assert data == b"\x42" * 4
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "byte_type",
     (bytes, bytearray, memoryview),
@@ -244,7 +241,6 @@ async def test_noise_protector_event_loop(byte_type: Any) -> None:
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_incorrect_key():
     """Test that the noise frame helper raises InvalidEncryptionKeyAPIError on bad key."""
     outgoing_packets = [
@@ -276,7 +272,6 @@ async def test_noise_frame_helper_incorrect_key():
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_incorrect_key_fragments():
     """Test that the noise frame helper raises InvalidEncryptionKeyAPIError on bad key with fragmented packets."""
     outgoing_packets = [
@@ -310,7 +305,6 @@ async def test_noise_frame_helper_incorrect_key_fragments():
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_noise_incorrect_name():
     """Test we raise on bad name."""
     outgoing_packets = [
@@ -343,7 +337,6 @@ async def test_noise_incorrect_name():
     assert exc_info.value.received_name == "servicetest"
 
 
-@pytest.mark.asyncio
 async def test_noise_incorrect_mac():
     """Test we raise on bad name."""
     outgoing_packets = [
@@ -377,7 +370,6 @@ async def test_noise_incorrect_mac():
     assert exc_info.value.received_mac == "244cab06499c"
 
 
-@pytest.mark.asyncio
 async def test_noise_mac_in_exception():
     """Test the mac is in the exception when the key is wrong if available."""
     outgoing_packets = [
@@ -427,7 +419,6 @@ def test_varuint_to_bytes(val, encoded):
     assert cached_varuint_to_bytes(val) == encoded
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_handshake_failure():
     """Test the noise frame helper handshake failure."""
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
@@ -477,7 +468,6 @@ async def test_noise_frame_helper_handshake_failure():
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_handshake_success_with_single_packet():
     """Test the noise frame helper handshake success with a single packet."""
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
@@ -538,7 +528,6 @@ async def test_noise_frame_helper_handshake_success_with_single_packet():
     mock_data_received(helper, encrypted_packet)
 
 
-@pytest.mark.asyncio
 async def test_noise_valid_encryption_invalid_payload(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -606,7 +595,6 @@ async def test_noise_valid_encryption_invalid_payload(
     helper.close()
 
 
-@pytest.mark.asyncio
 async def test_noise_valid_encryption_payload_short(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -685,7 +673,6 @@ async def test_noise_valid_encryption_payload_short(
     helper.close()
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_bad_encryption(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -748,7 +735,6 @@ async def test_noise_frame_helper_bad_encryption(
     helper.close()
 
 
-@pytest.mark.asyncio
 async def test_init_plaintext_with_wrong_preamble(
     conn: APIConnection, aiohappyeyeballs_start_connection
 ):
@@ -771,7 +757,6 @@ async def test_init_plaintext_with_wrong_preamble(
         await task
 
 
-@pytest.mark.asyncio
 async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> None:
     loop = asyncio.get_running_loop()
     transport = MagicMock()
@@ -796,7 +781,6 @@ async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> N
             await task
 
 
-@pytest.mark.asyncio
 async def test_init_noise_with_plaintext_byte_marker(noise_conn: APIConnection) -> None:
     loop = asyncio.get_running_loop()
     transport = MagicMock()
@@ -823,7 +807,6 @@ async def test_init_noise_with_plaintext_byte_marker(noise_conn: APIConnection) 
             await task
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_empty_hello():
     """Test empty hello with noise."""
     connection, _ = _make_mock_connection()
@@ -844,7 +827,6 @@ async def test_noise_frame_helper_empty_hello():
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_noise_frame_helper_wrong_protocol():
     """Test noise with the wrong protocol."""
     connection, _ = _make_mock_connection()
@@ -868,7 +850,6 @@ async def test_noise_frame_helper_wrong_protocol():
         await helper.ready_future
 
 
-@pytest.mark.asyncio
 async def test_init_noise_attempted_when_esp_uses_plaintext(
     noise_conn: APIConnection,
 ) -> None:
@@ -897,7 +878,6 @@ async def test_init_noise_attempted_when_esp_uses_plaintext(
             await task
 
 
-@pytest.mark.asyncio
 async def test_eof_received_closes_connection(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -918,7 +898,6 @@ async def test_eof_received_closes_connection(
         (SocketClosedAPIError("original message"), SocketClosedAPIError),
     ],
 )
-@pytest.mark.asyncio
 async def test_connection_lost_closes_connection_and_logs(
     caplog: pytest.LogCaptureFixture,
     plaintext_connect_task_with_login: tuple[
@@ -935,7 +914,6 @@ async def test_connection_lost_closes_connection_and_logs(
         await connect_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("bad_psk", "error"),
     (

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -752,7 +752,7 @@ async def test_noise_frame_helper_bad_encryption(
 async def test_init_plaintext_with_wrong_preamble(
     conn: APIConnection, aiohappyeyeballs_start_connection
 ):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol = get_mock_protocol(conn)
     with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
@@ -773,7 +773,7 @@ async def test_init_plaintext_with_wrong_preamble(
 
 @pytest.mark.asyncio
 async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     protocol: APINoiseFrameHelper | None = None
 
@@ -798,7 +798,7 @@ async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> N
 
 @pytest.mark.asyncio
 async def test_init_noise_with_plaintext_byte_marker(noise_conn: APIConnection) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     protocol: APINoiseFrameHelper | None = None
 
@@ -872,7 +872,7 @@ async def test_noise_frame_helper_wrong_protocol():
 async def test_init_noise_attempted_when_esp_uses_plaintext(
     noise_conn: APIConnection,
 ) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     protocol: APINoiseFrameHelper | None = None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,7 +180,6 @@ def patch_api_version(client: APIClient, version: APIVersion):
     client._connection.api_version = version
 
 
-@pytest.mark.asyncio
 async def test_expected_name(auth_client: APIClient) -> None:
     """Ensure expected name can be set externally."""
     assert auth_client.expected_name is None
@@ -188,7 +187,6 @@ async def test_expected_name(auth_client: APIClient) -> None:
     assert auth_client.expected_name == "awesome"
 
 
-@pytest.mark.asyncio
 async def test_connect_backwards_compat() -> None:
     """Verify connect is a thin wrapper around start_connection and finish_connection."""
 
@@ -206,7 +204,6 @@ async def test_connect_backwards_compat() -> None:
     assert mock_finish_connection.mock_calls == [call(False)]
 
 
-@pytest.mark.asyncio
 async def test_finish_connection_wraps_exceptions_as_unhandled_api_error(
     aiohappyeyeballs_start_connection,
 ) -> None:
@@ -227,7 +224,6 @@ async def test_finish_connection_wraps_exceptions_as_unhandled_api_error(
         await cli.finish_connection(False)
 
 
-@pytest.mark.asyncio
 async def test_connection_released_if_connecting_is_cancelled() -> None:
     """Verify connection is unset if connecting is cancelled."""
     cli = APIClient("127.0.0.1", 1234, None)
@@ -276,7 +272,6 @@ async def test_connection_released_if_connecting_is_cancelled() -> None:
     assert cli._connection is None
 
 
-@pytest.mark.asyncio
 async def test_request_while_handshaking() -> None:
     """Test trying a request while handshaking raises."""
 
@@ -303,14 +298,12 @@ async def test_request_while_handshaking() -> None:
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_connect_while_already_connected(auth_client: APIClient) -> None:
     """Test connecting while already connected raises."""
     with pytest.raises(APIConnectionError):
         await auth_client.start_connection()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "input, output",
     [
@@ -332,7 +325,6 @@ async def test_list_entities(
     assert resp == output
 
 
-@pytest.mark.asyncio
 async def test_subscribe_states(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_state = MagicMock()
@@ -343,7 +335,6 @@ async def test_subscribe_states(auth_client: APIClient) -> None:
     on_state.assert_called_once_with(BinarySensorState())
 
 
-@pytest.mark.asyncio
 async def test_subscribe_states_camera(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_state = MagicMock()
@@ -355,7 +346,6 @@ async def test_subscribe_states_camera(auth_client: APIClient) -> None:
     on_state.assert_called_once_with(CameraState(key=1, data=b"asdfqwer"))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -390,7 +380,6 @@ async def test_cover_command_legacy(
     send.assert_called_once_with(CoverCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -414,7 +403,6 @@ async def test_cover_command(
     send.assert_called_once_with(CoverCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -451,7 +439,6 @@ async def test_fan_command(
     send.assert_called_once_with(FanCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -515,7 +502,6 @@ async def test_light_command(
     send.assert_called_once_with(LightCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -532,7 +518,6 @@ async def test_switch_command(
     send.assert_called_once_with(SwitchCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -556,7 +541,6 @@ async def test_climate_command_legacy(
     send.assert_called_once_with(ClimateCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -612,7 +596,6 @@ async def test_climate_command(
     send.assert_called_once_with(ClimateCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -629,7 +612,6 @@ async def test_number_command(
     send.assert_called_once_with(NumberCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -653,7 +635,8 @@ async def test_date_command(
 
 
 # Test time command
-@pytest.mark.asyncio
+
+
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -677,7 +660,8 @@ async def test_time_command(
 
 
 # Test date_time command
-@pytest.mark.asyncio
+
+
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -700,7 +684,6 @@ async def test_datetime_command(
     send.assert_called_once_with(DateTimeCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -725,7 +708,6 @@ async def test_lock_command(
     send.assert_called_once_with(LockCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -744,7 +726,6 @@ async def test_valve_command(
     send.assert_called_once_with(ValveCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -768,7 +749,6 @@ async def test_valve_command_version_1_1(
     send.assert_called_once_with(ValveCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -785,7 +765,6 @@ async def test_select_command(
     send.assert_called_once_with(SelectCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -822,7 +801,6 @@ async def test_media_player_command(
     send.assert_called_once_with(MediaPlayerCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -838,7 +816,6 @@ async def test_button_command(
     send.assert_called_once_with(ButtonCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -872,7 +849,6 @@ async def test_siren_command(
     send.assert_called_once_with(SirenCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 async def test_execute_service(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
     patch_api_version(auth_client, APIVersion(1, 3))
@@ -974,7 +950,6 @@ async def test_execute_service(auth_client: APIClient) -> None:
     send.reset_mock()
 
 
-@pytest.mark.asyncio
 async def test_request_single_image(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
@@ -982,7 +957,6 @@ async def test_request_single_image(auth_client: APIClient) -> None:
     send.assert_called_once_with(CameraImageRequest(single=True, stream=False))
 
 
-@pytest.mark.asyncio
 async def test_request_image_stream(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
@@ -990,7 +964,6 @@ async def test_request_image_stream(auth_client: APIClient) -> None:
     send.assert_called_once_with(CameraImageRequest(single=False, stream=True))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -1017,7 +990,6 @@ async def test_alarm_panel_command(
     send.assert_called_once_with(AlarmControlPanelCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -1034,7 +1006,6 @@ async def test_text_command(
     send.assert_called_once_with(TextCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, req",
     [
@@ -1057,7 +1028,6 @@ async def test_update_command(
     send.assert_called_once_with(UpdateCommandRequest(**req))
 
 
-@pytest.mark.asyncio
 async def test_noise_psk_handles_subclassed_string():
     """Test that the noise_psk gets converted to a string."""
 
@@ -1097,7 +1067,6 @@ async def test_noise_psk_handles_subclassed_string():
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_no_noise_psk():
     """Test not using a noise_psk."""
     cli = APIClient(
@@ -1113,7 +1082,6 @@ async def test_no_noise_psk():
     assert type(cli._params.expected_name) is str
 
 
-@pytest.mark.asyncio
 async def test_empty_noise_psk_or_expected_name():
     """Test an empty noise_psk is treated as None."""
     cli = APIClient(
@@ -1128,7 +1096,6 @@ async def test_empty_noise_psk_or_expected_name():
     assert cli._params.expected_name is None
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_disconnect(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1145,7 +1112,6 @@ async def test_bluetooth_disconnect(
     await disconnect_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_pair(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1164,7 +1130,6 @@ async def test_bluetooth_pair(
     await pair_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_pair_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1186,7 +1151,6 @@ async def test_bluetooth_pair_connection_drops(
         await pair_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_unpair_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1208,7 +1172,6 @@ async def test_bluetooth_unpair_connection_drops(
         await pair_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_clear_cache_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1230,7 +1193,6 @@ async def test_bluetooth_clear_cache_connection_drops(
         await pair_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_unpair(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1245,7 +1207,6 @@ async def test_bluetooth_unpair(
     await unpair_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_clear_cache(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1260,7 +1221,6 @@ async def test_bluetooth_clear_cache(
     await clear_task
 
 
-@pytest.mark.asyncio
 async def test_device_info(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1295,7 +1255,6 @@ async def test_device_info(
         await client.device_info()
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_read(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1318,7 +1277,6 @@ async def test_bluetooth_gatt_read(
     assert await read_task == b"1234"
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_read_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1340,7 +1298,6 @@ async def test_bluetooth_gatt_read_connection_drops(
         await read_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_read_error(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1358,7 +1315,6 @@ async def test_bluetooth_gatt_read_error(
         await read_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_read_descriptor(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1381,7 +1337,6 @@ async def test_bluetooth_gatt_read_descriptor(
     assert await read_task == b"1234"
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_write(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1404,7 +1359,6 @@ async def test_bluetooth_gatt_write(
     await write_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_write_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1428,7 +1382,6 @@ async def test_bluetooth_gatt_write_connection_drops(
         await write_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_write_without_response(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1453,7 +1406,6 @@ async def test_bluetooth_gatt_write_without_response(
         await client.bluetooth_gatt_write(1234, 1234, b"1234", True, timeout=0)
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_write_descriptor(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1476,7 +1428,6 @@ async def test_bluetooth_gatt_write_descriptor(
     await write_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_write_descriptor_without_response(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1503,7 +1454,6 @@ async def test_bluetooth_gatt_write_descriptor_without_response(
         await client.bluetooth_gatt_write_descriptor(1234, 1234, b"1234", timeout=0)
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_get_services_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1526,7 +1476,6 @@ async def test_bluetooth_gatt_get_services_connection_drops(
         await services_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_get_services(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1563,7 +1512,6 @@ async def test_bluetooth_gatt_get_services(
     )
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_get_services_errors(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1587,7 +1535,6 @@ async def test_bluetooth_gatt_get_services_errors(
         await services_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_start_notify_connection_drops(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1611,7 +1558,6 @@ async def test_bluetooth_gatt_start_notify_connection_drops(
         await notify_task
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_start_notify(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1665,7 +1611,6 @@ async def test_bluetooth_gatt_start_notify(
     await cancel_cb()
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_start_notify_fails(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1696,7 +1641,6 @@ async def test_bluetooth_gatt_start_notify_fails(
     )
 
 
-@pytest.mark.asyncio
 async def test_subscribe_bluetooth_le_advertisements(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1810,7 +1754,6 @@ async def test_subscribe_bluetooth_le_advertisements(
     unsub()
 
 
-@pytest.mark.asyncio
 async def test_subscribe_bluetooth_le_raw_advertisements(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1850,7 +1793,6 @@ async def test_subscribe_bluetooth_le_raw_advertisements(
     unsub()
 
 
-@pytest.mark.asyncio
 async def test_subscribe_bluetooth_connections_free(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1876,7 +1818,6 @@ async def test_subscribe_bluetooth_connections_free(
     unsub()
 
 
-@pytest.mark.asyncio
 async def test_subscribe_home_assistant_states(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1926,7 +1867,6 @@ async def test_subscribe_home_assistant_states(
     assert requests == [("sensor.blue", "any"), ("sensor.white", "")]
 
 
-@pytest.mark.asyncio
 async def test_subscribe_logs(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_logs = MagicMock()
@@ -1942,7 +1882,6 @@ async def test_subscribe_logs(auth_client: APIClient) -> None:
     on_logs.reset_mock()
 
 
-@pytest.mark.asyncio
 async def test_send_home_assistant_state(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
     auth_client.send_home_assistant_state("binary_sensor.bla", None, "on")
@@ -1953,7 +1892,6 @@ async def test_send_home_assistant_state(auth_client: APIClient) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_subscribe_service_calls(auth_client: APIClient) -> None:
     send = patch_response_callback(auth_client)
     on_service_call = MagicMock()
@@ -1963,7 +1901,6 @@ async def test_subscribe_service_calls(auth_client: APIClient) -> None:
     on_service_call.assert_called_with(HomeassistantServiceCall.from_pb(service_msg))
 
 
-@pytest.mark.asyncio
 async def test_set_debug(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1997,7 +1934,6 @@ async def test_set_debug(
     assert "My Device" not in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_force_disconnect(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2014,7 +1950,6 @@ async def test_force_disconnect(
     assert connection.is_connected is False
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("has_cache", "feature_flags", "method"),
     [
@@ -2101,7 +2036,6 @@ async def test_bluetooth_device_connect(
     cancel()
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_device_connect_and_disconnect_times_out(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2130,7 +2064,6 @@ async def test_bluetooth_device_connect_and_disconnect_times_out(
     assert states == []
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_device_connect_times_out_disconnect_ok(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2172,7 +2105,6 @@ async def test_bluetooth_device_connect_times_out_disconnect_ok(
     assert states == []
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_device_connect_cancelled(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2218,7 +2150,6 @@ async def test_bluetooth_device_connect_cancelled(
     assert handlers_after == handlers_before
 
 
-@pytest.mark.asyncio
 async def test_send_voice_assistant_event(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
@@ -2248,7 +2179,6 @@ async def test_send_voice_assistant_event(auth_client: APIClient) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_subscribe_voice_assistant(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2331,7 +2261,6 @@ async def test_subscribe_voice_assistant(
     assert len(send.mock_calls) == 0
 
 
-@pytest.mark.asyncio
 async def test_subscribe_voice_assistant_failure(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2414,7 +2343,6 @@ async def test_subscribe_voice_assistant_failure(
     assert len(send.mock_calls) == 0
 
 
-@pytest.mark.asyncio
 async def test_subscribe_voice_assistant_cancels_long_running_handle_start(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2482,7 +2410,6 @@ async def test_subscribe_voice_assistant_cancels_long_running_handle_start(
     ]
 
 
-@pytest.mark.asyncio
 async def test_subscribe_voice_assistant_api_audio(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2593,7 +2520,6 @@ async def test_subscribe_voice_assistant_api_audio(
     assert len(send.mock_calls) == 0
 
 
-@pytest.mark.asyncio
 async def test_send_voice_assistant_timer_event(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 
@@ -2618,7 +2544,6 @@ async def test_send_voice_assistant_timer_event(auth_client: APIClient) -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_send_voice_assistant_announcement_await_response(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2646,7 +2571,6 @@ async def test_send_voice_assistant_announcement_await_response(
         assert isinstance(finished, VoiceAssistantAnnounceFinishedModel)
 
 
-@pytest.mark.asyncio
 async def test_subscribe_voice_assistant_announcement_finished(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2695,7 +2619,6 @@ async def test_subscribe_voice_assistant_announcement_finished(
     assert len(send.mock_calls) == 0
 
 
-@pytest.mark.asyncio
 async def test_get_voice_assistant_configuration(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2729,7 +2652,6 @@ async def test_get_voice_assistant_configuration(
         assert isinstance(config, VoiceAssistantConfigurationResponseModel)
 
 
-@pytest.mark.asyncio
 async def test_set_voice_assistant_configuration(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2746,7 +2668,6 @@ async def test_set_voice_assistant_configuration(
         await client.set_voice_assistant_configuration(["1234"])
 
 
-@pytest.mark.asyncio
 async def test_api_version_after_connection_closed(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -2759,7 +2680,6 @@ async def test_api_version_after_connection_closed(
     assert client.api_version is None
 
 
-@pytest.mark.asyncio
 async def test_calls_after_connection_closed(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,7 +231,7 @@ async def test_finish_connection_wraps_exceptions_as_unhandled_api_error(
 async def test_connection_released_if_connecting_is_cancelled() -> None:
     """Verify connection is unset if connecting is cancelled."""
     cli = APIClient("127.0.0.1", 1234, None)
-    asyncio.get_event_loop()
+    asyncio.get_running_loop()
 
     async def _start_connection_with_delay(*args, **kwargs):
         await asyncio.sleep(1)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -57,7 +57,6 @@ from .common import (
 KEEP_ALIVE_TIMEOUT_RATIO = 4.5
 
 
-@pytest.mark.asyncio
 async def test_connect(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -86,7 +85,6 @@ async def test_connect(
     assert conn.is_connected
 
 
-@pytest.mark.asyncio
 async def test_timeout_sending_message(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -122,7 +120,6 @@ async def test_timeout_sending_message(
     assert " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_disconnect_when_not_fully_connected(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -159,7 +156,6 @@ async def test_disconnect_when_not_fully_connected(
     assert " Timeout waiting for DisconnectResponse after 0.0s" in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_requires_encryption_propagates(conn: APIConnection):
     loop = asyncio.get_running_loop()
     protocol = get_mock_protocol(conn)
@@ -186,7 +182,6 @@ async def test_requires_encryption_propagates(conn: APIConnection):
     assert isinstance(conn._fatal_exception, RequiresEncryptionAPIError)
 
 
-@pytest.mark.asyncio
 async def test_plaintext_connection(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -227,7 +222,6 @@ async def test_plaintext_connection(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_start_connection_socket_error(
     conn: APIConnection,
     resolve_host,
@@ -246,7 +240,6 @@ async def test_start_connection_socket_error(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_start_connection_cannot_increase_recv_buffer(
     conn: APIConnection,
     resolve_host,
@@ -299,7 +292,6 @@ async def test_start_connection_cannot_increase_recv_buffer(
     conn.force_disconnect()
 
 
-@pytest.mark.asyncio
 async def test_start_connection_can_only_increase_buffer_size_to_262144(
     conn: APIConnection,
     resolve_host,
@@ -352,7 +344,6 @@ async def test_start_connection_can_only_increase_buffer_size_to_262144(
     conn.force_disconnect()
 
 
-@pytest.mark.asyncio
 async def test_start_connection_times_out(
     conn: APIConnection,
     resolve_host,
@@ -384,7 +375,6 @@ async def test_start_connection_times_out(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_start_connection_os_error(conn: APIConnection, resolve_host):
     """Test handling of start connection has an OSError."""
     asyncio.get_running_loop()
@@ -402,7 +392,6 @@ async def test_start_connection_os_error(conn: APIConnection, resolve_host):
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_start_connection_is_cancelled(conn: APIConnection, resolve_host):
     """Test handling of start connection is cancelled."""
     asyncio.get_running_loop()
@@ -420,7 +409,6 @@ async def test_start_connection_is_cancelled(conn: APIConnection, resolve_host):
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_finish_connection_is_cancelled(
     conn: APIConnection,
     resolve_host,
@@ -439,7 +427,6 @@ async def test_finish_connection_is_cancelled(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_finish_connection_times_out(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -487,7 +474,6 @@ async def test_finish_connection_times_out(
         (asyncio.CancelledError, APIConnectionError),
     ],
 )
-@pytest.mark.asyncio
 async def test_plaintext_connection_fails_handshake(
     conn: APIConnection,
     resolve_host: AsyncMock,
@@ -573,7 +559,6 @@ async def test_plaintext_connection_fails_handshake(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_connect_wrong_password(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -590,7 +575,6 @@ async def test_connect_wrong_password(
     assert not conn.is_connected
 
 
-@pytest.mark.asyncio
 async def test_connect_correct_password(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -606,7 +590,6 @@ async def test_connect_correct_password(
     assert conn.is_connected
 
 
-@pytest.mark.asyncio
 async def test_connect_wrong_version(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -623,7 +606,6 @@ async def test_connect_wrong_version(
     assert conn.is_connected is False
 
 
-@pytest.mark.asyncio
 async def test_connect_wrong_name(
     plaintext_connect_task_expected_name: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -642,7 +624,6 @@ async def test_connect_wrong_name(
     assert conn.is_connected is False
 
 
-@pytest.mark.asyncio
 async def test_force_disconnect_fails(
     caplog: pytest.LogCaptureFixture,
     plaintext_connect_task_with_login: tuple[
@@ -671,7 +652,6 @@ async def test_force_disconnect_fails(
         (SocketClosedAPIError("original message"), SocketClosedAPIError),
     ],
 )
-@pytest.mark.asyncio
 async def test_connection_lost_while_connecting(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -697,7 +677,6 @@ async def test_connection_lost_while_connecting(
         (SocketClosedAPIError("original message"), SocketClosedAPIError),
     ],
 )
-@pytest.mark.asyncio
 async def test_connection_error_during_hello(
     conn: APIConnection,
     resolve_host,
@@ -734,7 +713,6 @@ async def test_connection_error_during_hello(
         (SocketClosedAPIError("original message"), SocketClosedAPIError),
     ],
 )
-@pytest.mark.asyncio
 async def test_connection_cancelled_during_hello(
     conn: APIConnection,
     resolve_host,
@@ -767,7 +745,6 @@ async def test_connection_cancelled_during_hello(
     assert not conn.is_connected
 
 
-@pytest.mark.asyncio
 async def test_connect_resolver_times_out(
     conn: APIConnection, aiohappyeyeballs_start_connection
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
@@ -795,7 +772,6 @@ async def test_connect_resolver_times_out(
         await connect(conn, login=False)
 
 
-@pytest.mark.asyncio
 async def test_disconnect_fails_to_send_response(
     connection_params: ConnectionParams,
     resolve_host,
@@ -844,7 +820,6 @@ async def test_disconnect_fails_to_send_response(
     assert expected_disconnect is True
 
 
-@pytest.mark.asyncio
 async def test_disconnect_success_case(
     connection_params: ConnectionParams,
     resolve_host,
@@ -893,7 +868,6 @@ async def test_disconnect_success_case(
     assert not client._connection
 
 
-@pytest.mark.asyncio
 async def test_ping_disconnects_after_no_responses(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -933,7 +907,6 @@ async def test_ping_disconnects_after_no_responses(
     assert conn.is_connected is False
 
 
-@pytest.mark.asyncio
 async def test_ping_does_not_disconnect_if_we_get_responses(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -971,7 +944,6 @@ def test_raise_during_send_messages_when_not_yet_connected(conn: APIConnection) 
         conn.send_message(PingRequest())
 
 
-@pytest.mark.asyncio
 async def test_respond_to_ping_request(
     caplog: pytest.LogCaptureFixture,
     plaintext_connect_task_with_login: tuple[
@@ -994,7 +966,6 @@ async def test_respond_to_ping_request(
     assert transport.writelines.mock_calls == [call(ping_response_bytes)]
 
 
-@pytest.mark.asyncio
 async def test_unknown_protobuf_message_type_logged(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1026,7 +997,6 @@ async def test_unknown_protobuf_message_type_logged(
     await asyncio.sleep(0)
 
 
-@pytest.mark.asyncio
 async def test_bad_protobuf_message_drops_connection(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
@@ -1056,7 +1026,6 @@ async def test_bad_protobuf_message_drops_connection(
     assert connection.is_connected is False
 
 
-@pytest.mark.asyncio
 async def test_connection_cannot_be_reused(
     plaintext_connect_task_with_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task
@@ -1071,7 +1040,6 @@ async def test_connection_cannot_be_reused(
         await conn.start_connection()
 
 
-@pytest.mark.asyncio
 async def test_attempting_to_finish_unstarted_connection(
     conn: APIConnection,
 ) -> None:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -161,7 +161,7 @@ async def test_disconnect_when_not_fully_connected(
 
 @pytest.mark.asyncio
 async def test_requires_encryption_propagates(conn: APIConnection):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol = get_mock_protocol(conn)
     with patch.object(loop, "create_connection") as create_connection:
         create_connection.return_value = (MagicMock(), protocol)
@@ -234,7 +234,7 @@ async def test_start_connection_socket_error(
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of socket error during start connection."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     with patch.object(loop, "create_connection", side_effect=OSError("Socket error")):
         connect_task = asyncio.create_task(connect(conn, login=False))
@@ -254,7 +254,7 @@ async def test_start_connection_cannot_increase_recv_buffer(
     caplog: pytest.LogCaptureFixture,
 ):
     """Test failing to increase the recv buffer."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
     tried_sizes = []
@@ -307,7 +307,7 @@ async def test_start_connection_can_only_increase_buffer_size_to_262144(
     caplog: pytest.LogCaptureFixture,
 ):
     """Test the receive buffer can only be increased to 262144."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
     tried_sizes = []
@@ -359,7 +359,7 @@ async def test_start_connection_times_out(
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of start connection timing out."""
-    asyncio.get_event_loop()
+    asyncio.get_running_loop()
 
     async def _mock_socket_connect(*args, **kwargs):
         await asyncio.sleep(500)
@@ -387,7 +387,7 @@ async def test_start_connection_times_out(
 @pytest.mark.asyncio
 async def test_start_connection_os_error(conn: APIConnection, resolve_host):
     """Test handling of start connection has an OSError."""
-    asyncio.get_event_loop()
+    asyncio.get_running_loop()
 
     with patch(
         "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
@@ -405,7 +405,7 @@ async def test_start_connection_os_error(conn: APIConnection, resolve_host):
 @pytest.mark.asyncio
 async def test_start_connection_is_cancelled(conn: APIConnection, resolve_host):
     """Test handling of start connection is cancelled."""
-    asyncio.get_event_loop()
+    asyncio.get_running_loop()
 
     with patch(
         "aioesphomeapi.connection.aiohappyeyeballs.start_connection",
@@ -427,7 +427,7 @@ async def test_finish_connection_is_cancelled(
     aiohappyeyeballs_start_connection,
 ):
     """Test handling of finishing connection being cancelled."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     with patch.object(loop, "create_connection", side_effect=asyncio.CancelledError):
         connect_task = asyncio.create_task(connect(conn, login=False))
@@ -498,7 +498,7 @@ async def test_plaintext_connection_fails_handshake(
 
     If we don't do this, asyncio will get confused and not release the socket.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     exception, raised_exception = exception_map
     messages = []
     transport = MagicMock()
@@ -704,7 +704,7 @@ async def test_connection_error_during_hello(
     aiohappyeyeballs_start_connection,
     exception_map: tuple[Exception, Exception],
 ) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
     exception, raised_exception = exception_map
@@ -741,7 +741,7 @@ async def test_connection_cancelled_during_hello(
     aiohappyeyeballs_start_connection,
     exception_map: tuple[Exception, Exception],
 ) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
     exception, raised_exception = exception_map
@@ -801,7 +801,7 @@ async def test_disconnect_fails_to_send_response(
     resolve_host,
     aiohappyeyeballs_start_connection,
 ) -> None:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
     client = APIClient(

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -66,7 +66,6 @@ def mock_getaddrinfo() -> list[tuple[int, int, int, str, tuple[str, int]]]:
     ]
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     info = MagicMock(auto_spec=AsyncServiceInfo)
     info.ip_addresses_by_version.side_effect = [
@@ -84,7 +83,6 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     info = MagicMock(auto_spec=AsyncServiceInfo)
     ipv6 = IPv6Address("2001:db8:85a3::8a2e:370:7334%0")
@@ -101,7 +99,6 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
     await asyncio.sleep(0.1)
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
     with patch(
         "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request"
@@ -113,7 +110,6 @@ async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
     assert ret == []
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
     with (
         patch(
@@ -125,7 +121,6 @@ async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
         await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf.local", 6052)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo", return_value=[])
 async def test_resolve_host_zeroconf_fails_end_to_end(async_zeroconf: AsyncZeroconf):
     with (
@@ -138,7 +133,6 @@ async def test_resolve_host_zeroconf_fails_end_to_end(async_zeroconf: AsyncZeroc
         await hr.async_resolve_host(["asdf.local"], 6052)
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_getaddrinfo(addr_infos):
     event_loop = asyncio.get_running_loop()
     with patch.object(event_loop, "getaddrinfo") as mock:
@@ -164,7 +158,6 @@ async def test_resolve_host_getaddrinfo(addr_infos):
         assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_getaddrinfo_oserror():
     event_loop = asyncio.get_running_loop()
     with patch.object(event_loop, "getaddrinfo") as mock:
@@ -173,7 +166,6 @@ async def test_resolve_host_getaddrinfo_oserror():
             await hr._async_resolve_host_getaddrinfo("example.com", 6052)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns_and_dns(resolve_addr, resolve_zc, addr_infos):
@@ -185,7 +177,6 @@ async def test_resolve_host_mdns_and_dns(resolve_addr, resolve_zc, addr_infos):
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_slow_mdns_wins(
     addr_infos: list[AddrInfo],
 ) -> None:
@@ -219,7 +210,6 @@ async def test_resolve_host_mdns_and_dns_slow_mdns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_exception_mdns_wins(
     addr_infos: list[AddrInfo],
 ) -> None:
@@ -252,7 +242,6 @@ async def test_resolve_host_mdns_and_dns_exception_mdns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_fast_mdns_wins(
     addr_infos: list[AddrInfo],
 ) -> None:
@@ -285,7 +274,6 @@ async def test_resolve_host_mdns_and_dns_fast_mdns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_slow_dns_wins(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -320,7 +308,6 @@ async def test_resolve_host_mdns_and_dns_slow_dns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_mdns_exception_dns_wins(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -353,7 +340,6 @@ async def test_resolve_host_mdns_and_mdns_exception_dns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_mdns_no_results_dns_wins(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -380,7 +366,6 @@ async def test_resolve_host_mdns_and_mdns_no_results_dns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_fast_dns_wins(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -411,7 +396,6 @@ async def test_resolve_host_mdns_and_dns_fast_dns_wins(
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_cache(addr_infos: list[AddrInfo]) -> None:
     """Test not requests for DNS are made when we can use the mDNS cache."""
     loop = asyncio.get_running_loop()
@@ -433,7 +417,6 @@ async def test_resolve_host_mdns_cache(addr_infos: list[AddrInfo]) -> None:
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_mdns_both_fail(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -458,7 +441,6 @@ async def test_resolve_host_mdns_and_mdns_both_fail(
         await hr.async_resolve_host(["example.local"], 6052)
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_mdns_and_dns_slow_all_timeout(
     addr_infos: list[AddrInfo],
     mock_getaddrinfo: list[tuple[int, int, int, str, tuple[str, int]]],
@@ -492,7 +474,6 @@ async def test_resolve_host_mdns_and_dns_slow_all_timeout(
         await hr.async_resolve_host(["example.local"], 6052, timeout=0.01)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
@@ -505,7 +486,6 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver.AsyncServiceInfo.async_request", return_value=False)
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
@@ -514,7 +494,6 @@ async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
         await hr.async_resolve_host(["example.local"], 6052)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
@@ -526,7 +505,6 @@ async def test_resolve_host_addrinfo(resolve_addr, resolve_zc, addr_infos):
     assert ret == addr_infos
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos):
@@ -538,7 +516,6 @@ async def test_resolve_host_addrinfo_empty(resolve_addr, resolve_zc, addr_infos)
     resolve_addr.assert_called_once_with("example.com", 6052)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_short_host_zeroconf")
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_with_address(resolve_addr, resolve_zc):
@@ -558,7 +535,6 @@ async def test_resolve_host_with_address(resolve_addr, resolve_zc):
     ]
 
 
-@pytest.mark.asyncio
 async def test_resolve_host_zeroconf_service_info_oserror(
     async_zeroconf: AsyncZeroconf, addr_infos
 ):
@@ -579,7 +555,6 @@ async def test_resolve_host_zeroconf_service_info_oserror(
         await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
 
-@pytest.mark.asyncio
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_create_zeroconf_oserror(
     resolve_addr, async_zeroconf: AsyncZeroconf, addr_infos

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -38,7 +38,7 @@ async def test_log_runner(
     aiohappyeyeballs_start_connection,
 ):
     """Test the log runner logic."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()
     connected = asyncio.Event()
@@ -107,7 +107,7 @@ async def test_log_runner_reconnects_on_disconnect(
     aiohappyeyeballs_start_connection,
 ) -> None:
     """Test the log runner reconnects on disconnect."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()
     connected = asyncio.Event()
@@ -187,7 +187,7 @@ async def test_log_runner_reconnects_on_subscribe_failure(
     aiohappyeyeballs_start_connection,
 ) -> None:
     """Test the log runner reconnects on subscribe failure."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()
     connected = asyncio.Event()

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -32,7 +32,6 @@ from .common import (
 )
 
 
-@pytest.mark.asyncio
 async def test_log_runner(
     conn: APIConnection,
     aiohappyeyeballs_start_connection,
@@ -100,7 +99,6 @@ async def test_log_runner(
     await stop_task
 
 
-@pytest.mark.asyncio
 async def test_log_runner_reconnects_on_disconnect(
     conn: APIConnection,
     caplog: pytest.LogCaptureFixture,
@@ -180,7 +178,6 @@ async def test_log_runner_reconnects_on_disconnect(
     await stop()
 
 
-@pytest.mark.asyncio
 async def test_log_runner_reconnects_on_subscribe_failure(
     conn: APIConnection,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -571,7 +571,6 @@ def test_supported_color_modes_compat(
     assert info.supported_color_modes_compat(APIVersion(1, 9)) == [42]
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_gatt_services_from_dict() -> None:
     """Test bluetooth_gatt_get_services success case."""
     services: message.Message = BluetoothGATTGetServicesResponse(

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -48,7 +48,6 @@ async def quick_connect_fail(*args, **kwargs):
     raise APIConnectionError
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_name_from_host():
     """Test that the name is set correctly from the host."""
     cli = APIClient(
@@ -72,7 +71,6 @@ async def test_reconnect_logic_name_from_host():
     assert cli.log_name == "mydevice.local"
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_name_from_host_and_set():
     """Test that the name is set correctly from the host."""
     cli = APIClient(
@@ -98,7 +96,6 @@ async def test_reconnect_logic_name_from_host_and_set():
     assert cli.log_name == "mydevice.local"
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_name_from_address():
     """Test that the name is set correctly from the address."""
     cli = APIClient(
@@ -122,7 +119,6 @@ async def test_reconnect_logic_name_from_address():
     assert cli.log_name == "127.0.0.1"
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_name_from_name():
     """Test that the name is set correctly from the address."""
     cli = APIClient(
@@ -147,7 +143,6 @@ async def test_reconnect_logic_name_from_name():
     assert cli.log_name == "mydevice @ 127.0.0.1"
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_name_from_cli_address():
     """Test that the name is set correctly from the address."""
     cli = APIClient(
@@ -172,7 +167,6 @@ async def test_reconnect_logic_name_from_cli_address():
     assert rl.name == "mydevice"
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_state(patchable_api_client: APIClient):
     """Test that reconnect logic state changes."""
     on_disconnect_called = []
@@ -244,7 +238,6 @@ async def test_reconnect_logic_state(patchable_api_client: APIClient):
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_reconnect_retry(
     patchable_api_client: APIClient, caplog: pytest.LogCaptureFixture
 ):
@@ -392,7 +385,6 @@ DNS_POINTER = DNSPointer(
         ),
     ),
 )
-@pytest.mark.asyncio
 async def test_reconnect_zeroconf(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,
@@ -475,7 +467,6 @@ async def test_reconnect_zeroconf(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_reconnect_zeroconf_not_while_handshaking(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,
@@ -535,7 +526,6 @@ async def test_reconnect_zeroconf_not_while_handshaking(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_connect_task_not_cancelled_while_handshaking(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,
@@ -595,7 +585,6 @@ async def test_connect_task_not_cancelled_while_handshaking(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_connect_aborts_if_stopped(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,
@@ -635,7 +624,6 @@ async def test_connect_aborts_if_stopped(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_stop_callback(patchable_api_client: APIClient):
     """Test that the stop_callback stops the ReconnectLogic."""
     cli = patchable_api_client
@@ -659,7 +647,6 @@ async def test_reconnect_logic_stop_callback(patchable_api_client: APIClient):
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_reconnect_logic_stop_callback_waits_for_handshake(
     patchable_api_client: APIClient,
 ):
@@ -699,7 +686,6 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
-@pytest.mark.asyncio
 async def test_handling_unexpected_disconnect(aiohappyeyeballs_start_connection):
     """Test the disconnect callback fires with expected_disconnect=False."""
     loop = asyncio.get_running_loop()
@@ -776,7 +762,6 @@ async def test_handling_unexpected_disconnect(aiohappyeyeballs_start_connection)
     await logic.stop()
 
 
-@pytest.mark.asyncio
 async def test_backoff_on_encryption_error(
     caplog: pytest.LogCaptureFixture,
     aiohappyeyeballs_start_connection,

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -702,7 +702,7 @@ async def test_reconnect_logic_stop_callback_waits_for_handshake(
 @pytest.mark.asyncio
 async def test_handling_unexpected_disconnect(aiohappyeyeballs_start_connection):
     """Test the disconnect callback fires with expected_disconnect=False."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()
     connected = asyncio.Event()
@@ -782,7 +782,7 @@ async def test_backoff_on_encryption_error(
     aiohappyeyeballs_start_connection,
 ) -> None:
     """Test we backoff on encryption error."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     protocol: APIPlaintextFrameHelper | None = None
     transport = MagicMock()
     connected = asyncio.Event()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,7 +33,6 @@ def test_fix_float_single_double_conversion_nan():
     assert math.isnan(util.fix_float_single_double_conversion(float("nan")))
 
 
-@pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test requires Python 3.12+")
 async def test_create_eager_task_312() -> None:
     """Test create_eager_task schedules a task eagerly in the event loop.
@@ -59,7 +58,6 @@ async def test_create_eager_task_312() -> None:
     await task2
 
 
-@pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="Test requires < Python 3.12")
 async def test_create_eager_task_pre_312() -> None:
     """Test create_eager_task schedules a task in the event loop.

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -10,7 +10,6 @@ from aioesphomeapi.zeroconf import ZeroconfManager
 from .common import get_mock_async_zeroconf
 
 
-@pytest.mark.asyncio
 async def test_does_not_closed_passed_in_async_instance(async_zeroconf: AsyncZeroconf):
     """Test that the passed in instance is not closed."""
     manager = ZeroconfManager()
@@ -19,7 +18,6 @@ async def test_does_not_closed_passed_in_async_instance(async_zeroconf: AsyncZer
     assert async_zeroconf.async_close.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_does_not_closed_passed_in_sync_instance(async_zeroconf: AsyncZeroconf):
     """Test that the passed in instance is not closed."""
     manager = ZeroconfManager()
@@ -28,7 +26,6 @@ async def test_does_not_closed_passed_in_sync_instance(async_zeroconf: AsyncZero
     assert async_zeroconf.async_close.call_count == 0
 
 
-@pytest.mark.asyncio
 async def test_closes_created_instance(async_zeroconf: AsyncZeroconf):
     """Test that the created instance is closed."""
     with patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf):
@@ -38,7 +35,6 @@ async def test_closes_created_instance(async_zeroconf: AsyncZeroconf):
     assert async_zeroconf.async_close.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_runtime_error_multiple_instances(async_zeroconf: AsyncZeroconf):
     """Test runtime error is raised on multiple instances."""
     manager = ZeroconfManager(async_zeroconf)


### PR DESCRIPTION
Calling `get_event_loop` with no running loop emits a warning, in a future Python version it will be an error. Make sure we are not using it.  This is a breaking change because it would create an event loop if one was not running. Spontaneous event loop creation is generally considered a bad thing which is why its deprecated in Python itself. Someone could be expecting it to work though so we will increment the major version.

> https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop
