### PR TITLE
Fix DeviceInfo round-trip serialization after areas/devices fields additions

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -153,8 +153,7 @@ class AreaInfo(APIModelBase):
     def convert(cls, value: Any) -> AreaInfo:
         if isinstance(value, dict):
             return cls.from_dict(value)
-        else:
-            return cls.from_pb(value)
+        return cls.from_pb(value)
 
 
 @_frozen_dataclass_decorator

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -149,6 +149,13 @@ class AreaInfo(APIModelBase):
                 ret.append(AreaInfo.from_pb(x))
         return ret
 
+    @classmethod
+    def convert(cls, value: Any) -> AreaInfo:
+        if isinstance(value, dict):
+            return cls.from_dict(value)
+        else:
+            return cls.from_pb(value)
+
 
 @_frozen_dataclass_decorator
 class SubDeviceInfo(APIModelBase):
@@ -194,7 +201,7 @@ class DeviceInfo(APIModelBase):
         default_factory=list, converter=AreaInfo.convert_list
     )
     area: AreaInfo = converter_field(
-        default_factory=AreaInfo, converter=AreaInfo.from_pb
+        default_factory=AreaInfo, converter=AreaInfo.convert
     )
 
     def bluetooth_proxy_feature_flags_compat(self, api_version: APIVersion) -> int:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1008,3 +1008,73 @@ def test_device_info_with_areas_and_sub_devices() -> None:
     assert device_from_mixed.devices[0].name == "Door Sensor"
     assert device_from_mixed.devices[1].device_id == 55555555
     assert device_from_mixed.devices[1].name == "Leak Detector"
+
+
+def test_device_info_mock_with_friendly_name() -> None:
+    """Test that mocking DeviceInfo with friendly_name works after areas/devices were added."""
+    # Create a device info object
+    device = DeviceInfo(name="Test Device", friendly_name="Original Friendly Name")
+
+    # Try to mock it by modifying the friendly_name field like the user's example
+    # This simulates what a user would do when mocking
+    mocked_device = DeviceInfo(
+        **{**device.to_dict(), "friendly_name": "I have a friendly name"}
+    )
+
+    # This should work and the friendly_name should be updated
+    assert mocked_device.friendly_name == "I have a friendly name"
+    assert mocked_device.name == "Test Device"  # Other fields should be preserved
+
+
+def test_device_info_mock_with_areas_and_devices() -> None:
+    """Test that mocking DeviceInfo with areas and devices works correctly."""
+    # Create a device info object with areas and devices
+    device = DeviceInfo(
+        name="Test Device",
+        friendly_name="Original Friendly Name",
+        areas=[
+            AreaInfo(area_id=1, name="Living Room"),
+            AreaInfo(area_id=2, name="Bedroom"),
+        ],
+        devices=[
+            SubDeviceInfo(device_id=100, name="Sub Device 1", area_id=1),
+            SubDeviceInfo(device_id=200, name="Sub Device 2", area_id=2),
+        ],
+        area=AreaInfo(area_id=0, name="Main Area"),
+    )
+
+    # Convert to dict and back to simulate mocking
+    device_dict = device.to_dict()
+
+    # Modify some fields
+    device_dict["friendly_name"] = "Modified Friendly Name"
+    device_dict["area"]["name"] = "Modified Main Area"
+    device_dict["areas"][0]["name"] = "Modified Living Room"
+    device_dict["devices"][1]["name"] = "Modified Sub Device 2"
+
+    # Create a new DeviceInfo from the modified dict
+    mocked_device = DeviceInfo(**device_dict)
+
+    # Verify all fields are correctly handled
+    assert mocked_device.name == "Test Device"
+    assert mocked_device.friendly_name == "Modified Friendly Name"
+
+    # Check area field
+    assert mocked_device.area.area_id == 0
+    assert mocked_device.area.name == "Modified Main Area"
+
+    # Check areas list
+    assert len(mocked_device.areas) == 2
+    assert mocked_device.areas[0].area_id == 1
+    assert mocked_device.areas[0].name == "Modified Living Room"
+    assert mocked_device.areas[1].area_id == 2
+    assert mocked_device.areas[1].name == "Bedroom"
+
+    # Check devices list
+    assert len(mocked_device.devices) == 2
+    assert mocked_device.devices[0].device_id == 100
+    assert mocked_device.devices[0].name == "Sub Device 1"
+    assert mocked_device.devices[0].area_id == 1
+    assert mocked_device.devices[1].device_id == 200
+    assert mocked_device.devices[1].name == "Modified Sub Device 2"
+    assert mocked_device.devices[1].area_id == 2


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue with `DeviceInfo` round-trip serialization that was introduced when the `areas`, `devices`, and `area` fields were added in #1146. 

When using `DeviceInfo.to_dict()` followed by creating a new `DeviceInfo` instance from that dictionary (a common pattern for mocking in tests), the code would fail with an `AttributeError` because the `area` field converter expected a protobuf object but received a dictionary.

The fix adds a `convert` method to `AreaInfo` that properly handles both dictionary and protobuf inputs, similar to how the `convert_list` methods already work for the list fields.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes round-trip serialization issue introduced in #1146

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A - This only affects the Python model classes, not the protobuf definitions

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).