### PR TITLE
Expose the bound `APIClient` event loop with `.loop`

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -336,6 +336,10 @@ class APIClientBase:
         self._params.expected_name = value
 
     @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return self._loop
+
+    @property
     def address(self) -> str:
         return self._params.addresses[0]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1562,6 +1562,7 @@ async def test_client_properties(
     assert client.port == 6052
     assert client.noise_psk is None
     assert client.api_version == APIVersion(major=1, minor=9)
+    assert client.loop is asyncio.get_running_loop()
 
 
 async def test_bluetooth_disconnect(


### PR DESCRIPTION
# What does this implement/fix?
serialx accepts `aioesphomeapi.APIClient` instances and currently accesses the internal `._loop` attribute to be able to properly detect cross-loop interaction. It would be nice if this was a public API.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
