### PR TITLE
Fix subscribe_home_assistant_states_and_services with Cython

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -861,7 +861,7 @@ class APIClient(APIClientBase):
             (SubscribeHomeAssistantStateResponse,),
         )
 
-    def subscribe_homeassistant_states_and_services(
+    def subscribe_home_assistant_states_and_services(
         self,
         on_state: Callable[[EntityState], None],
         on_service_call: Callable[[HomeassistantServiceCall], None],

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -122,7 +122,7 @@ cdef class APIConnection:
     cpdef void send_message(self, object msg) except *
 
     @cython.locals(msg_type=tuple)
-    cdef void send_messages(self, tuple messages) except *
+    cpdef void send_messages(self, tuple messages) except *
 
     @cython.locals(handlers=set, handlers_copy=set, klass_merge=tuple)
     cpdef void process_packet(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1987,12 +1987,12 @@ async def test_subscribe_logs(auth_client: APIClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_subscribe_homeassistant_states_and_services(
+async def test_subscribe_home_assistant_states_and_services(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
     ],
 ) -> None:
-    """Test subscribe_homeassistant_states_and_services."""
+    """Test subscribe_home_assistant_states_and_services."""
     client, connection, transport, protocol = api_client
 
     # Patch send_messages to verify it's called with all 3 messages
@@ -2005,7 +2005,7 @@ async def test_subscribe_homeassistant_states_and_services(
     on_state_request = MagicMock()
 
     # Call the unified subscription method
-    client.subscribe_homeassistant_states_and_services(
+    client.subscribe_home_assistant_states_and_services(
         on_state=on_state,
         on_service_call=on_service_call,
         on_state_sub=on_state_sub,


### PR DESCRIPTION

# What does this implement/fix?

send_messages should have been cpdef so it was accessible via Python.

Rename subscribe_homeassistant_states_and_services to subscribe_home_assistant_states_and_services to be in line with other APIs

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
