### PR TITLE
Add version parameter to build_unique_id

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -487,8 +487,17 @@ def test_user_service_conversion():
     ],
 )
 def test_build_unique_id(model):
-    obj = model(object_id="id")
+    obj = model(object_id="id", name="My Sensor")
+    # Version 1 (default): uses object_id
     assert build_unique_id("mac", obj) == f"mac-{_TYPE_TO_NAME[type(obj)]}-id"
+    assert (
+        build_unique_id("mac", obj, version=1) == f"mac-{_TYPE_TO_NAME[type(obj)]}-id"
+    )
+    # Version 2: uses name directly (preserves spaces, Unicode, etc.)
+    assert (
+        build_unique_id("mac", obj, version=2)
+        == f"mac-{_TYPE_TO_NAME[type(obj)]}-My Sensor"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional `version` parameter to `build_unique_id()` to allow callers to choose between using `object_id` (version 1, default) or `name` (version 2) when constructing unique IDs.

```python
def build_unique_id(formatted_mac: str, entity_info: EntityInfo, *, version: int = 1) -> str:
```

**Version 1 (default):** `{mac}-{entity_type}-{object_id}`
**Version 2:** `{mac}-{entity_type}-{name}`

Version 2 preserves the full entity name including Unicode characters, which can be useful for distinguishing entities that would otherwise have identical `object_id` values after sanitization.

The docstring includes detailed rationale for future reference.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/backlog/issues/76

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
