### PR TITLE
Stop mDNS records from thrashing an in-flight connect attempt

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -377,6 +377,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             if self._connection_state != ReconnectLogicState.DISCONNECTED:
                 return
             self._tries = 0
+            # Clear any stale gate from a prior run that was stopped mid
+            # attempt after an mDNS triggered restart.
+            self._accept_zeroconf_records = True
             self._schedule_connect(0.0)
 
     async def stop(self) -> None:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -140,6 +140,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._async_set_connection_state_while_locked(
                 ReconnectLogicState.DISCONNECTED
             )
+            # The previous session ended — allow the next mDNS record to
+            # kick a fresh connect attempt early.
+            self._accept_zeroconf_records = True
             await self._on_disconnect_cb(expected_disconnect)
 
         if not self._is_stopped:
@@ -161,7 +164,6 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         when the state is CONNECTING.
         """
         self._connection_state = state
-        self._accept_zeroconf_records = state in NOT_YET_CONNECTED_STATES
 
     def _async_log_connection_error(self, err: Exception) -> None:
         """Log connection errors."""
@@ -241,6 +243,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
     async def _handle_connection_failure(self, err: Exception) -> None:
         """Handle a connection failure."""
         self._async_set_connection_state_while_locked(ReconnectLogicState.DISCONNECTED)
+        # The attempt has truly ended — allow the next mDNS record to
+        # kick a fresh connect attempt early.
+        self._accept_zeroconf_records = True
         if self._on_connect_error_cb is not None:
             await self._on_connect_error_cb(err)
         self._async_log_connection_error(err)
@@ -433,9 +438,14 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         This is a mDNS record from the device and could mean it just woke up.
         """
