### PR TITLE
Preserve parent task cancellation state in connect exception handling

### DIFF
--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -10,7 +10,7 @@ import logging
 import socket
 import sys
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import aiohappyeyeballs
 from async_interrupt import interrupt
@@ -668,11 +668,10 @@ class APIConnection:
                     self._params.zeroconf_manager,
                 )
         except (Exception, CancelledError) as ex:
-            # If the task was cancelled, we need to clean up the connection
-            # and raise the CancelledError as APIConnectionError
-            fatal_exc = self._wrap_fatal_connection_exception("resolving", ex)
-            self.report_fatal_error(fatal_exc)
-            raise fatal_exc
+            # Clean up the connection; re-raise the original CancelledError
+            # if the task is actually being cancelled so TaskGroup /
+            # asyncio.timeout semantics are preserved.
+            self._raise_fatal_connection_exception("resolving", ex)
         finally:
             self._set_resolve_host_future()
         self._set_connection_state(CONNECTION_STATE_HOST_RESOLVED)
@@ -703,11 +702,10 @@ class APIConnection:
             ):
                 await self._connect_socket_connect(self._addrs_info)
         except (Exception, CancelledError) as ex:
-            # If the task was cancelled, we need to clean up the connection
-            # and raise the CancelledError as APIConnectionError
-            fatal_exc = self._wrap_fatal_connection_exception("starting", ex)
-            self.report_fatal_error(fatal_exc)
-            raise fatal_exc
+            # Clean up the connection; re-raise the original CancelledError
+            # if the task is actually being cancelled so TaskGroup /
+            # asyncio.timeout semantics are preserved.
+            self._raise_fatal_connection_exception("starting", ex)
         finally:
             self._set_start_connect_future()
         self._set_connection_state(CONNECTION_STATE_SOCKET_OPENED)
@@ -719,6 +717,26 @@ class APIConnection:
         ):
             self._start_connect_future.set_result(None)
             self._start_connect_future = None
+
+    def _raise_fatal_connection_exception(
+        self, action: str, ex: BaseException
+    ) -> NoReturn:
+        """Report a fatal connection exception and raise the appropriate error.
+
+        If the awaiting task is actually being cancelled by a parent (for
+        example, a ``TaskGroup`` or ``asyncio.timeout``), the original
+        ``CancelledError`` is re-raised so the task's cancellation state is
+        preserved. Otherwise the exception is wrapped as an
+        ``APIConnectionError`` subclass as before.
+        """
+        fatal_exc = self._wrap_fatal_connection_exception(action, ex)
+        self.report_fatal_error(fatal_exc)
+        if isinstance(ex, CancelledError) and (
+            (current_task := asyncio.current_task()) is not None
+            and current_task.cancelling() > 0
+        ):
+            raise ex
+        raise fatal_exc
 
     def _wrap_fatal_connection_exception(
         self, action: str, ex: BaseException
@@ -779,11 +797,10 @@ class APIConnection:
             ):
                 await self._do_finish_connect(login)
         except (Exception, CancelledError) as ex:
