### PR TITLE
Skip waiting for ConnectResponse when no password is configured

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -462,11 +462,12 @@ class APIConnection:
 
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
+        has_password = self._params.password is not None
         messages = [make_hello_request(self._params.client_info)]
         msg_types = [HelloResponse]
         if login:
             messages.append(self._make_connect_request())
-            if self._params.password is not None:
+            if has_password:
                 # Only wait for ConnectResponse if we actually have
                 # a password to send, but we will still register
                 # a handler for a ConnectResponse just in case
@@ -483,7 +484,7 @@ class APIConnection:
         )
         resp = responses.pop(0)
         self._process_hello_resp(resp)
-        if login:
+        if has_password:
             login_response = responses.pop(0)
             self._process_login_response(login_response)
 

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -233,7 +233,7 @@ async def test_log_runner_reconnects_on_subscribe_failure(
             send_plaintext_hello(protocol)
             send_plaintext_connect_response(protocol, False)
 
-        await subscribed.wait()
+        await asyncio.wait_for(subscribed.wait(), timeout=1)
 
     assert cli._connection is None
 
@@ -253,10 +253,12 @@ async def test_log_runner_reconnects_on_subscribe_failure(
     stop_task = asyncio.create_task(stop())
     await asyncio.sleep(0)
 
-    send_plaintext_connect_response(protocol, False)
     send_plaintext_hello(protocol)
+    send_plaintext_connect_response(protocol, False)
 
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
     disconnect_response = DisconnectResponse()
     mock_data_received(protocol, generate_plaintext_packet(disconnect_response))
 
-    await stop_task
+    await asyncio.wait_for(stop_task, timeout=1)


### PR DESCRIPTION
# What does this implement/fix?

This PR implements pre-work for #1246 by modifying the connection logic to skip waiting for `ConnectResponse` when no password is configured, while still handling unexpected password responses gracefully.

When connecting to a passwordless ESPHome device, we now:
1. Only wait for `ConnectResponse` if we actually have a password to send
2. Register a handler for `ConnectResponse` messages that arrive unexpectedly
3. Report authentication errors if a device requires a password but we don't have one

This provides an immediate performance benefit for passwordless connections while maintaining backward compatibility and robust error handling.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Pre-work for #1246

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- Phase 1 already implemented: esphome/esphome#9445

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

