### PR TITLE
Fix `LockState::UNLOCKED` duplicate value

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -924,7 +924,7 @@ class ButtonInfo(EntityInfo):
 class LockState(APIIntEnum):
     NONE = 0
     LOCKED = 1
-    UNLOCKED = 3
+    UNLOCKED = 2
     JAMMED = 3
     LOCKING = 4
     UNLOCKING = 5

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -121,6 +121,7 @@ from aioesphomeapi.model import (
     LightState,
     LockEntityState,
     LockInfo,
+    LockState,
     MediaPlayerEntityFeature,
     MediaPlayerEntityState,
     MediaPlayerInfo,
@@ -2282,3 +2283,11 @@ def test_climate_info_unknown_temperature_unit_converts_to_none() -> None:
 def test_water_heater_info_unknown_temperature_unit_converts_to_none() -> None:
     info = WaterHeaterInfo(temperature_unit=999)
     assert info.temperature_unit is None
+
+
+def test_lock_state_enum_is_dense_and_unique() -> None:
+    values = [member.value for member in LockState]
+    assert len(values) == len(set(values)), f"LockState has duplicate values: {values}"
+    assert values == list(range(len(values))), (
+        f"LockState must be contiguous from 0; got {values}"
+    )


### PR DESCRIPTION
# What does this implement/fix?

### Brought back to consistency with ESPHome.

* Discovered by CodeRabbit in https://github.com/esphome/aioesphomeapi/pull/1599#discussion_r3122305263

Probably was a typo.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).