-            # If the task was cancelled, we need to clean up the connection
-            # and raise the CancelledError as APIConnectionError
-            fatal_exc = self._wrap_fatal_connection_exception("finishing", ex)
-            self.report_fatal_error(fatal_exc)
-            raise fatal_exc
+            # Clean up the connection; re-raise the original CancelledError
+            # if the task is actually being cancelled so TaskGroup /
+            # asyncio.timeout semantics are preserved.
+            self._raise_fatal_connection_exception("finishing", ex)
         finally:
             self._set_finish_connect_future()
         self._set_connection_state(CONNECTION_STATE_CONNECTED)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -888,6 +888,50 @@ async def test_connection_cancelled_during_hello(
     assert not conn.is_connected
 
 
+async def test_connection_task_cancelled_during_hello_propagates_cancel(
+    conn: APIConnection,
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """Test parent task cancellation propagates as CancelledError.
+
+    When the awaiting task is actually being cancelled by a parent (for
+    example, a ``TaskGroup`` or ``asyncio.timeout``), the original
+    ``CancelledError`` must propagate to the parent so the task's cancellation
+    state is preserved. Previously the ``CancelledError`` would be swallowed
+    and converted to an ``APIConnectionCancelledError``, breaking
+    ``asyncio.timeout`` / ``TaskGroup`` semantics.
+    """
+    loop = asyncio.get_running_loop()
+    transport = MagicMock()
+    connected = asyncio.Event()
+    hello_started = asyncio.Event()
+    hello_release = asyncio.Event()
+
+    async def _slow_hello(*args, **kwargs):
+        hello_started.set()
+        await hello_release.wait()
+
+    with (
+        patch.object(
+            loop,
+            "create_connection",
+            side_effect=partial(_create_mock_transport_protocol, transport, connected),
+        ),
+        patch.object(conn, "_connect_hello_login", _slow_hello),
+    ):
+        connect_task = asyncio.create_task(connect(conn, login=False))
+        await connected.wait()
+        await hello_started.wait()
+        # Cancel the parent task while it is parked inside finish_connection.
+        assert connect_task.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await connect_task
+        assert connect_task.cancelled()
+
+    assert not conn.is_connected
+
+
 async def test_connect_resolver_times_out(
     conn: APIConnection, aiohappyeyeballs_start_connection
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:


### PR DESCRIPTION
# What does this implement/fix?

``APIConnection.resolve_host``, ``start_connection``, and ``finish_connection`` all catch ``(Exception, CancelledError)`` and wrap the exception as an ``APIConnectionError`` subclass (``APIConnectionCancelledError`` for ``CancelledError``). When the awaiting task is actually being cancelled by a parent (for example, a ``TaskGroup`` or ``asyncio.timeout``), this converts the ``CancelledError`` into a regular exception and the task's cancellation state is lost, breaking ``TaskGroup`` / ``asyncio.timeout`` semantics. Per the Python docs (https://docs.python.org/3/library/asyncio-task.html#task-cancellation) and cpython#102780, code that catches ``CancelledError`` must either re-raise it or call ``uncancel()`` so that the cancellation state is preserved.

This PR introduces ``_raise_fatal_connection_exception`` which centralises the fatal exception handling at the three call sites. It still reports the fatal error (so the connection is cleaned up) and still wraps non-cancellation exceptions as ``APIConnectionError`` subclasses as before, but when the caught exception is a ``CancelledError`` and ``asyncio.current_task().cancelling() > 0``, it re-raises the original ``CancelledError`` so the parent task (``TaskGroup``, ``asyncio.timeout``, etc.) sees the cancellation it requested. Synthetic ``CancelledError`` cases (such as the one raised internally by ``async_interrupt``) continue to be converted to ``APIConnectionCancelledError`` because ``task.cancelling()`` is 0 in that situation.

**Side-effect ordering note**: ``report_fatal_error(fatal_exc)`` is still invoked **before** the cancelling-check / re-raise. This means that on the propagating-CancelledError branch, the connection is now marked fatally errored with a synthetic ``APIConnectionCancelledError`` (via ``report_fatal_error``) and *then* the original ``CancelledError`` propagates to the parent. This is intentional: the connection state is unrecoverable in either case, and structured-concurrency callers care about the cancellation propagation, not the connection state. The behavior change versus the previous code is only the type of exception that propagates out of ``start_resolve_host`` / ``start_connection`` / ``finish_connection`` (``CancelledError`` instead of ``APIConnectionCancelledError``), not what gets reported via ``report_fatal_error``.

Fixes #1553. Note: this is the **swallow** side of the same ``task.cancelling()`` check that #1572 applies in the **leak** direction in ``bluetooth_device_connect``; both are real bugs and both are fixed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1553

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).