### PR TITLE
Fix TypeError when addresses parameter contains Estr objects

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -255,7 +255,9 @@ class APIClientBase:
         """
         self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(
-            addresses=addresses if addresses else [str(address)],
+            addresses=[str(addr) for addr in addresses]
+            if addresses
+            else [str(address)],
             port=port,
             password=password,
             client_info=client_info,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1138,6 +1138,24 @@ async def test_empty_noise_psk_or_expected_name():
     assert cli._params.expected_name is None
 
 
+async def test_addresses_parameter_handles_subclassed_string() -> None:
+    """Test that the addresses parameter gets converted to a list of strings."""
+    cli = APIClient(
+        address=Estr("127.0.0.1"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=None,
+        addresses=[Estr("192.168.1.100"), Estr("192.168.1.101"), Estr("10.0.0.1")],
+    )
+    # Make sure all addresses are converted to regular strings
+    assert len(cli._params.addresses) == 3
+    assert all(type(addr) is str for addr in cli._params.addresses)
+    assert cli._params.addresses[0] == "192.168.1.100"
+    assert cli._params.addresses[1] == "192.168.1.101"
+    assert cli._params.addresses[2] == "10.0.0.1"
+
+
 async def test_bluetooth_disconnect(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a TypeError that occurs when ESPHome passes `Estr` (subclassed string) objects in the `addresses` parameter to the APIClient. The fix ensures all address strings are properly converted to regular Python `str` objects before being used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes TypeError: Expected str, got EStr when using multiple addresses

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A (This is a client-side fix for handling ESPHome's string types)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Details

The issue occurs when ESPHome passes addresses as `Estr` objects (a subclassed string type used in ESPHome). While individual address parameters and other string parameters like `noise_psk` and `expected_name` were already being converted using `_stringify_or_none()`, the `addresses` list parameter was not converting its elements.

### Changes made:
1. Updated `APIClientBase.__init__` to convert all addresses in the list to regular strings using a list comprehension
2. Added test `test_addresses_parameter_handles_subclassed_string()` to verify the fix works correctly

### Error that was fixed:
```
TypeError: Expected str, got EStr
  File "aioesphomeapi/client_base.py", line 308, in aioesphomeapi.client_base.APIClientBase._set_log_name
```
