### PR TITLE
Expose `SerialProxyRequestResponse`

### DIFF
--- a/aioesphomeapi/core.py
+++ b/aioesphomeapi/core.py
@@ -113,6 +113,7 @@ from .api_pb2 import (  # type: ignore
     SerialProxyGetModemPinsRequest,
     SerialProxyGetModemPinsResponse,
     SerialProxyRequest,
+    SerialProxyRequestResponse,
     SerialProxySetModemPinsRequest,
     SerialProxyWriteRequest,
     SirenCommandRequest,
@@ -534,6 +535,7 @@ MESSAGE_TYPE_TO_PROTO = {
     144: SerialProxyRequest,
     145: BluetoothSetConnectionParamsRequest,
     146: BluetoothSetConnectionParamsResponse,
+    147: SerialProxyRequestResponse,
 }
 
 MESSAGE_NUMBER_TO_PROTO = tuple(MESSAGE_TYPE_TO_PROTO.values())


### PR DESCRIPTION
# What does this implement/fix?

This `SerialProxyRequestResponse` response type (147) isn't currently exposed in the `MESSAGE_TYPE_TO_PROTO` dict:
```python
2026-03-08 12:46:34.255 DEBUG serialx-host-daemon @ 127.0.0.1: Skipping unknown message type 147
```

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
