### PR TITLE
Only compute object_id for API version 1.14+

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -175,6 +175,21 @@ DEFAULT_BLE_TIMEOUT = 30.0
 DEFAULT_BLE_DISCONNECT_TIMEOUT = 20.0
 DEFAULT_EXECUTE_SERVICE_TIMEOUT = 30.0
 
+# API version 1.14+ may omit object_id to reduce protocol overhead
+MIN_VERSION_OBJECT_ID_OPTIONAL = APIVersion(1, 14)
+
+
+def _fill_object_ids_if_needed(
+    api_version: APIVersion,
+    entities: list[EntityInfo],
+    device_info: DeviceInfo,
+) -> list[EntityInfo]:
+    """Fill in missing object_id values if API version supports omitting them."""
+    if api_version >= MIN_VERSION_OBJECT_ID_OPTIONAL:
+        return fill_missing_object_ids(entities, device_info)
+    return entities
+
+
 SUBSCRIBE_STATES_MSG_TYPES = (*SUBSCRIBE_STATES_RESPONSE_TYPES, CameraImageResponse)
 
 LIST_ENTITIES_MSG_TYPES = (
@@ -325,8 +340,9 @@ class APIClient(APIClientBase):
             if cls := response_types[msg_type]:
                 entities.append(cls.from_pb(msg))
         # Fill in missing object_id values using cached device_info
-        entities = fill_missing_object_ids(entities, device_info)
-        return entities, services
+        api_version = self.api_version
+        assert api_version is not None
+        return _fill_object_ids_if_needed(api_version, entities, device_info), services
 
     async def device_info_and_list_entities(
         self,
@@ -382,9 +398,13 @@ class APIClient(APIClientBase):
         assert device_info is not None
         self._cached_device_info = device_info
         # Fill in missing object_id values for entities that don't have them
-        # (ESPHome may stop sending object_id to reduce protocol overhead)
-        entities = fill_missing_object_ids(entities, device_info)
-        return device_info, entities, services
+        api_version = self.api_version
+        assert api_version is not None
+        return (
+            device_info,
+            _fill_object_ids_if_needed(api_version, entities, device_info),
+            services,
+        )
 
     def subscribe_states(self, on_state: Callable[[EntityState], None]) -> None:
         """Subscribe to state updates."""


### PR DESCRIPTION
# What does this implement/fix?

Only compute `object_id` client-side when connected to devices with API version 1.14+.

API 1.14+ devices may omit `object_id` from entity responses to reduce protocol overhead (see esphome/esphome#12698). This change ensures we only run the `fill_missing_object_ids` logic when connected to devices that support this optimization.

For devices with API version < 1.14, `object_id` is always sent by the device, so client-side computation is unnecessary.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#12698

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
