### PR TITLE
Fix race condition with internal message handlers registration

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -644,8 +644,11 @@ class APIConnection:
 
     async def _do_finish_connect(self, login: bool) -> None:
         """Finish the connection process."""
-        await self._connect_init_frame_helper()
+        # Register internal handlers before
+        # connecting the helper so we can ensure
+        # we handle any messages that are received immediately
         self._register_internal_message_handlers()
+        await self._connect_init_frame_helper()
         await self._connect_hello_login(login)
         self._async_schedule_keep_alive(self._loop.time())
 


### PR DESCRIPTION

# What does this implement/fix?

This PR fixes a race condition where internal message handlers were registered too late, causing early internal messages to be dropped during connection setup.

When establishing a connection, the internal message handlers (for DisconnectRequest, PingRequest, and GetTimeRequest) were being registered after the frame helper was initialized. Since the frame helper starts receiving traffic immediately upon initialization, any internal messages received before handler registration would be lost.

Moved the `_register_internal_message_handlers()` call to occur before `_connect_init_frame_helper()` in the `_do_finish_connect` method. This ensures handlers are ready before any network traffic can be received.

Added `test_internal_message_received_immediately_after_connection` which:
- Simulates receiving a PingRequest immediately after frame helper initialization
- Verifies the ping handler is called successfully
- Confirms the fix prevents dropped internal messages during early connection

This ensures the ESPHome device can send internal messages immediately upon connection without risk of them being lost.


## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
