### PR TITLE
Add combined device_info_and_list_entities method to reduce connection latency

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,6 +57,7 @@ from aioesphomeapi.api_pb2 import (
     LightCommandRequest,
     ListEntitiesBinarySensorResponse,
     ListEntitiesDoneResponse,
+    ListEntitiesSensorResponse,
     ListEntitiesServicesResponse,
     LockCommandRequest,
     MediaPlayerCommandRequest,
@@ -114,6 +115,7 @@ from aioesphomeapi.model import (
     ClimateMode,
     ClimatePreset,
     ClimateSwingMode,
+    DeviceInfo,
     ESPHomeBluetoothGATTServices,
     FanDirection,
     FanSpeed,
@@ -122,6 +124,7 @@ from aioesphomeapi.model import (
     LightColorCapability,
     LockCommand,
     MediaPlayerCommand,
+    SensorInfo,
     UpdateCommand,
     UserService,
     UserServiceArg,
@@ -315,7 +318,7 @@ async def test_connect_while_already_connected(auth_client: APIClient) -> None:
 
 
 @pytest.mark.parametrize(
-    "input, output",
+    ("input", "output"),
     [
         (
             [ListEntitiesBinarySensorResponse(), ListEntitiesDoneResponse()],
@@ -332,6 +335,44 @@ async def test_list_entities(
 ) -> None:
     patch_response_complex(auth_client, input)
     resp = await auth_client.list_entities_services()
+    assert resp == output
+
+
+@pytest.mark.parametrize(
+    ("input", "output"),
+    [
+        (
+            [
+                DeviceInfoResponse(name="test", mac_address="AA:BB:CC:DD:EE:FF"),
+                ListEntitiesBinarySensorResponse(),
+                ListEntitiesDoneResponse(),
+            ],
+            (
+                DeviceInfo(name="test", mac_address="AA:BB:CC:DD:EE:FF"),
+                [BinarySensorInfo()],
+                [],
+            ),
+        ),
+        (
+            [
+                DeviceInfoResponse(name="test2", mac_address="11:22:33:44:55:66"),
+                ListEntitiesServicesResponse(),
+                ListEntitiesSensorResponse(),
+                ListEntitiesDoneResponse(),
+            ],
+            (
+                DeviceInfo(name="test2", mac_address="11:22:33:44:55:66"),
+                [SensorInfo()],
+                [UserService()],
+            ),
+        ),
+    ],
+)
+async def test_device_info_and_list_entities(
+    auth_client: APIClient, input: list[Any], output: tuple[Any, Any, Any]
+) -> None:
+    patch_response_complex(auth_client, input)
+    resp = await auth_client.device_info_and_list_entities()
     assert resp == output
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a new `device_info_and_list_entities()` method that combines the `device_info()` and `list_entities_services()` calls into a single network packet, reducing connection latency and improving efficiency.

When establishing a connection with an ESPHome device, Home Assistant currently fetches device info and entity list separately using `asyncio.gather()` with `create_eager_task()`. This results in two separate network packets being sent and unnecessary task creation overhead. By combining these requests into a single method, we can:
- Reduce network round trips from 2 to 1
- Allow ESP devices to process both requests in a single event loop iteration
- Improve battery life for battery-powered ESP devices
- Eliminate the need for `asyncio.gather()` and `create_eager_task()` in Home Assistant
- Simplify the code and reduce overhead from task creation
- Encapsulates the complexity of coordinating multiple requests from API consumers
- Provide a cleaner, more intuitive API interface for Home Assistant and other consumers

This optimization follows the same pattern as the recently added `subscribe_homeassistant_states_and_services()` method (#1311).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1315

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- Not applicable - no api.proto changes needed

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. (N/A - no api.proto changes)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).