### PR TITLE
Add support for rendering multi-line log messages

### DIFF
--- a/aioesphomeapi/__init__.py
+++ b/aioesphomeapi/__init__.py
@@ -25,3 +25,4 @@ from .core import (
 )
 from .model import *
 from .reconnect_logic import ReconnectLogic
+from .log_parser import parse_log_message

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -72,14 +72,12 @@ def parse_log_message(
             # Remove color code from line for prefix extraction
             first_line_no_color = first_line[len(color_code) :]
 
-        # Find the last ']:' which marks the end of the ESPHome prefix
-        # Look for pattern like [C][template.sensor:022]:
-        last_bracket_colon = first_line_no_color.rfind(
-            "]:", 0, len(first_line_no_color) // 2
-        )
-        if last_bracket_colon != -1:
-            # Include the ']:' part
-            prefix = first_line_no_color[: last_bracket_colon + 2]
+        # Find the ESPHome prefix - the first ']:' is always the split point
+        # ESPHome log format: [LEVEL][component:line]: message
+        # The first ']:' will always be at the end of the component:line part
+        bracket_colon = first_line_no_color.find("]:")
+        if bracket_colon != -1:
+            prefix = first_line_no_color[: bracket_colon + 2]
 
     # Process subsequent lines
     for line in lines[1:]:

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -9,6 +9,10 @@ ANSI_ESCAPE = re.compile(
     r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])"
 )
 
