### PR TITLE
Mark deprecated protobuf fields to reduce flash usage

### DIFF
--- a/aioesphomeapi/api.proto
+++ b/aioesphomeapi/api.proto
@@ -230,14 +230,16 @@ message DeviceInfoResponse {
 
   uint32 webserver_port = 10 [(field_ifdef) = "USE_WEBSERVER"];
 
-  uint32 legacy_bluetooth_proxy_version = 11 [(field_ifdef) = "USE_BLUETOOTH_PROXY"];
+  // Deprecated in API version 1.9
+  uint32 legacy_bluetooth_proxy_version = 11 [deprecated=true, (field_ifdef) = "USE_BLUETOOTH_PROXY"];
   uint32 bluetooth_proxy_feature_flags = 15 [(field_ifdef) = "USE_BLUETOOTH_PROXY"];
 
   string manufacturer = 12;
 
   string friendly_name = 13;
 
-  uint32 legacy_voice_assistant_version = 14 [(field_ifdef) = "USE_VOICE_ASSISTANT"];
+  // Deprecated in API version 1.10
+  uint32 legacy_voice_assistant_version = 14 [deprecated=true, (field_ifdef) = "USE_VOICE_ASSISTANT"];
   uint32 voice_assistant_feature_flags = 17 [(field_ifdef) = "USE_VOICE_ASSISTANT"];
 
   string suggested_area = 16 [(field_ifdef) = "USE_AREAS"];
@@ -337,6 +339,7 @@ message ListEntitiesCoverResponse {
   uint32 device_id = 13 [(field_ifdef) = "USE_DEVICES"];
 }
 
+// Deprecated in API version 1.1
 enum LegacyCoverState {
   LEGACY_COVER_STATE_OPEN = 0;
   LEGACY_COVER_STATE_CLOSED = 1;
@@ -356,7 +359,8 @@ message CoverStateResponse {
   fixed32 key = 1;
   // legacy: state has been removed in 1.13
   // clients/servers must still send/accept it until the next protocol change
-  LegacyCoverState legacy_state = 2;
+  // Deprecated in API version 1.1
+  LegacyCoverState legacy_state = 2 [deprecated=true];
 
   float position = 3;
   float tilt = 4;
@@ -364,6 +368,7 @@ message CoverStateResponse {
   uint32 device_id = 6 [(field_ifdef) = "USE_DEVICES"];
 }
 
+// Deprecated in API version 1.1
 enum LegacyCoverCommand {
   LEGACY_COVER_COMMAND_OPEN = 0;
   LEGACY_COVER_COMMAND_CLOSE = 1;
@@ -432,6 +437,7 @@ message FanStateResponse {
   fixed32 key = 1;
   bool state = 2;
   bool oscillating = 3;
+  // Deprecated in API version 1.6
   FanSpeed speed = 4 [deprecated = true];
   FanDirection direction = 5;
   int32 speed_level = 6;
@@ -448,7 +454,9 @@ message FanCommandRequest {
   fixed32 key = 1;
   bool has_state = 2;
   bool state = 3;
+  // Deprecated in API version 1.6
   bool has_speed = 4 [deprecated = true];
+  // Deprecated in API version 1.6
   FanSpeed speed = 5 [deprecated = true];
   bool has_oscillating = 6;
   bool oscillating = 7;
@@ -488,9 +496,13 @@ message ListEntitiesLightResponse {
 
   repeated ColorMode supported_color_modes = 12;
   // next four supports_* are for legacy clients, newer clients should use color modes
+  // Deprecated in API version 1.6
   bool legacy_supports_brightness = 5 [deprecated=true];
+  // Deprecated in API version 1.6
   bool legacy_supports_rgb = 6 [deprecated=true];
+  // Deprecated in API version 1.6
   bool legacy_supports_white_value = 7 [deprecated=true];
+  // Deprecated in API version 1.6
   bool legacy_supports_color_temperature = 8 [deprecated=true];
   float min_mireds = 9;
   float max_mireds = 10;
@@ -567,6 +579,7 @@ enum SensorStateClass {
   STATE_CLASS_TOTAL = 3;
 }
 
+// Deprecated in API version 1.5
 enum SensorLastResetType {
   LAST_RESET_NONE = 0;
   LAST_RESET_NEVER = 1;
@@ -591,7 +604,8 @@ message ListEntitiesSensorResponse {
   string device_class = 9;
   SensorStateClass state_class = 10;
   // Last reset type removed in 2021.9.0
-  SensorLastResetType legacy_last_reset_type = 11;
+  // Deprecated in API version 1.5
+  SensorLastResetType legacy_last_reset_type = 11 [deprecated=true];
   bool disabled_by_default = 12;
   EntityCategory entity_category = 13;
   uint32 device_id = 14 [(field_ifdef) = "USE_DEVICES"];
@@ -947,7 +961,8 @@ message ListEntitiesClimateResponse {
   float visual_target_temperature_step = 10;
   // for older peer versions - in new system this
   // is if CLIMATE_PRESET_AWAY exists is supported_presets
-  bool legacy_supports_away = 11;
+  // Deprecated in API version 1.5
+  bool legacy_supports_away = 11 [deprecated=true];
   bool supports_action = 12;
   repeated ClimateFanMode supported_fan_modes = 13;
   repeated ClimateSwingMode supported_swing_modes = 14;
@@ -978,7 +993,8 @@ message ClimateStateResponse {
   float target_temperature_low = 5;
   float target_temperature_high = 6;
   // For older peers, equal to preset == CLIMATE_PRESET_AWAY
-  bool unused_legacy_away = 7;
+  // Deprecated in API version 1.5
+  bool unused_legacy_away = 7 [deprecated=true];
   ClimateAction action = 8;
   ClimateFanMode fan_mode = 9;
   ClimateSwingMode swing_mode = 10;
@@ -1006,8 +1022,10 @@ message ClimateCommandRequest {
   bool has_target_temperature_high = 8;
   float target_temperature_high = 9;
   // legacy, for older peers, newer ones should use CLIMATE_PRESET_AWAY in preset
-  bool unused_has_legacy_away = 10;
-  bool unused_legacy_away = 11;
+  // Deprecated in API version 1.5
+  bool unused_has_legacy_away = 10 [deprecated=true];
+  // Deprecated in API version 1.5
+  bool unused_legacy_away = 11 [deprecated=true];
   bool has_fan_mode = 12;
   ClimateFanMode fan_mode = 13;
   bool has_swing_mode = 14;
@@ -1356,6 +1374,7 @@ message SubscribeBluetoothLEAdvertisementsRequest {
 
 message BluetoothServiceData {
   string uuid = 1;
+  // Deprecated in API version 1.7
   repeated uint32 legacy_data = 2 [deprecated = true];  // Removed in api version 1.7
   bytes data = 3;  // Added in api version 1.7
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR marks deprecated protobuf fields with `[deprecated=true]` to enable ESPHome to optimize code generation and save flash space on devices.

Currently, ESPHome generates code for all fields in the protobuf definitions, including those that have been deprecated for many API versions. By marking these fields as deprecated using the standard protobuf `[deprecated=true]` annotation, we enable the ESPHome code generator to skip generating code for these fields, resulting in significant flash space savings on constrained devices.

All fields being marked as deprecated have been deprecated for a long time (ranging from API version 1.1 to 1.10), and since users typically upgrade Home Assistant before updating ESPHome, we can safely stop sending these fields.

## Summary of deprecated fields:
- **API v1.1** (deprecated ~2021): Cover legacy state fields
- **API v1.5** (deprecated ~2021): Climate legacy away mode, sensor last reset type
- **API v1.6** (deprecated ~2021): Light legacy color support flags, fan speed enum
- **API v1.7** (deprecated ~2022): Bluetooth advertisement legacy data format
- **API v1.9** (deprecated ~2023): Legacy bluetooth proxy version
- **API v1.10** (deprecated ~2023): Legacy voice assistant version

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces flash usage on ESP devices by not generating code for deprecated fields

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).