### PR TITLE
Drop armv7l wheel builds from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,34 +29,6 @@ jobs:
             musl: "musllinux"
           - os: ubuntu-24.04-arm
             musl: "musllinux"
-          # qemu is slow, make a single
-          # runner per Python version
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: "musllinux"
-            pyver: cp311
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: "musllinux"
-            pyver: cp312
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: "musllinux"
-            pyver: cp313
-          # qemu is slow, make a single
-          # runner per Python version
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: ""
-            pyver: cp311
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: ""
-            pyver: cp312
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: ""
-            pyver: cp313
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# What does this implement/fix?

This PR removes armv7l wheel builds from the GitHub Actions release workflow. 

ESPHome no longer provides armv7l images, and Home Assistant will be dropping support for armv7l soon. For the short period that Home Assistant continues to support armv7l, they will build the wheels themselves. Additionally, piwheels will continue to provide armv7l wheels for users who still need them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).