+# ANSI reset sequences
+ANSI_RESET_CODES = ("\033[0m", "\x1b[0m")
+ANSI_RESET = "\033[0m"
+
 
 def parse_log_message(text: str, timestamp: str) -> list[str]:
     """Parse a log message and format it with timestamps and color preservation.
@@ -32,7 +36,7 @@ def parse_log_message(text: str, timestamp: str) -> list[str]:
         lines.pop()
 
     # Also remove if last line is just ANSI reset codes
-    if lines and lines[-1] in ("\033[0m", "\x1b[0m"):
+    if lines and lines[-1] in ANSI_RESET_CODES:
         lines.pop()
     result: list[str] = []
 
@@ -76,18 +80,18 @@ def parse_log_message(text: str, timestamp: str) -> list[str]:
             if color_code:
                 # Add reset at end to ensure color doesn't bleed
                 # But only if the line doesn't already end with a reset
-                if line.endswith(("\033[0m", "\x1b[0m")):
+                if line.endswith(ANSI_RESET_CODES):
                     result.append(f"{timestamp}{color_code}{prefix} {line}")
                 else:
-                    result.append(f"{timestamp}{color_code}{prefix} {line}\033[0m")
+                    result.append(f"{timestamp}{color_code}{prefix} {line}{ANSI_RESET}")
             else:
                 result.append(f"{timestamp}{prefix} {line}")
         # No prefix found, just add timestamp and line
         elif color_code:
-            if line.endswith(("\033[0m", "\x1b[0m")):
+            if line.endswith(ANSI_RESET_CODES):
                 result.append(f"{timestamp}{color_code}{line}")
             else:
-                result.append(f"{timestamp}{color_code}{line}\033[0m")
+                result.append(f"{timestamp}{color_code}{line}{ANSI_RESET}")
         else:
             result.append(f"{timestamp}{line}")
 

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -51,20 +51,27 @@ def parse_log_message(
     prefix = ""
     color_code = ""
 
-    # Extract ANSI color code at the beginning if present (only if not stripping)
-    first_line_no_color = first_line
-    if not strip_ansi_escapes and (color_match := ANSI_ESCAPE.match(first_line)):
-        color_code = color_match.group(0)
-        # Remove color code from line for prefix extraction
-        first_line_no_color = first_line[len(color_code) :]
+    # Check if first line starts with space - if so, no prefix to extract
+    if first_line and first_line[0].isspace():
+        # First line is already a continuation line, no prefix exists
+        pass
+    else:
+        # Extract ANSI color code at the beginning if present (only if not stripping)
+        first_line_no_color = first_line
+        if not strip_ansi_escapes and (color_match := ANSI_ESCAPE.match(first_line)):
+            color_code = color_match.group(0)
+            # Remove color code from line for prefix extraction
+            first_line_no_color = first_line[len(color_code) :]
 
-    # Find the last ']:' which marks the end of the ESPHome prefix
-    # Look for pattern like [C][template.sensor:022]:
-    last_bracket_colon = first_line_no_color.rfind(
-        "]:", 0, len(first_line_no_color) // 2
-    )
-    if last_bracket_colon != -1:
-        prefix = first_line_no_color[: last_bracket_colon + 2]  # Include the ']:' part
+        # Find the last ']:' which marks the end of the ESPHome prefix
+        # Look for pattern like [C][template.sensor:022]:
+        last_bracket_colon = first_line_no_color.rfind(
+            "]:", 0, len(first_line_no_color) // 2
+        )
+        if last_bracket_colon != -1:
+            prefix = first_line_no_color[
+                : last_bracket_colon + 2
+            ]  # Include the ']:' part
 
     # Process subsequent lines
     for line in lines[1:]:

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -1,0 +1,94 @@
+"""Log parser for ESPHome log messages with ANSI color support."""
+
+from __future__ import annotations
+
+import re
+
+# Pre-compiled regex for ANSI escape sequences
+ANSI_ESCAPE = re.compile(
+    r"(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x1B\[|\x9B)[0-?]*[ -/]*[@-~])"
+)
+
+
+def parse_log_message(text: str, timestamp: str) -> list[str]:
+    """Parse a log message and format it with timestamps and color preservation.
+
+    Args:
+        text: The log message text, potentially with ANSI codes and newlines
+        timestamp: The timestamp string to prepend (e.g., "[08:00:00.000]")
+
+    Returns:
+        List of formatted lines ready to be printed
+    """
+    # Fast path for single line (most common case)
+    if "\n" not in text:
+        return [f"{timestamp}{text}"]
+
+    # Multi-line handling
+    lines = text.split("\n")
+
+    # Remove trailing empty line if present (common when messages end with \n)
+    if lines and lines[-1] == "":
+        lines.pop()
+
+    # Also remove if last line is just ANSI reset codes
+    if lines and lines[-1] in ("\033[0m", "\x1b[0m"):
+        lines.pop()
+    result: list[str] = []
+
+    # Process the first line
+    result.append(f"{timestamp}{lines[0]}")
+
+    # Extract prefix and color from the first line
+    first_line = lines[0]
+    prefix = ""
+    color_code = ""
+
+    # Extract ANSI color code at the beginning if present
+    color_match = ANSI_ESCAPE.match(first_line)
+    if color_match:
+        color_code = color_match.group(0)
+        # Remove color code from line for prefix extraction
+        first_line_no_color = first_line[len(color_code) :]
+    else:
+        first_line_no_color = first_line
+
+    # Find the last ']:' which marks the end of the ESPHome prefix
+    # Look for pattern like [C][template.sensor:022]:
+    last_bracket_colon = first_line_no_color.rfind(
+        "]:", 0, len(first_line_no_color) // 2
+    )
+    if last_bracket_colon != -1:
+        prefix = first_line_no_color[: last_bracket_colon + 2]  # Include the ']:' part
+
+    # Process subsequent lines
+    for line in lines[1:]:
+        if not line.strip():  # Only process non-empty lines
+            # Empty line
+            result.append("")
+            continue
+        if not line[0].isspace():  # If line starts with whitespace, it's a continuation
+            # This is a new log entry within the same message
+            result.append(f"{timestamp}{line}")
+            continue
+        # Apply timestamp, color, prefix, and the continuation line
+        if prefix:
+            if color_code:
+                # Add reset at end to ensure color doesn't bleed
+                # But only if the line doesn't already end with a reset
+                if line.endswith(("\033[0m", "\x1b[0m")):
+                    result.append(f"{timestamp}{color_code}{prefix} {line}")
+                else:
+                    result.append(f"{timestamp}{color_code}{prefix} {line}\033[0m")
+            else:
+                result.append(f"{timestamp}{prefix} {line}")
+        # No prefix found, just add timestamp and line
+        elif color_code:
+            if line.endswith(("\033[0m", "\x1b[0m")):
+                result.append(f"{timestamp}{color_code}{line}")
+            else:
+                result.append(f"{timestamp}{color_code}{line}\033[0m")
+        else:
+            result.append(f"{timestamp}{line}")
+
+    return result

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -10,6 +10,7 @@ import sys
 
 from .api_pb2 import SubscribeLogsResponse  # type: ignore
 from .client import APIClient
+from .log_parser import parse_log_message
 from .log_runner import async_run
 
 
@@ -41,9 +42,14 @@ async def main(argv: list[str]) -> None:
         message: bytes = msg.message
         text = message.decode("utf8", "backslashreplace")
         nanoseconds = time_.microsecond // 1000
-        print(
-            f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}.{nanoseconds:03}]{text}"
+        timestamp = (
+            f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}.{nanoseconds:03}]"
         )
+
+        # Parse and print the log message
+        lines = parse_log_message(text, timestamp)
+        for line in lines:
+            print(line)
 
     stop = await async_run(cli, on_log)
     try:

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -47,8 +47,7 @@ async def main(argv: list[str]) -> None:
         )
 
         # Parse and print the log message
-        lines = parse_log_message(text, timestamp)
-        for line in lines:
+        for line in parse_log_message(text, timestamp):
             print(line)
 
     stop = await async_run(cli, on_log)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
-VERSION = "32.0.0"
+VERSION = "32.1.0"
 PROJECT_NAME = "aioesphomeapi"
 PROJECT_PACKAGE_NAME = "aioesphomeapi"
 PROJECT_LICENSE = "MIT"

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -323,6 +323,17 @@ def test_first_line_starts_with_space_with_color() -> None:
     assert result[1] == "[08:00:00.000]\033[0;32m  Another continuation\033[0m"
 
 
+def test_newline_only_message() -> None:
+    """Test edge case where message is just a newline."""
+    text = "\n"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    # Should handle gracefully - just timestamp with empty content
+    assert len(result) == 1
+    assert result[0] == "[08:00:00.000]"
+
+
 def test_color_bleeding_prevention() -> None:
     """Test that color codes don't bleed to next message when first line lacks reset."""
     # This simulates the issue from bleed_again.txt where first line of multi-line

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -290,3 +290,26 @@ def test_strip_ansi_escapes() -> None:
         result[0]
         == "[08:00:00.000][D][esp-idf:000][BTU_TASK]: W (2335697) BT_APPL: gattc_conn_cb"
     )
