### PR TITLE
Validate address_type is provided for Bluetooth connections

### DIFF
--- a/aioesphomeapi/api.proto
+++ b/aioesphomeapi/api.proto
@@ -1458,7 +1458,7 @@ message BluetoothDeviceRequest {
 
   uint64 address = 1;
   BluetoothDeviceRequestType request_type = 2;
-  bool has_address_type = 3;
+  bool has_address_type = 3;  // Deprecated, should be removed in 2027.8 - https://github.com/esphome/esphome/pull/10318
   uint32 address_type = 4;
 }
 

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -510,6 +510,12 @@ class APIClient(APIClientBase):
     ) -> Callable[[], None]:
         connect_future: asyncio.Future[None] = self._loop.create_future()
 
+        if address_type is None:
+            raise ValueError(
+                f"{self.log_name}: address_type is required for Bluetooth connection. "
+                "The connection attempt cannot proceed without a valid address_type."
+            )
+
         if has_cache:
             # REMOTE_CACHING feature with cache: requestor has services and mtu cached
             request_type = BluetoothDeviceRequestType.CONNECT_V3_WITH_CACHE
@@ -530,8 +536,8 @@ class APIClient(APIClientBase):
             BluetoothDeviceRequest(
                 address=address,
                 request_type=request_type,
-                has_address_type=address_type is not None,
-                address_type=address_type or 0,
+                has_address_type=True,  # Always true since we now require address_type
+                address_type=address_type,
             ),
             partial(
                 on_bluetooth_device_connection_response,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2262,6 +2262,31 @@ async def test_bluetooth_device_connect_without_cache_support_raises(
     assert "2022.12.0 or later" in str(exc_info.value)
 
 
+async def test_bluetooth_device_connect_without_address_type_raises(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test bluetooth_device_connect raises when address_type is None."""
+    client, connection, transport, protocol = api_client
+
+    def on_bluetooth_connection_state(connected: bool, mtu: int, error: int) -> None:
+        pass
+
+    with pytest.raises(
+        ValueError,
+        match="address_type is required for Bluetooth connection.*cannot proceed without a valid address_type",
+    ):
+        await client.bluetooth_device_connect(
+            1234,
+            on_bluetooth_connection_state,
+            timeout=1,
+            feature_flags=BluetoothProxyFeature.REMOTE_CACHING,
+            has_cache=False,
+            address_type=None,
+        )
+
+
 async def test_bluetooth_device_connect_and_disconnect_times_out(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2254,6 +2254,7 @@ async def test_bluetooth_device_connect_without_cache_support_raises(
             timeout=1,
             feature_flags=0,  # No REMOTE_CACHING feature
             has_cache=False,
+            address_type=0,
         )
 
     assert "ESPHome device does not support REMOTE_CACHING feature" in str(


### PR DESCRIPTION
# What does this implement/fix?

This PR makes `address_type` a required parameter for Bluetooth device connections by validating it is not `None` before attempting to connect. Previously, connections without an `address_type` would always fail on the ESPHome side, but now we raise a clear error immediately on the client side.

Additionally, this PR adds a deprecation comment for the `has_address_type` field in `api.proto`, marking it for removal in 2027.8 since `address_type` is now always required.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to investigation of ble_client issues

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#10318

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Notes

This is not a breaking change because Bluetooth connections without `address_type` never worked properly - they would always fail on the ESPHome device side. This change makes the failure explicit and immediate on the client side with a clear error message, rather than attempting a connection that would inevitably fail.

The `has_address_type` field is kept for backward compatibility with older ESPHome devices but is now always set to `True` since `address_type` is required.