### PR TITLE
Add timezone parameter to APIClient to fix container timezone override issue

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -230,6 +230,7 @@ class APIClientBase:
         expected_name: str_ | None = None,
         addresses: list[str_] | None = None,
         expected_mac: str_ | None = None,
+        timezone: str_ | None = None,
     ) -> None:
         """Create a client, this object is shared across sessions.
 
@@ -252,6 +253,9 @@ class APIClientBase:
         :param expected_mac: Optional MAC address to check against the device.
             The format should be lower case without : or - separators.
             Example: 00:aa:22:33:44:55 -> 00aa22334455
+        :param timezone: Optional IANA timezone name to send to ESPHome devices.
+            If not provided, the system timezone will be detected automatically.
+            Example: 'America/Chicago' or 'Europe/London'
         """
         self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(
@@ -267,6 +271,7 @@ class APIClientBase:
             noise_psk=_stringify_or_none(noise_psk) or None,
             expected_name=_stringify_or_none(expected_name) or None,
             expected_mac=_stringify_or_none(expected_mac) or None,
+            timezone=_stringify_or_none(timezone) or None,
         )
         self._connection: APIConnection | None = None
         self.cached_name: str | None = None

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -87,6 +87,7 @@ cdef class ConnectionParams:
     cdef public object noise_psk
     cdef public object expected_name
     cdef public object expected_mac
+    cdef public object timezone
 
 
 cdef class APIConnection:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -50,7 +50,7 @@ from .core import (
     UnhandledAPIConnectionError,
 )
 from .model import APIVersion, message_types_to_names
-from .timezone import get_local_timezone
+from .timezone import get_timezone
 from .util import asyncio_timeout
 from .zeroconf import ZeroconfManager
 
@@ -122,6 +122,7 @@ class ConnectionParams:
     noise_psk: str | None
     expected_name: str | None
     expected_mac: str | None
+    timezone: str | None = None
 
 
 class ConnectionState(enum.Enum):
@@ -700,7 +701,9 @@ class APIConnection:
         """Finish the connection process."""
         # Cache timezone before registering handlers to ensure it's available
         # when GetTimeRequest is received
-        self._cached_timezone = await get_local_timezone()
+        # Use provided timezone from params (converted from IANA to POSIX if needed),
+        # or fall back to local timezone detection
+        self._cached_timezone = await get_timezone(self._params.timezone)
         # Register internal handlers before
         # connecting the helper so we can ensure
         # we handle any messages that are received immediately

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,6 +58,7 @@ def get_mock_connection_params() -> ConnectionParams:
         noise_psk=None,
         expected_name=None,
         expected_mac=None,
+        timezone=None,
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -201,6 +201,16 @@ async def test_expected_name(auth_client: APIClient) -> None:
     assert auth_client.expected_name == "awesome"
 
 
+async def test_timezone_parameter() -> None:
+    """Test that timezone parameter is passed to ConnectionParams."""
+    cli = PatchableAPIClient("host", 1234, None, timezone="America/Chicago")
+    assert cli._params.timezone == "America/Chicago"
+
+    # Test with None timezone (should use auto-detection)
+    cli2 = PatchableAPIClient("host", 1234, None)
+    assert cli2._params.timezone is None
+
+
 async def test_connect_backwards_compat() -> None:
     """Verify connect is a thin wrapper around start_resolve_host, start_connection and finish_connection."""
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a `timezone` parameter to `APIClient` to allow Home Assistant to explicitly pass its configured timezone to ESPHome devices, ensuring ESPHome devices use Home Assistant's timezone rather than the container's timezone when they differ.

While this works correctly on Home Assistant OS, users who run Home Assistant in self-configured containers may set a `TZ` environment variable that differs from Home Assistant's configured timezone. Currently, the `tzlocal` library detects and uses the container's `TZ` environment variable, causing ESPHome devices to prefer the container-configured timezone over Home Assistant's configured timezone. This leads to scheduling issues when the two timezones don't match (e.g., sprinklers running at unexpected times).

The fix allows Home Assistant to pass its timezone directly as an IANA timezone name (e.g., "America/Chicago"), which is then converted to a POSIX TZ string for ESPHome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10817

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- Not required (no api.proto changes)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
