### PR TITLE
Prevent duplicate connection error logging when using reconnect_logic

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -204,9 +204,10 @@ class APIClient(APIClientBase):
         self,
         on_stop: Callable[[bool], Coroutine[Any, Any, None]] | None = None,
         login: bool = False,
+        log_errors: bool = True,
     ) -> None:
         """Connect to the device."""
-        await self.start_resolve_host(on_stop)
+        await self.start_resolve_host(on_stop, log_errors=log_errors)
         await self.start_connection()
         await self.finish_connection(login)
 
@@ -223,6 +224,7 @@ class APIClient(APIClientBase):
     async def start_resolve_host(
         self,
         on_stop: Callable[[bool], Coroutine[Any, Any, None]] | None = None,
+        log_errors: bool = True,
     ) -> None:
         """Start resolving the host."""
         if self._connection is not None:
@@ -232,6 +234,7 @@ class APIClient(APIClientBase):
             partial(self._on_stop, on_stop),
             self._debug_enabled,
             self.log_name,
+            log_errors=log_errors,
         )
         await self._execute_connection_coro(self._connection.start_resolve_host())
 

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -117,6 +117,7 @@ cdef class APIConnection:
     cdef public str received_name
     cdef public str connected_address
     cdef list _addrs_info
+    cdef bint _log_errors
 
     cpdef void send_message(self, object msg) except *
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -202,6 +202,7 @@ class APIConnection:
         "_handshake_complete",
         "_keep_alive_interval",
         "_keep_alive_timeout",
+        "_log_errors",
         "_loop",
         "_message_handlers",
         "_params",
@@ -227,6 +228,7 @@ class APIConnection:
         on_stop: Callable[[bool], None] | None,
         debug_enabled: bool,
         log_name: str | None,
+        log_errors: bool = True,
     ) -> None:
         self._params = params
         self.on_stop = on_stop
@@ -263,6 +265,7 @@ class APIConnection:
         self.received_name: str = ""
         self.connected_address: str | None = None
         self._addrs_info: list[hr.AddrInfo] = []
+        self._log_errors = log_errors
 
     def set_log_name(self, name: str) -> None:
         """Set the friendly log name for this connection."""
@@ -909,7 +912,7 @@ class APIConnection:
         This method does not log the error, the call site should do so.
         """
         if self._fatal_exception is None:
-            if self._expected_disconnect is False:
+            if self._expected_disconnect is False and self._log_errors:
                 # Only log the first error
                 log_level = (
                     logging.DEBUG

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -196,7 +196,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._async_set_connection_state_while_locked(ReconnectLogicState.RESOLVING)
         start_resolve_time = time.perf_counter()
         try:
-            await self._cli.start_resolve_host(on_stop=self._on_disconnect)
+            await self._cli.start_resolve_host(
+                on_stop=self._on_disconnect, log_errors=False
+            )
         except Exception as err:  # pylint: disable=broad-except
             await self._handle_connection_failure(err)
             return False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -206,7 +206,7 @@ async def test_connect_backwards_compat() -> None:
     ):
         await cli.connect()
 
-    assert mock_start_resolve_host.mock_calls == [call(None)]
+    assert mock_start_resolve_host.mock_calls == [call(None, log_errors=True)]
     assert mock_start_connection.mock_calls == [call()]
     assert mock_finish_connection.mock_calls == [call(False)]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1271,3 +1271,23 @@ async def test_report_fatal_error_regular_errors_logged_at_warning_level(
     ]
     assert len(matching_records) == 1
     assert matching_records[0].levelno == logging.WARNING
+
+
+@pytest.mark.asyncio
+async def test_report_fatal_error_with_log_errors_false(
+    connection_params: ConnectionParams,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that report_fatal_error doesn't log when log_errors=False."""
+    conn = APIConnection(connection_params, None, False, None, log_errors=False)
+
+    with caplog.at_level(logging.DEBUG):
+        # Report a regular connection error
+        regular_error = APIConnectionError("Test connection error")
+        conn.report_fatal_error(regular_error)
+
+    # Verify no error was logged
+    assert len(caplog.records) == 0
+
+    # Verify the error is still stored internally
+    assert conn._fatal_exception is regular_error


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where connection errors are logged twice when ESPHome devices are offline and reconnect_logic is being used. Currently, both the `connection.py` layer and `reconnect_logic.py` layer log the same errors, resulting in log spam with potentially different log levels.

The solution adds a `log_errors` parameter to APIConnection that allows reconnect_logic to disable the connection layer's internal error logging. This ensures that:
- When using reconnect_logic: Only reconnect_logic logs errors (WARNING for first attempt, DEBUG for retries)
- When using direct connections: connection.py still logs errors normally
- No duplicate logging between the two layers

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/home-assistant/core/issues/149775

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Details

### Changes made:
1. Added `log_errors` parameter (default `True`) to:
   - `APIConnection.__init__()`
   - `APIClient.start_resolve_host()`
   - `APIClient.connect()`

2. Modified `APIConnection.report_fatal_error()` to check `self._log_errors` before logging

3. Updated `reconnect_logic.py` to pass `log_errors=False` when creating connections

4. Updated the Cython `.pxd` file to include the new `_log_errors` field

5. Added tests to verify the new behavior works correctly

### Testing:
- Added test `test_report_fatal_error_with_log_errors_false` to verify logging can be disabled
- Updated existing test `test_connect_backwards_compat` to expect the new parameter
- All existing tests pass