### PR TITLE
Ensure third party callbacks on BLE notify do not cause disconnect

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -112,7 +112,14 @@ def on_bluetooth_gatt_notify_data_response(
 ) -> None:
     """Handle a BluetoothGATTNotifyDataResponse message."""
     if address == msg.address and handle == msg.handle:
-        on_bluetooth_gatt_notify(handle, bytearray(msg.data))
+        try:
+            on_bluetooth_gatt_notify(handle, bytearray(msg.data))
+        except Exception:
+            _LOGGER.exception(
+                "Unexpected error in Bluetooth GATT notify callback for address %s, handle %s",
+                address,
+                handle,
+            )
 
 
 def on_bluetooth_scanner_state_response(


### PR DESCRIPTION


# What does this implement/fix?

We need a broad exception catch around the callback since it calls back into third party code which may raise up to the protocol handler and disconnect the device.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
