### PR TITLE
Reduce log spam from repeated "Successfully resolved" messages during reconnection attempts

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -205,8 +205,11 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._async_set_connection_state_while_locked(ReconnectLogicState.CONNECTING)
         start_connect_time = time.perf_counter()
         resolve_time = start_connect_time - start_resolve_time
-        _LOGGER.info(
-            "Successfully resolved %s in %0.3fs", self._cli.log_name, resolve_time
+        _LOGGER.log(
+            logging.INFO if self._tries == 0 else logging.DEBUG,
+            "Successfully resolved %s in %0.3fs",
+            self._cli.log_name,
+            resolve_time,
         )
         try:
             await self._cli.start_connection()


### PR DESCRIPTION
# What does this implement/fix?

Fixes log spam when devices are not online by adjusting the log level for "Successfully resolved" messages in reconnection logic.

When a device is offline, the reconnect logic continuously attempts to resolve and connect to the device. Previously, each successful DNS resolution was logged at INFO level, resulting in repetitive log entries every ~1 minute (e.g., "Successfully resolved esp8266-gateway-usb-2 @ 192.168.1.102 in 0.000s").

This PR implements the same log level pattern already used for connection errors:
- **First attempt**: Log at INFO level (users see that initial resolution succeeded)
- **Subsequent attempts**: Log at DEBUG level (eliminates spam in logs)

The "Successfully connected" and "Successful handshake" messages remain at INFO level since those indicate actual successful connection progress.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1386

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
