### PR TITLE
Downgrade APIConnectionCancelledError log level to DEBUG in connection.py

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -911,7 +911,13 @@ class APIConnection:
         if self._fatal_exception is None:
             if self._expected_disconnect is False:
                 # Only log the first error
-                _LOGGER.warning(
+                log_level = (
+                    logging.DEBUG
+                    if isinstance(err, APIConnectionCancelledError)
+                    else logging.WARNING
+                )
+                _LOGGER.log(
+                    log_level,
                     "%s: Connection error occurred: %s",
                     self.log_name,
                     err or type(err),


### PR DESCRIPTION
# What does this implement/fix?

This is a follow-up to PR #1267 which downgraded `APIConnectionCancelledError` log level to DEBUG in `reconnect_logic.py`. 

This PR applies the same fix to `connection.py`'s `report_fatal_error` method, which was logging the same harmless cancellation errors at WARNING level. It was observed that these warnings appear during ESPHome OTA updates:

```
WARNING maui_es015_tb_b @ 192.168.106.162: Connection error occurred: Error while starting connection: Starting connection cancelled
```

These cancellation errors are expected behavior when connections are intentionally cancelled and should not be logged at WARNING level.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #1267

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).