### PR TITLE
Ensure fatal exception is logged when cleaning up

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -287,7 +287,14 @@ class APIConnection:
         was_connected = self.is_connected
         self._set_connection_state(CONNECTION_STATE_CLOSED)
         if self._debug_enabled:
-            _LOGGER.debug("Cleaning up connection to %s", self.log_name)
+            if self._fatal_exception:
+                _LOGGER.debug(
+                    "Cleaning up connection to %s (error: %s)",
+                    self.log_name,
+                    self._fatal_exception,
+                )
+            else:
+                _LOGGER.debug("Cleaning up connection to %s", self.log_name)
         for fut in self._read_exception_futures:
             if not fut.done():
                 err = self._fatal_exception or APIConnectionError("Connection closed")


### PR DESCRIPTION
# What does this implement/fix?

Ensure fatal exception is logged when cleaning up

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
