### PR TITLE
Downgrade APIConnectionCancelledError log level to DEBUG

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -15,6 +15,7 @@ from zeroconf.const import (
 
 from .client import APIClient
 from .core import (
+    APIConnectionCancelledError,
     APIConnectionError,
     InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
@@ -173,6 +174,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         ) and isinstance(err, APIConnectionError)
         if not is_handled_exception:
             level = logging.ERROR
+        elif isinstance(err, APIConnectionCancelledError):
+            # APIConnectionCancelledError is harmless and should always be DEBUG
+            level = logging.DEBUG
         elif self._tries == 0:
             level = logging.WARNING
         else:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -21,6 +21,7 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR
 from aioesphomeapi import APIConnectionError, RequiresEncryptionAPIError
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.client import APIClient
+from aioesphomeapi.core import APIConnectionCancelledError
 from aioesphomeapi.reconnect_logic import (
     MAXIMUM_BACKOFF_TRIES,
     ReconnectLogic,
@@ -1023,3 +1024,55 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         mock_get_zc.assert_called()
 
         await logic_with_name.stop()
+
+
+@pytest.mark.asyncio
+async def test_connection_cancelled_error_logged_at_debug_level(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that APIConnectionCancelledError is always logged at DEBUG level."""
+    cli = patchable_api_client
+
+    on_connect = AsyncMock()
+    on_disconnect = AsyncMock()
+    on_connect_fail = AsyncMock()
+
+    logic = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        on_connect_error=on_connect_fail,
+        name="mydevice",
+    )
+
+    caplog.clear()
+    # First attempt - APIConnectionCancelledError should be DEBUG even on first try
+    with patch.object(
+        cli,
+        "start_resolve_host",
+        side_effect=APIConnectionCancelledError("Starting connection cancelled"),
+    ):
+        await logic.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert len(on_connect_fail.call_args_list) == 1
+    assert isinstance(
+        on_connect_fail.call_args_list[0][0][0], APIConnectionCancelledError
+    )
+
+    # Check that the error was logged at DEBUG level, not WARNING
+    found_log = False
+    for record in caplog.records:
+        if (
+            "Can't connect to ESPHome API" in record.message
+            and "APIConnectionCancelledError" in record.message
+        ):
+            assert record.levelno == logging.DEBUG
+            found_log = True
+            break
+
+    assert found_log, "Expected log message not found"
+
+    await logic.stop()


### PR DESCRIPTION
# What does this implement/fix?

This PR downgrades the log level for `APIConnectionCancelledError` from WARNING to DEBUG, as these errors are harmless and occur during normal operation when ESPHome detects a device coming online via mDNS and cancels the current connection attempt to restart with updated connection information.

The error message "Starting connection cancelled" was being logged at WARNING level on the first connection attempt, which could be confusing to users as it suggests something is wrong when in fact this is expected behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1263

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).