### PR TITLE
Convert spurious CancelledError in bluetooth_device_connect to APIConnectionError

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -870,6 +870,21 @@ class APIClient(APIClientBase):
                 f"after {timeout}s, disconnect timed out: {disconnect_timed_out}, "
                 f" after {disconnect_timeout}s"
             ) from err
+        except asyncio.CancelledError:
+            unhandled_exception = True
+            # Distinguish an outside cancellation of our task from
+            # a cancellation of the connect_future itself. If the
+            # current task is not actually being cancelled, convert
+            # the CancelledError into an APIConnectionError so that
+            # callers (and their retry logic) can handle it as a
+            # normal connection failure instead of aborting.
+            current_task = asyncio.current_task()
+            if current_task is None or not current_task.cancelling():
+                addr = to_human_readable_address(address)
+                raise APIConnectionError(
+                    f"Connect attempt to {addr} was cancelled"
+                ) from None
+            raise
         except BaseException:
             unhandled_exception = True
             raise

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3823,6 +3823,73 @@ async def test_bluetooth_device_connect_future_cancelled_raises_api_error(
     assert handlers_after == handlers_before
 
 
+async def test_bluetooth_device_connect_base_exception_propagates(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test a BaseException other than CancelledError propagates and cleans up.
+
+    The ``except BaseException`` branch must still run cleanup (unsub the
+    message handler and send a disconnect) and re-raise the original
+    exception unchanged.
+    """
+    client, connection, transport, _protocol = api_client
+    states = []
+
+    handlers_before = len(list(itertools.chain(*connection._message_handlers.values())))
+
+    def on_bluetooth_connection_state(connected: bool, mtu: int, error: int) -> None:
+        states.append((connected, mtu, error))
+
+    original_create_future = client._loop.create_future
+    captured: list[asyncio.Future[None]] = []
+
+    def capturing_create_future() -> asyncio.Future[None]:
+        fut = original_create_future()
+        captured.append(fut)
+        return fut
+
+    with patch.object(client._loop, "create_future", capturing_create_future):
+        connect_task = asyncio.create_task(
+            client.bluetooth_device_connect(
+                1234,
+                on_bluetooth_connection_state,
+                timeout=10,
+                feature_flags=0,
+                has_cache=True,
+                disconnect_timeout=10,
+                address_type=1,
+            )
+        )
+        await asyncio.sleep(0)
+        assert len(transport.writelines.mock_calls) == 1
+        assert len(captured) == 1
+
+        # Inject a non-CancelledError BaseException via the future so the
+        # ``except BaseException`` branch is exercised. A custom
+        # BaseException subclass avoids pytest's special handling of
+        # ``KeyboardInterrupt`` / ``SystemExit``.
+        class _TestBaseException(BaseException):
+            pass
+
+        captured[0].set_exception(_TestBaseException("boom"))
+        with pytest.raises(_TestBaseException, match="boom"):
+            await connect_task
+        assert states == []
+
+    # Ensure the disconnect request was written as cleanup.
+    assert len(transport.writelines.mock_calls) == 2
+    req = BluetoothDeviceRequest(
+        address=1234, request_type=BluetoothDeviceRequestType.DISCONNECT
+    ).SerializeToString()
+    assert transport.writelines.mock_calls[-1] == call([b"\x00", b"\x05", b"D", req])
+
+    # Ensure the message handler was unsubscribed.
+    handlers_after = len(list(itertools.chain(*connection._message_handlers.values())))
+    assert handlers_after == handlers_before
+
+
 async def test_send_voice_assistant_event(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3765,6 +3765,64 @@ async def test_bluetooth_device_connect_cancelled(
     assert handlers_after == handlers_before
 
 
+async def test_bluetooth_device_connect_future_cancelled_raises_api_error(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test that external cancellation of the connect_future raises APIConnectionError.
+
+    When the connect_future is cancelled externally (not via a cancel of the
+    awaiting task), the CancelledError should be converted into an
+    APIConnectionError so callers can treat it as a normal connection failure
+    instead of aborting with CancelledError.
+    """
+    client, connection, transport, _protocol = api_client
+    states = []
+
+    handlers_before = len(list(itertools.chain(*connection._message_handlers.values())))
+
+    def on_bluetooth_connection_state(connected: bool, mtu: int, error: int) -> None:
+        states.append((connected, mtu, error))
+
+    original_create_future = client._loop.create_future
+    captured: list[asyncio.Future[None]] = []
+
+    def capturing_create_future() -> asyncio.Future[None]:
+        fut = original_create_future()
+        captured.append(fut)
+        return fut
+
+    with patch.object(client._loop, "create_future", capturing_create_future):
+        connect_task = asyncio.create_task(
+            client.bluetooth_device_connect(
+                1234,
+                on_bluetooth_connection_state,
+                timeout=10,
+                feature_flags=0,
+                has_cache=True,
+                disconnect_timeout=10,
+                address_type=1,
+            )
+        )
+        await asyncio.sleep(0)
+        # The connect request should be written and the future captured
+        assert len(transport.writelines.mock_calls) == 1
+        assert len(captured) == 1
+        # Cancel the connect_future directly (not the task); this simulates
+        # an external cancel of the future itself.
+        captured[0].cancel()
+        with pytest.raises(APIConnectionError, match="cancelled"):
+            await connect_task
+        assert states == []
+        # Current task was not actually cancelled.
+        assert connect_task.cancelling() == 0
+
+    # The unsub + disconnect should have run, so handlers are not leaked.
+    handlers_after = len(list(itertools.chain(*connection._message_handlers.values())))
+    assert handlers_after == handlers_before
+
+
 async def test_send_voice_assistant_event(auth_client: APIClient) -> None:
     send = patch_send(auth_client)
 


### PR DESCRIPTION
# What does this implement/fix?

When the local ``connect_future`` inside ``APIClient.bluetooth_device_connect`` is cancelled externally (for example, when another code path cancels it while the awaiting task itself is not being cancelled), the resulting ``CancelledError`` would leak out of ``bluetooth_device_connect`` and propagate up through ``bleak`` into caller code paths such as Home Assistant config entry setup. Because ``CancelledError`` is a ``BaseException``, normal ``except Exception`` retry handlers do not catch it, causing integrations like ``airthings_ble`` to be marked as cancelled and abort setup instead of retrying.

This PR adds a dedicated ``except asyncio.CancelledError`` branch that uses ``asyncio.current_task().cancelling()`` to distinguish a genuine task cancellation from a cancellation of the future itself. When the current task is not actually being cancelled, the ``CancelledError`` is converted to a descriptive ``APIConnectionError`` so callers can treat it as a normal connection failure. Real task cancellations still propagate unchanged, and the existing cleanup in the ``finally`` block (``unsub()``, ``timeout_handle.cancel()``, and ``_bluetooth_disconnect_no_wait``) still runs via ``unhandled_exception = True``.

Note: this is not the same bug as #1553 — they are opposite directions of the same ``task.cancelling()`` check. #1553 describes a **swallow** bug in ``_wrap_fatal_connection_exception`` (a real task cancellation is converted into ``APIConnectionCancelledError`` and the task's cancellation state is lost, breaking ``TaskGroup`` / ``asyncio.timeout()``). This PR fixes an **upward leak** — the mirror case, where a ``CancelledError`` escapes to the caller even though the awaiting task was never actually cancelled. Both are real bugs; #1553 still needs a separate fix.

Companion PR in bleak-esphome: Bluetooth-Devices/bleak-esphome#286.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #1553 (opposite direction; not fixed by this PR)

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under ``tests/`` folder).