### PR TITLE
Sync api.proto from esphome for USE_API_HOMEASSISTANT_STATES

### DIFF
--- a/aioesphomeapi/api.proto
+++ b/aioesphomeapi/api.proto
@@ -781,11 +781,13 @@ message HomeassistantServiceResponse {
 message SubscribeHomeAssistantStatesRequest {
   option (id) = 38;
   option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_API_HOMEASSISTANT_STATES";
 }
 
 message SubscribeHomeAssistantStateResponse {
   option (id) = 39;
   option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_API_HOMEASSISTANT_STATES";
   string entity_id = 1;
   string attribute = 2;
   bool once = 3;
@@ -795,6 +797,7 @@ message HomeAssistantStateResponse {
   option (id) = 40;
   option (source) = SOURCE_CLIENT;
   option (no_delay) = true;
+  option (ifdef) = "USE_API_HOMEASSISTANT_STATES";
 
   string entity_id = 1;
   string state = 2;


### PR DESCRIPTION
# What does this implement/fix?

Sync api.proto from esphome for USE_API_HOMEASSISTANT_STATES

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
