### PR TITLE
Add missing water_heater entity command mappings

### DIFF
--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -89,6 +89,7 @@ from .api_pb2 import (  # type: ignore
     ListEntitiesTimeResponse,
     ListEntitiesUpdateResponse,
     ListEntitiesValveResponse,
+    ListEntitiesWaterHeaterResponse,
     LockCommandRequest,
     LockStateResponse,
     MediaPlayerCommandRequest,
@@ -135,6 +136,8 @@ from .api_pb2 import (  # type: ignore
     VoiceAssistantResponse,
     VoiceAssistantSetConfiguration,
     VoiceAssistantTimerEventResponse,
+    WaterHeaterCommandRequest,
+    WaterHeaterStateResponse,
     ZWaveProxyFrame,
     ZWaveProxyRequest,
 )
@@ -493,6 +496,9 @@ MESSAGE_TYPE_TO_PROTO = {
     129: ZWaveProxyRequest,
     130: HomeassistantActionResponse,
     131: ExecuteServiceResponse,
+    132: ListEntitiesWaterHeaterResponse,
+    133: WaterHeaterStateResponse,
+    134: WaterHeaterCommandRequest,
 }
 
 MESSAGE_NUMBER_TO_PROTO = tuple(MESSAGE_TYPE_TO_PROTO.values())


### PR DESCRIPTION
# What does this implement/fix?

Add missing water_heater entity command mappings

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
