### PR TITLE
Add test covering serial_proxy_get_modem_pins instance matcher

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3105,6 +3105,41 @@ async def test_serial_proxy_get_modem_pins(
     assert result.line_states == 1
 
 
+async def test_serial_proxy_get_modem_pins_matches_instance(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test that serial_proxy_get_modem_pins filters responses by instance.
+
+    A response for a different instance must be ignored so that an in-flight
+    request for a specific instance does not pick up an unrelated response.
+    """
+    client, _connection, _transport, protocol = api_client
+    task = asyncio.create_task(client.serial_proxy_get_modem_pins(instance=1))
+    await asyncio.sleep(0)
+
+    # Send a response for a different instance; it must not satisfy the
+    # request.
+    other_instance_response: message.Message = SerialProxyGetModemPinsResponsePb(
+        instance=0, line_states=7
+    )
+    mock_data_received(protocol, generate_plaintext_packet(other_instance_response))
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    # Now send the response for the requested instance.
+    matching_response: message.Message = SerialProxyGetModemPinsResponsePb(
+        instance=1, line_states=3
+    )
+    mock_data_received(protocol, generate_plaintext_packet(matching_response))
+    result = await task
+
+    assert isinstance(result, SerialProxyModemPins)
+    assert result.instance == 1
+    assert result.line_states == 3
+
+
 async def test_serial_proxy_get_modem_pins_timeout(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper


### PR DESCRIPTION
# What does this implement/fix?

The ``is_matching_response`` closure inside ``APIClient._send_serial_proxy_get_modem_pins`` (``client.py:599``) filters ``SerialProxyGetModemPinsResponse`` messages by ``instance`` so that a request for a specific serial proxy instance does not accidentally pick up an unrelated response. The existing test ``test_serial_proxy_get_modem_pins`` mocks ``send_messages_await_response_complex`` wholesale and therefore never exercises the matcher closure itself.

This PR adds ``test_serial_proxy_get_modem_pins_matches_instance`` which drives the real ``api_client`` fixture: it injects a response for a non-matching instance first (asserts the awaiting task is still pending), then injects the matching response and asserts the request completes with the correct payload. This exercises the ``is_matching_response`` path end-to-end.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under ``tests/`` folder).