### PR TITLE
Split proto lookup into parallel klass/merge tuples

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -72,7 +72,8 @@ cpdef void handle_complex_message(
 cdef object _handle_timeout
 cdef object _handle_complex_message
 
-cdef tuple MESSAGE_NUMBER_TO_PROTO
+cdef tuple MESSAGE_NUMBER_TO_KLASS
+cdef tuple MESSAGE_NUMBER_TO_MERGE
 
 
 @cython.dataclasses.dataclass
@@ -126,7 +127,7 @@ cdef class APIConnection:
     @cython.locals(msg_type=tuple)
     cpdef void send_messages(self, tuple messages) except *
 
-    @cython.locals(handlers=set, handlers_copy=set, klass_merge=tuple)
+    @cython.locals(handlers=set, handlers_copy=set)
     cpdef void process_packet(
         self,
         unsigned int msg_type_proto,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -48,7 +48,6 @@ from .core import (
     HandshakeAPIError,
     InvalidAuthAPIError,
     PingFailedAPIError,
-    ProtocolAPIError,
     ReadFailedAPIError,
     SocketAPIError,
     SocketClosedAPIError,
@@ -63,9 +62,12 @@ from .zeroconf import ZeroconfManager
 
 _LOGGER = logging.getLogger(__name__)
 
-MESSAGE_NUMBER_TO_PROTO: tuple[
-    tuple[Callable[[], message.Message], Callable[[message.Message, bytes], None]], ...
-] = tuple((msg, msg.MergeFromString) for msg in MESSAGE_TYPE_TO_PROTO.values())
+MESSAGE_NUMBER_TO_KLASS: tuple[Callable[[], message.Message], ...] = tuple(
+    MESSAGE_TYPE_TO_PROTO.values()
+)
+MESSAGE_NUMBER_TO_MERGE: tuple[Callable[[message.Message, bytes], None], ...] = tuple(
+    msg.MergeFromString for msg in MESSAGE_TYPE_TO_PROTO.values()
+)
 
 
 PREFERRED_BUFFER_SIZE = 2097152  # Set buffer limit to 2MB
@@ -1003,37 +1005,21 @@ class APIConnection:
         # This method is HOT and extremely performance critical
         # since its called for every incoming packet. Take
         # extra care when modifying this method.
-        try:
-            # MESSAGE_NUMBER_TO_PROTO is 0-indexed
-            # but the message type is 1-indexed
-            klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
-            klass, merge = klass_merge
-            msg = klass()
-            merge(msg, data)
-        except Exception as e:
-            # IndexError will be very rare so we check for it
-            # after the broad exception catch to avoid having
-            # to check the exception type twice for the common case
-            if isinstance(e, IndexError):
-                if self._debug_enabled:
-                    _LOGGER.debug(
-                        "%s: Skipping unknown message type %s",
-                        self.log_name,
-                        msg_type_proto,
-                    )
-                return
-            _LOGGER.exception(
-                "%s: Invalid protobuf message: type=%s data=%s",
-                self.log_name,
-                klass.__name__,
-                data,
-            )
-            self.report_fatal_error(
-                ProtocolAPIError(
-                    f"Invalid protobuf message: type={klass.__name__} data={data!r}: {e}"
+        # Bounds check first to avoid the overhead of try/except
+        # which forces Cython to save/restore exception state on every call.
+        if msg_type_proto < 1 or msg_type_proto > len(MESSAGE_NUMBER_TO_KLASS):
+            if self._debug_enabled:
+                _LOGGER.debug(
+                    "%s: Skipping unknown message type %s",
+                    self.log_name,
+                    msg_type_proto,
                 )
-            )
-            raise
+            return
+
+        # MESSAGE_NUMBER_TO_KLASS/MESSAGE_NUMBER_TO_MERGE are 0-indexed
+        # but the message type is 1-indexed
+        msg = MESSAGE_NUMBER_TO_KLASS[msg_type_proto - 1]()
+        MESSAGE_NUMBER_TO_MERGE[msg_type_proto - 1](msg, data)
 
         if self._debug_enabled:
             _LOGGER.debug(


### PR DESCRIPTION
## Summary
- Split `MESSAGE_NUMBER_TO_PROTO` (tuple of `(klass, merge)` pairs) into `MESSAGE_NUMBER_TO_KLASS` and `MESSAGE_NUMBER_TO_MERGE`
- Eliminates the inner tuple unpack in `process_packet` which generates 2x `PyTuple_GET_ITEM` + 2x `INCREF` per packet
- Direct tuple indexing for both klass and merge function

## Test plan
- [ ] CI passes
- [ ] Benchmark shows improvement on BLE advertisement processing