### PR TITLE
Add noexcept to hot path cdef methods

### DIFF
--- a/aioesphomeapi/_frame_helper/base.pxd
+++ b/aioesphomeapi/_frame_helper/base.pxd
@@ -26,13 +26,13 @@ cdef class APIFrameHelper:
         new_pos="unsigned int",
         cstr="const unsigned char *"
     )
-    cdef bytes _read(self, int length) noexcept
+    cdef bytes _read(self, int length)
 
     @cython.locals(bytes_data=bytes)
     cdef void _add_to_buffer(self, object data) except *
 
     @cython.locals(end_of_frame_pos="unsigned int", cstr="const unsigned char *")
-    cdef void _remove_from_buffer(self) noexcept
+    cdef void _remove_from_buffer(self) except *
 
     cpdef void write_packets(self, list packets, bint debug_enabled) except *
 


### PR DESCRIPTION
## Summary
- Mark `_read_varuint` as `noexcept` in its `.pxd` declaration
- This is called 3 times per packet in the inner loop of `data_received` (preamble, length, msg_type)
- Eliminates `PyErr_Occurred` checks that Cython inserts after each call

## How it works
Without `noexcept`, Cython generates a `PyErr_Occurred()` call after every invocation of a `cdef` method to check if an exception was raised. This is a function call into libpython that reads thread-local state. By marking methods that cannot raise as `noexcept`, Cython skips these checks entirely.

`_read_varuint` is safe for `noexcept` because it only does C-level integer math and direct byte pointer access (`const unsigned char *`) with no memory allocations. Other buffer methods like `_read` and `_remove_from_buffer` were deliberately marked `except *` in af87614be because they do bytes slicing which can allocate and raise.

## Test plan
- [ ] CI passes (Cython compilation + test suite)
- [ ] Benchmark shows improvement on BLE advertisement processing