### PR TITLE
Fix handling multi-line log messages with ANSI resets

### DIFF
--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -127,11 +127,6 @@ class LogParser:
             self._current_prefix, self._current_color_code, _ = (
                 _extract_prefix_and_color(line, self.strip_ansi_escapes)
             )
-
-        # Check if line has color codes but no reset at end
-        if not self.strip_ansi_escapes and _needs_reset(line):
-            return f"{timestamp}{line}{ANSI_RESET}"
-
         return f"{timestamp}{line}"
 
 

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -60,7 +60,7 @@ def _format_continuation_line(
         return f"{timestamp}{color_code}{line_content}{reset}"
 
     # Always add reset to continuation lines if they don't have one (prevents color bleeding)
-    if not strip_ansi and not line.endswith(ANSI_RESET_CODES):
+    if not strip_ansi and color_code and not line.endswith(ANSI_RESET_CODES):
         return f"{timestamp}{line_content}{ANSI_RESET}"
 
     return f"{timestamp}{line_content}"
@@ -129,7 +129,11 @@ class LogParser:
             )
 
         # Check if line has color codes but no reset
-        if not self.strip_ansi_escapes and not line.endswith(ANSI_RESET_CODES):
+        if (
+            not self.strip_ansi_escapes
+            and self._current_color_code
+            and not line.endswith(ANSI_RESET_CODES)
+        ):
             return f"{timestamp}{line}{ANSI_RESET}"
 
         return f"{timestamp}{line}"

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -127,6 +127,11 @@ class LogParser:
             self._current_prefix, self._current_color_code, _ = (
                 _extract_prefix_and_color(line, self.strip_ansi_escapes)
             )
+
+        # Check if line has color codes but no reset at end
+        if not self.strip_ansi_escapes and _needs_reset(line):
+            return f"{timestamp}{line}{ANSI_RESET}"
+
         return f"{timestamp}{line}"
 
 

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -36,15 +36,6 @@ def _extract_prefix_and_color(line: str, strip_ansi: bool) -> tuple[str, str, st
     return prefix, color_code, line_no_color
 
 
-def _needs_reset(line: str) -> bool:
-    """Check if line needs ANSI reset code appended."""
-    return bool(
-        line
-        and not line.endswith(ANSI_RESET_CODES)
-        and ("\033[" in line or "\x1b[" in line)
-    )
-
-
 def _format_continuation_line(
     timestamp: str,
     prefix: str,

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -128,12 +128,8 @@ class LogParser:
                 _extract_prefix_and_color(line, self.strip_ansi_escapes)
             )
 
-        # Check if line has color codes but no reset
-        if (
-            not self.strip_ansi_escapes
-            and self._current_color_code
-            and not line.endswith(ANSI_RESET_CODES)
-        ):
+        # Check if line has color codes but no reset at end
+        if not self.strip_ansi_escapes and _needs_reset(line):
             return f"{timestamp}{line}{ANSI_RESET}"
 
         return f"{timestamp}{line}"

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -36,6 +36,15 @@ def _extract_prefix_and_color(line: str, strip_ansi: bool) -> tuple[str, str, st
     return prefix, color_code, line_no_color
 
 
+def _needs_reset(line: str) -> bool:
+    """Check if line needs ANSI reset code appended."""
+    return bool(
+        line
+        and not line.endswith(ANSI_RESET_CODES)
+        and ("\033[" in line or "\x1b[" in line)
+    )
+
+
 def _format_continuation_line(
     timestamp: str,
     prefix: str,

--- a/aioesphomeapi/log_parser.py
+++ b/aioesphomeapi/log_parser.py
@@ -171,7 +171,7 @@ def parse_log_message(
     result: list[str] = []
 
     # Check if first line has color but no reset at end (to prevent bleeding)
-    if not strip_ansi_escapes and not lines[0].endswith(ANSI_RESET_CODES):
+    if not strip_ansi_escapes and _needs_reset(lines[0]):
         result.append(f"{timestamp}{lines[0]}{ANSI_RESET}")
     else:
         result.append(f"{timestamp}{lines[0]}")

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -80,6 +80,20 @@ def test_multi_line_with_color() -> None:
     )
 
 
+def test_two_line_with_color() -> None:
+    """Test parsing a two-line log with ANSI color codes."""
+    text = "\033[0;35m[C][mdns:120]: mDNS:\n  Hostname: bktest\033[0m"
+    timestamp = "[08:00:00.000]"
+    result = parse_log_message(text, timestamp)
+
+    assert isinstance(result, (list, tuple))
+    assert len(result) == 2
+    assert result[0] == "[08:00:00.000]\033[0;35m[C][mdns:120]: mDNS:\033[0m"
+    assert (
+        result[1] == "[08:00:00.000]\033[0;35m[C][mdns:120]:   Hostname: bktest\033[0m"
+    )
+
+
 def test_multi_line_with_empty_lines() -> None:
     """Test parsing a multi-line log with empty lines."""
     text = "[C][logger:224]: Logger:\n\n  Max Level: DEBUG\n  Initial Level: DEBUG"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This PR fixes an issue where ANSI color codes in multi-line log messages could "bleed" into subsequent log messages, causing them to be displayed with unintended colors.

When ESPHome sends multi-line log messages with ANSI color codes, the color escape sequence might appear at the beginning or middle of the first line, but the reset sequence (`\033[0m`) only appears at the end of the entire message. This caused intermediate continuation lines to be missing ANSI reset codes, leading to color bleeding into the next log message.

Example of the issue:
```
[W][component:123] Warning \033[0;33mmessage line 1
  continuation line 2
  continuation line 3\033[0m
```

In this case, "continuation line 2" would not have a reset code, causing any subsequent log messages to inherit the yellow color.

The fix ensures that every line in a multi-line log message ends with an ANSI reset code when needed to prevent color bleeding.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).