### PR TITLE
Fix IndexError when connecting with login=False and password=None

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -462,12 +462,11 @@ class APIConnection:
 
     async def _connect_hello_login(self, login: bool) -> None:
         """Step 4 in connect process: send hello and login and get api version."""
-        has_password = self._params.password is not None
         messages = [make_hello_request(self._params.client_info)]
         msg_types = [HelloResponse]
         if login:
             messages.append(self._make_connect_request())
-            if has_password:
+            if self._params.password:
                 # Only wait for ConnectResponse if we actually have
                 # a password to send, but we will still register
                 # a handler for a ConnectResponse just in case
@@ -482,9 +481,10 @@ class APIConnection:
             tuple(msg_types),
             CONNECT_REQUEST_TIMEOUT,
         )
+
         resp = responses.pop(0)
         self._process_hello_resp(resp)
-        if has_password:
+        if login and self._params.password:
             login_response = responses.pop(0)
             self._process_login_response(login_response)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -58,6 +58,66 @@ from .common import (
 KEEP_ALIVE_TIMEOUT_RATIO = 4.5
 
 
+async def test_connect_hello_login_with_login_false_and_password_none(
+    conn: APIConnection,
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """Test that _connect_hello_login works with login=False and password=None.
+
+    This test verifies the fix for the issue where _connect_hello_login would
+    try to pop from an empty list when login=False but password=None.
+    """
+    loop = asyncio.get_running_loop()
+    transport = MagicMock()
+    connected = asyncio.Event()
+    protocol: APIPlaintextFrameHelper | None = None
+
+    async def _create_connection(*args, **kwargs):
+        nonlocal protocol
+        transport_proto = _create_mock_transport_protocol(
+            transport,
+            connected,
+            lambda: APIPlaintextFrameHelper(
+                connection=conn,
+                client_info="test",
+                log_name=conn.log_name,
+            ),
+        )
+        protocol = transport_proto[1]
+        return transport, protocol
+
+    with patch.object(loop, "create_connection", side_effect=_create_connection):
+        # Start the connection process
+        await conn.start_resolve_host()
+        await conn.start_connection()
+
+        # Register internal handlers like in normal flow
+        conn._register_internal_message_handlers()
+
+        # Create a task for finish_connection with login=False
+        finish_task = asyncio.create_task(conn.finish_connection(login=False))
+
+        # Let the task start
+        await asyncio.sleep(0)
+
+        # Send only HelloResponse (no ConnectResponse since login=False)
+        assert protocol is not None
+        hello_response = bytes.fromhex(
+            "003602080110091a216d6173746572617672656c61792028657"
+            "370686f6d652076323032332e362e3329220d6d617374657261"
+            "7672656c6179"
+        )
+        mock_data_received(protocol, hello_response)
+
+        # The connection should complete successfully without trying to pop
+        # a ConnectResponse from an empty list
+        await finish_task
+
+        assert conn.is_connected
+        assert conn.api_version is not None
+
+
 async def test_connect(
     plaintext_connect_task_no_login: tuple[
         APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an IndexError that occurs when `login=False` but `password=None` in the `_connect_hello_login` method. Previously, the code would attempt to pop a `ConnectResponse` from an empty responses list, causing the connection to fail.

The fix adds a proper guard to only pop the login response when both `login` is True AND a password is configured (`has_password` is True).

This regression was introduced in #1276 where the pop logic was updated to check `has_password`, but it missed also checking the `login` parameter, causing it to still attempt to pop when `login=False`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes IndexError when connecting with login=False and password=None

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).