### PR TITLE
Do not create zeroconf listeners when name is an IP address

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -22,7 +22,7 @@ from .core import (
     RequiresEncryptionAPIError,
     UnhandledAPIConnectionError,
 )
-from .util import address_is_local, create_eager_task, host_is_name_part
+from .util import address_is_local, create_eager_task, host_is_name_part, is_ip_address
 from .zeroconf import ZeroconfInstanceType
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,6 +84,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self.loop = asyncio.get_running_loop()
         self._cli = client
         self.name: str | None = None
+        self._is_ip_address = is_ip_address(name)
         if name:
             self.name = name
         elif host_is_name_part(client.address) or address_is_local(client.address):
@@ -382,7 +383,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         This listener allows us to schedule a connect as soon as a
         received mDNS record indicates the node is up again.
         """
-        if not self._zc_listening and self.name:
+        if not self._zc_listening and self.name and not self._is_ip_address:
             _LOGGER.debug("Starting zeroconf listener for %s", self.name)
             self._ptr_alias = f"{self.name}._esphomelib._tcp.local."
             self._a_name = f"{self.name}.local."

--- a/aioesphomeapi/util.py
+++ b/aioesphomeapi/util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from asyncio import AbstractEventLoop, Task, get_running_loop
 from collections.abc import Coroutine
+import ipaddress
 import math
 import sys
 from typing import Any, TypeVar
@@ -46,6 +47,24 @@ def host_is_name_part(address: str) -> bool:
 def address_is_local(address: str) -> bool:
     """Return True if the address is a local address."""
     return address.removesuffix(".").endswith(".local")
+
+
+def is_ip_address(address: str | None) -> bool:
+    """Return True if the address is an IP address.
+
+    Handles addresses with or without port (e.g., "192.168.1.1" or "192.168.1.1:6053").
+    Returns False if address is None.
+    """
+    if address is None:
+        return False
+    # Remove port if present
+    host = address.partition(":")[0]
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    else:
+        return True
 
 
 def build_log_name(
@@ -104,4 +123,5 @@ __all__ = (
     "create_eager_task",
     "fix_float_single_double_conversion",
     "host_is_name_part",
+    "is_ip_address",
 )


### PR DESCRIPTION
# What does this implement/fix?

Prevents unnecessary creation of zeroconf instances when connecting to devices using IP addresses.

When ReconnectLogic is initialized with a `name` parameter that is actually an IP address (e.g., "192.168.1.100" or "127.0.0.1:6053"), the code was starting a zeroconf listener and creating an AsyncZeroconf instance. This is unnecessary because:

1. IP addresses don't need mDNS resolution
2. IP addresses don't change, so there's no need to monitor mDNS records
3. Creating zeroconf instances has overhead and resource usage

This fix adds detection for when the `name` parameter is an IP address and skips zeroconf listener initialization in those cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Details

The changes include:

1. **New utility function** `is_ip_address()` in `util.py` that detects if a string is an IP address (with or without port)
2. **Track IP address names** in ReconnectLogic with `_is_ip_address` flag
3. **Skip zeroconf listener** in `_start_zc_listen()` when the name is an IP address
4. **Comprehensive test** that verifies zeroconf is not created for IP addresses but still works for device names

Before this fix:
```
2025-06-29 08:25:31,580 - aioesphomeapi.reconnect_logic - DEBUG - Starting zeroconf listener for 127.0.0.1:52642
2025-06-29 08:25:31,580 - aioesphomeapi.zeroconf - DEBUG - Creating new AsyncZeroconf instance
```

After this fix:
- No zeroconf listener is started for IP addresses
- No AsyncZeroconf instance is created
- Connection proceeds normally without zeroconf overhead