-        # Check if already connected, no lock needed for this access and
-        # bail if either the already stopped or we haven't received device info yet
-        if not self._accept_zeroconf_records or self._is_stopped:
+        # Bail if we've been stopped, if the current attempt has already been
+        # kicked by a previous mDNS record (one-shot gate), or if we're past
+        # the point where a restart could still help (HANDSHAKING / READY).
+        if (
+            not self._accept_zeroconf_records
+            or self._is_stopped
+            or self._connection_state not in NOT_YET_CONNECTED_STATES
+        ):
             return
 
         for record_update in records:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -696,6 +696,47 @@ async def test_reconnect_zeroconf_only_cancels_connecting_once(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
+async def test_start_clears_stale_zeroconf_gate(
+    patchable_api_client: APIClient,
+) -> None:
+    """A stop() while the gate is closed must not leak into the next start().
+
+    If the logic is stopped mid attempt after an mDNS triggered restart,
+    _accept_zeroconf_records is False. A subsequent start() on the same
+    instance must reopen the gate, otherwise the next run would ignore
+    mDNS records until its first real failure.
+    """
+    cli = patchable_api_client
+    mock_zeroconf = MagicMock(spec=Zeroconf)
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=mock_zeroconf,
+        name="mydevice",
+        on_connect_error=AsyncMock(),
+    )
+
+    with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+        await rl.start()
+        await asyncio.sleep(0)
+
+    # Simulate the stop-mid-attempt-with-closed-gate state directly.
+    rl._accept_zeroconf_records = False
+    await rl.stop()
+    assert rl._is_stopped is True
+    assert rl._accept_zeroconf_records is False
+
+    with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+        await rl.start()
+        await asyncio.sleep(0)
+
+    assert rl._accept_zeroconf_records is True
+
+    await rl.stop()
+
+
 async def test_reconnect_zeroconf_does_not_cancel_connecting_with_socket(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -617,6 +617,85 @@ async def test_reconnect_zeroconf_cancels_connecting_no_socket(
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
 
 
+async def test_reconnect_zeroconf_only_cancels_connecting_once(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Further mDNS records during a single connect attempt must not retrigger.
+
+    Regression: previously every A / PTR record cancelled the in-flight
+    CONNECTING task and restarted from RESOLVING, thrashing the connect for
+    as long as the device kept announcing itself on mDNS.
+    """
+    cli = patchable_api_client
+
+    mock_zeroconf = MagicMock(spec=Zeroconf)
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=mock_zeroconf,
+        name="mydevice",
+        on_connect_error=AsyncMock(),
+    )
+
+    with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+        await rl.start()
+        await asyncio.sleep(0)
+
+    with (
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection", side_effect=slow_connect_fail),
+    ):
+        assert rl._connect_timer is not None
+        rl._connect_timer._run()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert rl._connection_state is ReconnectLogicState.CONNECTING
+        assert rl._accept_zeroconf_records is True
+
+    with (
+        patch.object(cli, "start_resolve_host") as mock_resolve_2,
+        patch.object(
+            cli, "start_connection", side_effect=slow_connect_fail
+        ) as mock_connect_2,
+        patch.object(cli, "finish_connection"),
+    ):
+        caplog.clear()
+        rl.async_update_records(
+            mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
+        )
+        assert (
+            caplog.text.count("Triggering connect because of received mDNS record") == 1
+        )
+        assert rl._accept_zeroconf_records is False
+
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert mock_resolve_2.call_count == 1
+        assert mock_connect_2.call_count == 1
+        assert rl._connection_state is ReconnectLogicState.CONNECTING
+
+        # Subsequent mDNS records during the same attempt must be ignored.
+        caplog.clear()
+        for _ in range(5):
+            rl.async_update_records(
+                mock_zeroconf,
+                current_time_millis(),
+                [RecordUpdate(DNS_POINTER, None)],
+            )
+        assert "Triggering connect because of received mDNS record" not in caplog.text
+        assert mock_resolve_2.call_count == 1
+        assert mock_connect_2.call_count == 1
+
+    rl._cancel_connect("forced cancel in test")
+    await rl.stop()
+    assert rl._is_stopped is True
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+
+
 async def test_reconnect_zeroconf_does_not_cancel_connecting_with_socket(
     patchable_api_client: APIClient,
     caplog: pytest.LogCaptureFixture,
@@ -785,7 +864,7 @@ async def test_reconnect_zeroconf_not_while_handshaking(
         assert mock_start_connection.call_count == 1
         assert mock_finish_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.HANDSHAKING
-        assert rl._accept_zeroconf_records is False
+        assert rl._accept_zeroconf_records is True
         assert not rl._is_stopped
 
     rl.async_update_records(
@@ -843,7 +922,7 @@ async def test_connect_task_not_cancelled_while_handshaking(
         assert mock_start_connection.call_count == 1
         assert mock_finish_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.HANDSHAKING
-        assert rl._accept_zeroconf_records is False
+        assert rl._accept_zeroconf_records is True
         assert not rl._is_stopped
 
     caplog.clear()


### PR DESCRIPTION
# What does this implement/fix?

While connecting to a device, every inbound A or PTR record was cancelling the in-flight RESOLVING or CONNECTING task and restarting it; zeroconf delivers several records back to back, so the connect would restart over and over until the announcements stopped. The `_accept_zeroconf_records` throttle was already there, but it was rebound to `(state in NOT_YET_CONNECTED_STATES)` on every state transition, so entering RESOLVING silently reopened the gate after each trigger.

The problem was only obvious on ESP8266; its mDNS stack re-announces very aggressively after boot or OTA, so the cancel and restart loop would fire several times in a row and visibly thrash the connect. ESP32 is quieter on mDNS in the same window, so the same bug was mostly invisible there, the connect just waited for TCP on its own.

This makes the flag a true one shot per connect attempt; it only reopens when the attempt actually ends, via `_handle_connection_failure` or `_on_disconnect`. The HANDSHAKING and READY states are gated by an explicit state check in `async_update_records` rather than riding on the same flag. The first mDNS kicked cancel and restart, which is the useful case when we send SYN to a device that just woke up, still happens exactly once.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).