### PR TITLE
Add support for getting the connected_address in the client

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -297,6 +297,13 @@ class APIClientBase:
         return self._params.addresses[0]
 
     @property
+    def connected_address(self) -> str | None:
+        """Return the address we are currently connected to, or None if not connected."""
+        if self._connection is None:
+            return None
+        return self._connection.connected_address
+
+    @property
     def api_version(self) -> APIVersion | None:
         if self._connection is None:
             return None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1202,12 +1202,12 @@ async def test_addresses_parameter_handles_subclassed_string() -> None:
     assert cli._params.addresses[2] == "10.0.0.1"
 
 
-async def test_conneted_address(
+async def test_connected_address(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
     ],
 ) -> None:
-    """Test bluetooth_device_disconnect."""
+    """Test getting the connected address."""
     client, _connection, _transport, _protocol = api_client
     assert client.connected_address == "10.0.0.512"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,6 +205,8 @@ async def test_connect_backwards_compat() -> None:
     """Verify connect is a thin wrapper around start_resolve_host, start_connection and finish_connection."""
 
     cli = PatchableAPIClient("host", 1234, None)
+    assert cli.connected_address is None
+
     with (
         patch.object(cli, "start_resolve_host") as mock_start_resolve_host,
         patch.object(cli, "start_connection") as mock_start_connection,
@@ -1198,6 +1200,16 @@ async def test_addresses_parameter_handles_subclassed_string() -> None:
     assert cli._params.addresses[0] == "192.168.1.100"
     assert cli._params.addresses[1] == "192.168.1.101"
     assert cli._params.addresses[2] == "10.0.0.1"
+
+
+async def test_conneted_address(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test bluetooth_device_disconnect."""
+    client, _connection, _transport, _protocol = api_client
+    assert client.connected_address == "10.0.0.512"
 
 
 async def test_bluetooth_disconnect(


### PR DESCRIPTION
# What does this implement/fix?

Add support for getting the connected_address in the client

client.connected_address returns the currently connected address

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
