### PR TITLE
Silence log_runner warning for CameraState

### DIFF
--- a/aioesphomeapi/model_conversions.py
+++ b/aioesphomeapi/model_conversions.py
@@ -59,6 +59,7 @@ from .model import (
     BinarySensorState,
     ButtonInfo,
     CameraInfo,
+    CameraState,
     ClimateInfo,
     ClimateState,
     CoverInfo,
@@ -168,12 +169,16 @@ def _build_state_type_to_info_type() -> dict[type[EntityState], type[EntityInfo]
         for resp, info in LIST_ENTITIES_SERVICES_RESPONSE_TYPES.items()
         if info is not None
     }
-    return {
+    mapping: dict[type[EntityState], type[EntityInfo]] = {
         state_cls: info_by_stem[
             resp.__name__.removesuffix("StateResponse").removesuffix("Response")
         ]
         for resp, state_cls in SUBSCRIBE_STATES_RESPONSE_TYPES.items()
     }
+    # CameraState is derived from CameraImageResponse (not a subscribe-state
+    # response), so it won't be picked up by the loop above.
+    mapping[CameraState] = CameraInfo
+    return mapping
 
 
 STATE_TYPE_TO_INFO_TYPE: dict[type[EntityState], type[EntityInfo]] = (

--- a/tests/test_model_conversions.py
+++ b/tests/test_model_conversions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from aioesphomeapi.model import CameraInfo, CameraState
 from aioesphomeapi.model_conversions import (
     STATE_TYPE_TO_INFO_TYPE,
     SUBSCRIBE_STATES_RESPONSE_TYPES,
@@ -13,3 +14,12 @@ def test_state_type_to_info_type_covers_all_state_types() -> None:
     state_types = set(SUBSCRIBE_STATES_RESPONSE_TYPES.values())
     missing = state_types - STATE_TYPE_TO_INFO_TYPE.keys()
     assert not missing, f"STATE_TYPE_TO_INFO_TYPE is missing: {missing}"
+
+
+def test_state_type_to_info_type_includes_camera_state() -> None:
+    """CameraState is produced from CameraImageResponse rather than a
+    subscribe-state response, so it is not picked up by the auto-built
+    mapping and must be added explicitly. Without this entry, log_runner
+    warns on every camera frame.
+    """
+    assert STATE_TYPE_TO_INFO_TYPE[CameraState] is CameraInfo


### PR DESCRIPTION
# What does this implement/fix?

CameraState comes from CameraImageResponse rather than from a regular state response, so it was missing from STATE_TYPE_TO_INFO_TYPE; every camera frame was emitting a spurious WARNING with no informational benefit, since format_state_log has no camera formatter anyway.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).