### PR TITLE
Lock closed issues and PRs daily

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,11 @@
+---
+name: Lock closed issues and PRs
+
+on:
+  schedule:
+    - cron: "30 0 * * *"  # Run daily at 00:30 UTC
+  workflow_dispatch:
+
+jobs:
+  lock:
+    uses: esphome/workflows/.github/workflows/lock.yml@3c4e8446aa1029f1c346a482034b3ee1489077ca  # 2026.4.0


### PR DESCRIPTION
# What does this implement/fix?

Adds a scheduled workflow that locks closed issues and PRs so drive-by comments on already-merged work stop flooding maintainer inboxes. Reuses the existing `esphome/workflows/lock.yml@2026.4.0` workflow already in use by the main `esphome/esphome` repo, keeping behavior consistent across repos. Defaults lock closed PRs after 1 day, closed issues after 7 days, and respect the `keep-open` exclude label.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).