+
+
+def test_first_line_starts_with_space() -> None:
+    """Test edge case where first line starts with space."""
+    text = "  First line starts with space\n  Second line also starts with space\nNot a continuation"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 3
+    assert result[0] == "[08:00:00.000]  First line starts with space"
+    assert result[1] == "[08:00:00.000]  Second line also starts with space"
+    assert result[2] == "[08:00:00.000]Not a continuation"
+
+
+def test_first_line_starts_with_space_with_color() -> None:
+    """Test edge case where first line starts with space and has ANSI color."""
+    text = "\033[0;32m  Colored line starting with space\n  Another continuation\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000]\033[0;32m  Colored line starting with space"
+    assert result[1] == "[08:00:00.000]\033[0;32m  Another continuation\033[0m"

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,262 @@
+"""Tests for the log parser module."""
+
+from __future__ import annotations
+
+from aioesphomeapi.log_parser import parse_log_message
+
+
+def test_single_line_no_color() -> None:
+    """Test parsing a single line log without color codes."""
+    text = (
+        "[I][app:191]: ESPHome version 2025.6.0-dev compiled on Jun  8 2025, 07:48:30"
+    )
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert (
+        result[0]
+        == "[08:00:00.000][I][app:191]: ESPHome version 2025.6.0-dev compiled on Jun  8 2025, 07:48:30"
+    )
+
+
+def test_single_line_with_color() -> None:
+    """Test parsing a single line log with ANSI color codes."""
+    text = "\033[0;32m[I][app:191]: ESPHome version 2025.6.0-dev compiled on Jun  8 2025, 07:48:30\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert (
+        result[0]
+        == "[08:00:00.000]\033[0;32m[I][app:191]: ESPHome version 2025.6.0-dev compiled on Jun  8 2025, 07:48:30\033[0m"
+    )
+
+
+def test_multi_line_no_color() -> None:
+    """Test parsing a multi-line log without color codes."""
+    text = "[C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'\n  State Class: ''\n  Unit of Measurement: ''\n  Accuracy Decimals: 1"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 4
+    assert (
+        result[0]
+        == "[08:00:00.000][C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'"
+    )
+    assert result[1] == "[08:00:00.000][C][template.sensor:022]:   State Class: ''"
+    assert (
+        result[2] == "[08:00:00.000][C][template.sensor:022]:   Unit of Measurement: ''"
+    )
+    assert result[3] == "[08:00:00.000][C][template.sensor:022]:   Accuracy Decimals: 1"
+
+
+def test_multi_line_with_color() -> None:
+    """Test parsing a multi-line log with ANSI color codes."""
+    text = "\033[0;35m[C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'\n  State Class: ''\n  Unit of Measurement: ''\n  Accuracy Decimals: 1\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 4
+    assert (
+        result[0]
+        == "[08:00:00.000]\033[0;35m[C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'"
+    )
+    assert (
+        result[1]
+        == "[08:00:00.000]\033[0;35m[C][template.sensor:022]:   State Class: ''\033[0m"
+    )
+    assert (
+        result[2]
+        == "[08:00:00.000]\033[0;35m[C][template.sensor:022]:   Unit of Measurement: ''\033[0m"
+    )
+    assert (
+        result[3]
+        == "[08:00:00.000]\033[0;35m[C][template.sensor:022]:   Accuracy Decimals: 1\033[0m"
+    )
+
+
+def test_multi_line_with_empty_lines() -> None:
+    """Test parsing a multi-line log with empty lines."""
+    text = "[C][logger:224]: Logger:\n\n  Max Level: DEBUG\n  Initial Level: DEBUG"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 4
+    assert result[0] == "[08:00:00.000][C][logger:224]: Logger:"
+    assert result[1] == ""  # Empty line
+    # The prefix extraction finds "Logger:" not "[C][logger:224]:" so no prefix is added
+    assert result[2] == "[08:00:00.000]  Max Level: DEBUG"
+    assert result[3] == "[08:00:00.000]  Initial Level: DEBUG"
+
+
+def test_multi_line_mixed_entries() -> None:
+    """Test parsing multiple log entries in one message."""
+    text = "[C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'\n  State Class: ''\n[C][template.sensor:023]:   Update Interval: 60.0s"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert (
+        result[0]
+        == "[08:00:00.000][C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'"
+    )
+    assert result[1] == "[08:00:00.000][C][template.sensor:022]:   State Class: ''"
+    assert (
+        result[2] == "[08:00:00.000][C][template.sensor:023]:   Update Interval: 60.0s"
+    )
+
+
+def test_prefix_extraction_edge_cases() -> None:
+    """Test edge cases for prefix extraction."""
+    # No prefix found
+    text = "Simple log message\n  Continuation"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000]Simple log message"
+    assert result[1] == "[08:00:00.000]  Continuation"
+
+
+def test_various_ansi_codes() -> None:
+    """Test parsing with various ANSI escape sequences."""
+    # Bold green
+    text = "\033[1;32m[I][test:001]: Bold green message\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 1
+    assert (
+        result[0] == "[08:00:00.000]\033[1;32m[I][test:001]: Bold green message\033[0m"
+    )
+
+    # Complex escape sequence
+    text = "\033[38;5;214m[W][test:002]: 256-color warning\n  Details\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000]\033[38;5;214m[W][test:002]: 256-color warning"
+    assert result[1] == "[08:00:00.000]\033[38;5;214m[W][test:002]:   Details\033[0m"
+
+
+def test_empty_message() -> None:
+    """Test parsing an empty message."""
+    text = ""
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 1
+    assert result[0] == "[08:00:00.000]"
+
+
+def test_only_newlines() -> None:
+    """Test parsing a message with only newlines."""
+    text = "\n\n\n"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    # Three newlines create 4 parts when split, but last empty one is removed
+    assert len(result) == 3
+    assert result[0] == "[08:00:00.000]"
+    assert all(line == "" for line in result[1:])
+
+
+def test_continuation_without_prefix() -> None:
+    """Test continuation lines when no prefix is found."""
+    text = "Main line\n  Sub line 1\n  Sub line 2"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 3
+    assert result[0] == "[08:00:00.000]Main line"
+    assert result[1] == "[08:00:00.000]  Sub line 1"
+    assert result[2] == "[08:00:00.000]  Sub line 2"
+
+
+def test_real_world_example() -> None:
+    """Test with a real-world log example."""
+    text = "\033[0;35m[C][uptime.sensor:033]: Uptime Sensor 'Ethernet Uptime'\n  State Class: 'total_increasing'\n  Unit of Measurement: 's'\n  Accuracy Decimals: 0\033[0m"
+    timestamp = "[07:56:42.728]"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 4
+    assert (
+        result[0]
+        == "[07:56:42.728]\033[0;35m[C][uptime.sensor:033]: Uptime Sensor 'Ethernet Uptime'"
+    )
+    assert (
+        result[1]
+        == "[07:56:42.728]\033[0;35m[C][uptime.sensor:033]:   State Class: 'total_increasing'\033[0m"
+    )
+    assert (
+        result[2]
+        == "[07:56:42.728]\033[0;35m[C][uptime.sensor:033]:   Unit of Measurement: 's'\033[0m"
+    )
+    assert (
+        result[3]
+        == "[07:56:42.728]\033[0;35m[C][uptime.sensor:033]:   Accuracy Decimals: 0\033[0m"
+    )
+
+
+def test_timestamp_formats() -> None:
+    """Test with different timestamp formats."""
+    text = "[I][test:001]: Test message"
+
+    # Standard format
+    result = parse_log_message(text, "[08:00:00.000]")
+    assert result[0] == "[08:00:00.000][I][test:001]: Test message"
+
+    # Custom format
+    result = parse_log_message(text, "[2024-01-01 08:00:00]")
+    assert result[0] == "[2024-01-01 08:00:00][I][test:001]: Test message"
+
+    # Empty timestamp
+    result = parse_log_message(text, "")
+    assert result[0] == "[I][test:001]: Test message"
+
+
+def test_trailing_newline() -> None:
+    """Test handling of messages that end with a newline."""
+    # Single line with trailing newline
+    text = "[I][app:191]: ESPHome version 2025.6.0\n"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    # Should not include an empty line at the end
+    assert len(result) == 1
+    assert result[0] == "[08:00:00.000][I][app:191]: ESPHome version 2025.6.0"
+
+    # Multi-line with trailing newline (no ESPHome prefix found since "Config" doesn't end with ]:")
+    text = "[C][sensor:022]: Sensor Config\n  State: ON\n"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000][C][sensor:022]: Sensor Config"
+    assert result[1] == "[08:00:00.000]  State: ON"
+
+    # With proper ESPHome prefix format
+    text = "[C][sensor:022]: Temperature Sensor 'Living Room'\n  State Class: 'measurement'\n"
+    result = parse_log_message(text, timestamp)
+
+    assert len(result) == 2
+    assert (
+        result[0] == "[08:00:00.000][C][sensor:022]: Temperature Sensor 'Living Room'"
+    )
+    assert result[1] == "[08:00:00.000][C][sensor:022]:   State Class: 'measurement'"
+
+    # With color codes ending with reset on its own line
+    text = "\033[0;35m[C][sensor:022]: Temperature Sensor\n  State: ON\n\033[0m"
+    result = parse_log_message(text, timestamp)
+
+    # Should not include the line with just the reset code
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000]\033[0;35m[C][sensor:022]: Temperature Sensor"
+    assert result[1] == "[08:00:00.000]\033[0;35m[C][sensor:022]:   State: ON\033[0m"


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for properly formatting multi-line log messages from ESPHome devices. ESPHome will be able to minimize network overhead by sending multi-line log entries as single protobuf messages with embedded newlines, rather than splitting them into multiple messages. This is efficient for the network and the ESP device (which has limited resources), but requires the client to properly format these messages for human consumption.

The new log parser:
- Preserves timestamps, log level prefixes, and component names across continuation lines
- Maintains ANSI color codes throughout multi-line messages
- Prevents color bleeding by adding proper reset codes
- Optimizes for the common single-line case (11M ops/sec)

Example - Before:
```
[08:00:00.000][C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'
  State Class: ''
  Unit of Measurement: ''
```

After:
```
[08:00:00.000][C][template.sensor:022]: Template Sensor 'Lambda Sensor 153'
[08:00:00.000][C][template.sensor:022]:   State Class: ''
[08:00:00.000][C][template.sensor:022]:   Unit of Measurement: ''
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A - This change only affects client-side log formatting

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. *(N/A - no api.proto changes)*
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).