### PR TITLE
Adding API Password deprecation information.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,15 @@ Usage
 
 It's required that you enable the `Native API <https://esphome.io/components/api.html>`_ component for the device.
 
+The use of passwords for APIs in ESPHome is deprecated. Using an encryption key is the recomended method.
+
 .. code:: yaml
 
    # Example configuration entry
    api:
      password: 'MyPassword'
+     encryption:
+       key: 'aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaaaaaaaaaaaa=' # A key can be obtain at https://next.esphome.io/components/api/
 
 Check the output to get the local address of the device or use the ``name:``under ``esphome:`` from the device configuration.
 
@@ -60,7 +64,13 @@ The sample code below will connect to the device and retrieve details.
        """Connect to an ESPHome device and get details."""
 
        # Establish connection
-       api = aioesphomeapi.APIClient("api_test.local", 6053, "MyPassword")
+       
+       # If a password is used in the ESP configuration use the following line:
+       api = aioesphomeapi.APIClient("api_test.local", 6053, "MyPassword",noise_psk='aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaaaaaaaaaaaa=')
+       # OR
+       #If there is no password used in the ESP configuration:
+       api = aioesphomeapi.APIClient("api_test.local", 6053, None,noise_psk='aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaaaaaaaaaaaa=')
+
        await api.connect(login=True)
 
        # Get API version of the device's firmware
@@ -86,7 +96,11 @@ Subscribe to state changes of an ESPHome device.
 
    async def main():
        """Connect to an ESPHome device and wait for state changes."""
-       cli = aioesphomeapi.APIClient("api_test.local", 6053, "MyPassword")
+       # If a password is used in the ESP configuration use the following line:
+       cli = aioesphomeapi.APIClient("api_test.local", 6053, "MyPassword",noise_psk='aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaaaaaaaaaaaa=')
+       # OR
+       #If there is no password used in the ESP configuration:
+       cli = aioesphomeapi.APIClient("api_test.local", 6053, None, noise_psk='aaaaaaaaaaaaaaaaa/aaaaaaaaaaaaaaaaaaaaaaaaa=')
 
        await cli.connect(login=True)
 


### PR DESCRIPTION
Since API passwords are deprecated, I added information about using API encryption keys, instead of API Passwords to the readme file.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
