### PR TITLE
Show and archive generated proto-files if diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,6 @@ jobs:
       - run: mypy aioesphomeapi
         name: Check typing with mypy
         if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' && matrix.os == 'ubuntu-latest' }}
-      - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --timeout=4 --tb=native tests
-        name: Run tests with pytest
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - run: |
           docker run \
             -v "$PWD":/aioesphomeapi \
@@ -130,6 +124,21 @@ jobs:
           fi
         name: Check protobuf files match
         if: ${{ matrix.python-version == '3.12' && matrix.extension == 'skip_cython' && matrix.os == 'ubuntu-latest' }}
+      - name: Show changes
+        run: git diff
+        if: ${{ failure() && matrix.python-version == '3.12' && matrix.extension == 'skip_cython' && matrix.os == 'ubuntu-latest' }}
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: genrated-proto-files
+          path: aioesphomeapi/*pb2.py
+        if: ${{ failure() && matrix.python-version == '3.12' && matrix.extension == 'skip_cython' && matrix.os == 'ubuntu-latest' }}
+      - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --timeout=4 --tb=native tests
+        name: Run tests with pytest
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   benchmarks:
     name: Run benchmarks


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
If there is a diff in generated Proto-files, show the diff and archive the generated files for download to work-area.
Mitigating having to set-up a type-like proto environment locally.
Example for failed run https://github.com/esphome/aioesphomeapi/actions/runs/15255852122/job/42903200847

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
