### PR TITLE
Reduce connection latency by proactively sending time response during handshake

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -113,6 +113,7 @@ cdef class APIConnection:
     cdef bint _send_pending_ping
     cdef public bint is_connected
     cdef bint _handshake_complete
+    cdef bint _initial_time_sent
     cdef bint _debug_enabled
     cdef public str received_name
     cdef public str connected_address


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the connection process by proactively sending a `GetTimeResponse` during the initial handshake, eliminating an unnecessary round-trip that was slowing down the first command after reconnection.

Previously, the connection flow included:
1. Send Hello/Connect request
2. Receive Hello/Connect response  
3. Receive GetTimeRequest from device
4. Send GetTimeResponse back
5. Connection ready for commands

Now with this optimization:
1. Send Hello/Connect request + GetTimeResponse (in same packet)
2. Receive Hello/Connect response
3. Device receives time proactively, skips GetTimeRequest
4. Connection ready for commands (faster!)

This reduces connection latency by ~0.81 seconds as noted in the issue, which is particularly beneficial during reconnects when Home Assistant needs to quickly restore control of devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1313

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- Not applicable - no api.proto changes required

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Notes

- Devices without Home Assistant time enabled will simply ignore the proactive `GetTimeResponse`, making this optimization safe for all deployments
- The time response is sent in the same packet as other handshake messages, so there's virtually no overhead
- The implementation tracks whether we've sent the initial time response to avoid duplicate responses