### PR TITLE
Sync api.proto from esphome

### DIFF
--- a/aioesphomeapi/api.proto
+++ b/aioesphomeapi/api.proto
@@ -1463,19 +1463,19 @@ message BluetoothGATTGetServicesRequest {
 }
 
 message BluetoothGATTDescriptor {
-  repeated uint64 uuid = 1;
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
   uint32 handle = 2;
 }
 
 message BluetoothGATTCharacteristic {
-  repeated uint64 uuid = 1;
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
   uint32 handle = 2;
   uint32 properties = 3;
   repeated BluetoothGATTDescriptor descriptors = 4;
 }
 
 message BluetoothGATTService {
-  repeated uint64 uuid = 1;
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
   uint32 handle = 2;
   repeated BluetoothGATTCharacteristic characteristics = 3;
 }
@@ -1486,7 +1486,7 @@ message BluetoothGATTGetServicesResponse {
   option (ifdef) = "USE_BLUETOOTH_PROXY";
 
   uint64 address = 1;
-  repeated BluetoothGATTService services = 2;
+  repeated BluetoothGATTService services = 2 [(fixed_array_size) = 1];
 }
 
 message BluetoothGATTGetServicesDoneResponse {


### PR DESCRIPTION

# What does this implement/fix?


Sync api.proto from esphome
from https://github.com/esphome/esphome/pull/9782

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
