### PR TITLE
Fix log_runner info lookup colliding across entity types

### DIFF
--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -131,11 +131,15 @@ async def _subscribe_entity_states(
             seen_keys.add(state_id)
             return
         info_type = STATE_TYPE_TO_INFO_TYPE.get(type(state))
-        info = (
-            entity_info.get((info_type, state.device_id, state.key))
-            if info_type is not None
-            else None
-        )
+        if info_type is None:
+            _LOGGER.warning(
+                "No EntityInfo type mapping for state %s; "
+                "STATE_TYPE_TO_INFO_TYPE likely needs an entry",
+                type(state).__name__,
+            )
+            info = None
+        else:
+            info = entity_info.get((info_type, state.device_id, state.key))
         text = format_state_log(state, info)
         if text is not None:
             msg = SubscribeLogsResponse()

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -117,12 +117,15 @@ async def _subscribe_entity_states(
     entity_info: dict[tuple[type[EntityInfo], int, int], EntityInfo] = {
         (type(e), e.device_id, e.key): e for e in entities
     }
-    seen_keys: set[tuple[int, int]] = set()
+    # Include type(state) so that two colliding entities each get their own
+    # initial-dump skip; otherwise the second entity's first real state would
+    # be swallowed as if it were the initial dump.
+    seen_keys: set[tuple[type[EntityState], int, int]] = set()
 
     def on_state(state: EntityState) -> None:
         if proxy.seen_verbose:
             return
-        state_id = (state.device_id, state.key)
+        state_id = (type(state), state.device_id, state.key)
         if state_id not in seen_keys:
             # Skip initial state dump on connect
             seen_keys.add(state_id)

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -10,6 +10,7 @@ from .api_pb2 import SubscribeLogsResponse  # type: ignore
 from .client import APIClient
 from .core import APIConnectionError
 from .model import EntityInfo, EntityState, LogLevel
+from .model_conversions import STATE_TYPE_TO_INFO_TYPE
 from .reconnect_logic import ReconnectLogic
 from .state_log_formatter import format_state_log
 
@@ -110,7 +111,12 @@ async def _subscribe_entity_states(
     to avoid flooding the log with all current values.
     """
     _, entities, _ = await cli.device_info_and_list_entities()
-    entity_info: dict[int, EntityInfo] = {e.key: e for e in entities}
+    # Key by (info_type, device_id, key) so that two entities of different
+    # types on the same device sharing an entity key hash (e.g. a climate
+    # and a water_heater with the same name) don't overwrite each other.
+    entity_info: dict[tuple[type[EntityInfo], int, int], EntityInfo] = {
+        (type(e), e.device_id, e.key): e for e in entities
+    }
     seen_keys: set[tuple[int, int]] = set()
 
     def on_state(state: EntityState) -> None:
@@ -121,7 +127,12 @@ async def _subscribe_entity_states(
             # Skip initial state dump on connect
             seen_keys.add(state_id)
             return
-        info = entity_info.get(state.key)
+        info_type = STATE_TYPE_TO_INFO_TYPE.get(type(state))
+        info = (
+            entity_info.get((info_type, state.device_id, state.key))
+            if info_type is not None
+            else None
+        )
         text = format_state_log(state, info)
         if text is not None:
             msg = SubscribeLogsResponse()

--- a/aioesphomeapi/model_conversions.py
+++ b/aioesphomeapi/model_conversions.py
@@ -104,6 +104,31 @@ from .model import (
     WaterHeaterState,
 )
 
+STATE_TYPE_TO_INFO_TYPE: dict[type[EntityState], type[EntityInfo]] = {
+    AlarmControlPanelEntityState: AlarmControlPanelInfo,
+    BinarySensorState: BinarySensorInfo,
+    ClimateState: ClimateInfo,
+    CoverState: CoverInfo,
+    DateState: DateInfo,
+    DateTimeState: DateTimeInfo,
+    Event: EventInfo,
+    FanState: FanInfo,
+    LightState: LightInfo,
+    LockEntityState: LockInfo,
+    MediaPlayerEntityState: MediaPlayerInfo,
+    NumberState: NumberInfo,
+    SelectState: SelectInfo,
+    SensorState: SensorInfo,
+    SirenState: SirenInfo,
+    SwitchState: SwitchInfo,
+    TextSensorState: TextSensorInfo,
+    TextState: TextInfo,
+    TimeState: TimeInfo,
+    UpdateState: UpdateInfo,
+    ValveState: ValveInfo,
+    WaterHeaterState: WaterHeaterInfo,
+}
+
 SUBSCRIBE_STATES_RESPONSE_TYPES: dict[Any, type[EntityState]] = {
     AlarmControlPanelStateResponse: AlarmControlPanelEntityState,
     BinarySensorStateResponse: BinarySensorState,

--- a/aioesphomeapi/model_conversions.py
+++ b/aioesphomeapi/model_conversions.py
@@ -104,31 +104,6 @@ from .model import (
     WaterHeaterState,
 )
 
-STATE_TYPE_TO_INFO_TYPE: dict[type[EntityState], type[EntityInfo]] = {
-    AlarmControlPanelEntityState: AlarmControlPanelInfo,
-    BinarySensorState: BinarySensorInfo,
-    ClimateState: ClimateInfo,
-    CoverState: CoverInfo,
-    DateState: DateInfo,
-    DateTimeState: DateTimeInfo,
-    Event: EventInfo,
-    FanState: FanInfo,
-    LightState: LightInfo,
-    LockEntityState: LockInfo,
-    MediaPlayerEntityState: MediaPlayerInfo,
-    NumberState: NumberInfo,
-    SelectState: SelectInfo,
-    SensorState: SensorInfo,
-    SirenState: SirenInfo,
-    SwitchState: SwitchInfo,
-    TextSensorState: TextSensorInfo,
-    TextState: TextInfo,
-    TimeState: TimeInfo,
-    UpdateState: UpdateInfo,
-    ValveState: ValveInfo,
-    WaterHeaterState: WaterHeaterInfo,
-}
-
 SUBSCRIBE_STATES_RESPONSE_TYPES: dict[Any, type[EntityState]] = {
     AlarmControlPanelStateResponse: AlarmControlPanelEntityState,
     BinarySensorStateResponse: BinarySensorState,
@@ -182,3 +157,25 @@ LIST_ENTITIES_SERVICES_RESPONSE_TYPES: dict[Any, type[EntityInfo] | None] = {
     ListEntitiesValveResponse: ValveInfo,
     ListEntitiesWaterHeaterResponse: WaterHeaterInfo,
 }
+
+
+def _build_state_type_to_info_type() -> dict[type[EntityState], type[EntityInfo]]:
+    # Proto naming pairs each state response with a list-entities response by
+    # a common stem: "{X}StateResponse" or "EventResponse" on the state side,
+    # and "ListEntities{X}Response" on the info side.
+    info_by_stem: dict[str, type[EntityInfo]] = {
+        resp.__name__.removeprefix("ListEntities").removesuffix("Response"): info
+        for resp, info in LIST_ENTITIES_SERVICES_RESPONSE_TYPES.items()
+        if info is not None
+    }
+    return {
+        state_cls: info_by_stem[
+            resp.__name__.removesuffix("StateResponse").removesuffix("Response")
+        ]
+        for resp, state_cls in SUBSCRIBE_STATES_RESPONSE_TYPES.items()
+    }
+
+
+STATE_TYPE_TO_INFO_TYPE: dict[type[EntityState], type[EntityInfo]] = (
+    _build_state_type_to_info_type()
+)

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -26,6 +26,8 @@ from aioesphomeapi.model import (
     SensorInfo,
     SensorState,
     WaterHeaterInfo,
+    WaterHeaterMode,
+    WaterHeaterState,
 )
 from aioesphomeapi.reconnect_logic import EXPECTED_DISCONNECT_COOLDOWN, ReconnectLogic
 
@@ -399,7 +401,9 @@ async def test_async_run_with_colliding_entity_keys_across_types() -> None:
 
     assert state_callback is not None
 
-    # Skip initial state dump (first state per (device_id, key))
+    # Each entity type gets its own initial-dump skip; the second entity's
+    # first real state must not be swallowed just because (device_id, key)
+    # was already seen for the other type.
     state_callback(
         ClimateState(
             key=1,
@@ -408,7 +412,15 @@ async def test_async_run_with_colliding_entity_keys_across_types() -> None:
             target_temperature=22.0,
         )
     )
+    state_callback(WaterHeaterState(key=1, mode=WaterHeaterMode.HEAT_PUMP))
     assert len(log_messages) == 0
+
+    # WaterHeaterState with key=1 must resolve to WaterHeaterInfo (not the
+    # ClimateInfo that was listed first for the same key), proving ordering
+    # does not matter.
+    state_callback(WaterHeaterState(key=1, mode=WaterHeaterMode.HEAT_PUMP))
+    assert len(log_messages) == 1
+    assert "[S][water_heater]: 'Water Heater' >>" in log_messages[0].message.decode()
 
     # ClimateState must not crash on WaterHeaterInfo-specific fields and
     # must render as a climate line (proves the correct info was selected).
@@ -420,8 +432,8 @@ async def test_async_run_with_colliding_entity_keys_across_types() -> None:
             target_temperature=22.0,
         )
     )
-    assert len(log_messages) == 1
-    text = log_messages[0].message.decode()
+    assert len(log_messages) == 2
+    text = log_messages[1].message.decode()
     assert "[S][climate]: 'Water Heater' >>" in text
     assert "Mode: HEAT" in text
     assert "Current Temperature: 20.50" in text

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -18,7 +18,15 @@ from aioesphomeapi.client import APIClient
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.core import APIConnectionError
 from aioesphomeapi.log_runner import async_run
-from aioesphomeapi.model import LogLevel, SensorInfo, SensorState
+from aioesphomeapi.model import (
+    ClimateInfo,
+    ClimateMode,
+    ClimateState,
+    LogLevel,
+    SensorInfo,
+    SensorState,
+    WaterHeaterInfo,
+)
 from aioesphomeapi.reconnect_logic import EXPECTED_DISCONNECT_COOLDOWN, ReconnectLogic
 
 from .common import (
@@ -340,6 +348,83 @@ async def test_async_run_with_subscribe_states() -> None:
     assert "[S][sensor]:" in text
     assert "'CO2' >> 421 ppm" in text
     assert "\033[0;96m" in text
+
+    await stop()
+
+
+async def test_async_run_with_colliding_entity_keys_across_types() -> None:
+    """Two entities of different types sharing a device_id+key must each
+    resolve to their own info in the log runner.
+
+    Reproducer: a climate and a water_heater on the same device with names
+    that hash to the same entity key (e.g. both named "Water Heater" in an
+    external component). The on-wire key is platform-agnostic so both
+    entities ship with the same key; the log runner must still dispatch each
+    state to the info of the matching type rather than last-write-wins.
+    """
+    log_messages: list[SubscribeLogsResponse] = []
+    state_callback = None
+
+    climate_info = ClimateInfo(
+        key=1, name="Water Heater", supports_two_point_target_temperature=False
+    )
+    water_heater_info = WaterHeaterInfo(key=1, name="Water Heater")
+
+    cli = MagicMock(spec=APIClient)
+    cli.device_info_and_list_entities = AsyncMock(
+        return_value=(MagicMock(), [climate_info, water_heater_info], [])
+    )
+
+    def capture_subscribe_states(cb: object) -> None:
+        nonlocal state_callback
+        state_callback = cb
+
+    cli.subscribe_states = capture_subscribe_states
+
+    on_connect_callback = None
+
+    class MockReconnectLogic(ReconnectLogic):
+        def __init__(self, *, on_connect, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal on_connect_callback
+            on_connect_callback = on_connect
+
+        async def start(self) -> None:
+            await on_connect_callback()
+
+        async def stop(self) -> None:
+            pass
+
+    with patch("aioesphomeapi.log_runner.ReconnectLogic", MockReconnectLogic):
+        stop = await async_run(cli, log_messages.append, subscribe_states=True)
+
+    assert state_callback is not None
+
+    # Skip initial state dump (first state per (device_id, key))
+    state_callback(
+        ClimateState(
+            key=1,
+            mode=ClimateMode.HEAT,
+            current_temperature=20.0,
+            target_temperature=22.0,
+        )
+    )
+    assert len(log_messages) == 0
+
+    # ClimateState must not crash on WaterHeaterInfo-specific fields and
+    # must render as a climate line (proves the correct info was selected).
+    state_callback(
+        ClimateState(
+            key=1,
+            mode=ClimateMode.HEAT,
+            current_temperature=20.5,
+            target_temperature=22.0,
+        )
+    )
+    assert len(log_messages) == 1
+    text = log_messages[0].message.decode()
+    assert "[S][climate]: 'Water Heater' >>" in text
+    assert "Mode: HEAT" in text
+    assert "Current Temperature: 20.50" in text
 
     await stop()
 

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -441,6 +441,56 @@ async def test_async_run_with_colliding_entity_keys_across_types() -> None:
     await stop()
 
 
+async def test_async_run_warns_on_unmapped_state_type(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unmapped state type (future protobuf addition without a
+    STATE_TYPE_TO_INFO_TYPE entry) must warn rather than silently pass
+    info=None to the formatter.
+    """
+    log_messages: list[SubscribeLogsResponse] = []
+    state_callback = None
+
+    cli = MagicMock(spec=APIClient)
+    cli.device_info_and_list_entities = AsyncMock(return_value=(MagicMock(), [], []))
+
+    def capture_subscribe_states(cb: object) -> None:
+        nonlocal state_callback
+        state_callback = cb
+
+    cli.subscribe_states = capture_subscribe_states
+
+    on_connect_callback = None
+
+    class MockReconnectLogic(ReconnectLogic):
+        def __init__(self, *, on_connect, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal on_connect_callback
+            on_connect_callback = on_connect
+
+        async def start(self) -> None:
+            await on_connect_callback()
+
+        async def stop(self) -> None:
+            pass
+
+    class UnmappedState(SensorState):
+        """Stand-in for a future state type with no mapping entry."""
+
+    with patch("aioesphomeapi.log_runner.ReconnectLogic", MockReconnectLogic):
+        stop = await async_run(cli, log_messages.append, subscribe_states=True)
+
+    assert state_callback is not None
+
+    # Skip initial dump, then deliver an unmapped state type.
+    state_callback(UnmappedState(key=1, state=1.0))
+    caplog.clear()
+    state_callback(UnmappedState(key=1, state=2.0))
+
+    assert "No EntityInfo type mapping for state UnmappedState" in caplog.text
+
+    await stop()
+
+
 async def test_async_run_with_subscribe_states_suppresses_on_verbose() -> None:
     """Test that verbose firmware logs suppress synthetic state lines."""
     log_messages: list[SubscribeLogsResponse] = []

--- a/tests/test_model_conversions.py
+++ b/tests/test_model_conversions.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from aioesphomeapi.model_conversions import (
+    STATE_TYPE_TO_INFO_TYPE,
+    SUBSCRIBE_STATES_RESPONSE_TYPES,
+)
+
+
+def test_state_type_to_info_type_covers_all_state_types() -> None:
+    """Every state type the client decodes must have an info type mapping,
+    otherwise log_runner falls back to info=None and formatting degrades.
+    """
+    state_types = set(SUBSCRIBE_STATES_RESPONSE_TYPES.values())
+    missing = state_types - STATE_TYPE_TO_INFO_TYPE.keys()
+    assert not missing, f"STATE_TYPE_TO_INFO_TYPE is missing: {missing}"


### PR DESCRIPTION
# What does this implement/fix?

Two entities of different types on the same device can ship with the same on-wire entity key, since the key hash is derived from the object_id and does not mix in the platform. The log runner was flattening its info lookup to `{e.key: e for e in entities}`, so the later entry would overwrite the earlier one; a `ClimateState` could then be paired with a `WaterHeaterInfo` and crash `_format_climate` on a type specific attribute, which tears down the log connection in a reconnect loop.

This keys the info lookup by `(type(info), device_id, key)` and uses a new `STATE_TYPE_TO_INFO_TYPE` mapping to resolve the expected info type for each incoming state, so each entity resolves to its own info regardless of key collisions across types. This mirrors how Home Assistant already stores esphome entity info.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1588

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).