### PR TITLE
Avoid decoding protobuf messages when there are no subscribers

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -5,6 +5,7 @@ from ._frame_helper.base cimport APIFrameHelper
 
 cdef dict MESSAGE_TYPE_TO_PROTO
 cdef dict PROTO_TO_MESSAGE_TYPE
+cdef dict PROTO_TO_MESSAGE_ID
 
 cdef set OPEN_STATES
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -717,7 +717,7 @@ class APIConnection:
             for msg in msgs
             if (msg_type := PROTO_TO_MESSAGE_TYPE[type(msg)])
         ]
-        if debug_enabled := self._debug_enabled:
+        if self._debug_enabled:
             for msg in msgs:
                 _LOGGER.debug(
                     "%s: Sending %s: %s",
@@ -733,7 +733,7 @@ class APIConnection:
             assert self._frame_helper is not None
 
         try:
-            self._frame_helper.write_packets(packets, debug_enabled)
+            self._frame_helper.write_packets(packets, self._debug_enabled)
         except WRITE_EXCEPTIONS as err:
             # If writing packet fails, we don't know what state the frames
             # are in anymore and we have to close the connection

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -890,8 +890,6 @@ class APIConnection:
         # since its called for every incoming packet. Take
         # extra care when modifying this method.
         handlers = self._message_handlers.get(msg_type_proto)
-        if handlers is None and not self._debug_enabled:
-            return
 
         if self._pong_timer is not None:
             # Any valid message from the remote cancels the pong timer
@@ -902,6 +900,9 @@ class APIConnection:
             # Any valid message from the remove cancels the pending ping
             # since we know the connection is still alive
             self._send_pending_ping = False
+
+        if handlers is None and not self._debug_enabled:
+            return
 
         try:
             # MESSAGE_NUMBER_TO_PROTO is 0-indexed

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -974,6 +974,7 @@ async def test_unknown_protobuf_message_type_logged(
 ) -> None:
     """Test unknown protobuf messages are logged but do not cause the connection to collapse."""
     client, connection, transport, protocol = api_client
+    connection._message_handlers[16385] = lambda msg: None
     response: message.Message = DeviceInfoResponse(
         name="realname",
         friendly_name="My Device",
@@ -1005,6 +1006,7 @@ async def test_bad_protobuf_message_drops_connection(
 ) -> None:
     """Test ad bad protobuf messages is logged and causes the connection to collapse."""
     client, connection, transport, protocol = api_client
+    connection.add_message_callback(lambda msg: None, (TextSensorStateResponse,))
     msg: message.Message = TextSensorStateResponse(
         key=1, state="invalid", missing_state=False
     )


### PR DESCRIPTION
If we are going to throw away the message, don't bother decoding it
