### PR TITLE
Add opt-in plaintext fallback for log streams in ReconnectLogic

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -351,6 +351,16 @@ class APIClientBase:
     def noise_psk(self) -> str | None:
         return self._params.noise_psk
 
+    def clear_noise_psk(self) -> None:
+        """Clear the noise PSK so future connections use plaintext.
+
+        This is a security downgrade — callers must only invoke it after
+        explicit opt-in (e.g. ``ReconnectLogic(allow_plaintext_fallback=
+        True)`` for a one-way logger stream). Never call it for control-
+        plane clients such as Home Assistant.
+        """
+        self._params.noise_psk = None
+
     @property
     def connected_address(self) -> str | None:
         """Return the address we are currently connected to, or None if not connected."""

--- a/aioesphomeapi/log_reader.py
+++ b/aioesphomeapi/log_reader.py
@@ -25,6 +25,15 @@ async def main(argv: list[str]) -> None:
         action="store_true",
         help="Do not show entity state changes in log output.",
     )
+    parser.add_argument(
+        "--allow-plaintext-fallback",
+        action="store_true",
+        help=(
+            "If --noise-psk is set and the device is running plaintext "
+            "firmware, downgrade to plaintext (with a warning) instead of "
+            "failing repeatedly."
+        ),
+    )
     parser.add_argument("address")
     args = parser.parse_args(argv[1:])
 
@@ -55,7 +64,12 @@ async def main(argv: list[str]) -> None:
         for line in parse_log_message(text, timestamp):
             print(line)
 
-    stop = await async_run(cli, on_log, subscribe_states=not args.no_states)
+    stop = await async_run(
+        cli,
+        on_log,
+        subscribe_states=not args.no_states,
+        allow_plaintext_fallback=args.allow_plaintext_fallback,
+    )
     try:
         await asyncio.Event().wait()
     finally:

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -29,10 +29,21 @@ async def async_run(
     dump_config: bool = True,
     name: str | None = None,
     subscribe_states: bool = True,
+    allow_plaintext_fallback: bool = False,
 ) -> Callable[[], Coroutine[Any, Any, None]]:
     """Run logs until canceled.
 
     Returns a coroutine that can be awaited to stop the logs.
+
+    If ``allow_plaintext_fallback`` is True, the client will downgrade to
+    plaintext (and log a warning) when connecting with a PSK to a device
+    running plaintext firmware, instead of failing repeatedly. Defaults
+    to False so callers must opt in.
+
+    The logger stream is one-way (device → client), so enabling the
+    fallback here only exposes log output to an on-path attacker — no
+    commands or secrets are sent. Do not enable the equivalent flag on
+    control-plane connections (e.g. Home Assistant).
     """
     dumped_config = not dump_config
 
@@ -63,6 +74,7 @@ async def async_run(
         on_disconnect=on_disconnect,
         zeroconf_instance=aio_zeroconf_instance,
         name=name,
+        allow_plaintext_fallback=allow_plaintext_fallback,
     )
     await logic.start()
 

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -274,7 +274,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             # use plaintext; warn so the caller sees that it happened.
             _LOGGER.warning(
                 "%s: Device is using plaintext protocol; disabling "
-                "encryption for this session and retrying",
+                "encryption for this session and retrying. The device's "
+                "identity cannot be verified without encryption, so this "
+                "session may be talking to a different device.",
                 self._cli.log_name,
             )
             self._cli.clear_noise_psk()

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -17,6 +17,7 @@ from .client import APIClient
 from .core import (
     APIConnectionCancelledError,
     APIConnectionError,
+    EncryptionPlaintextAPIError,
     InvalidAuthAPIError,
     InvalidEncryptionKeyAPIError,
     RequiresEncryptionAPIError,
@@ -74,12 +75,25 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         zeroconf_instance: ZeroconfInstanceType | None = None,
         name: str | None = None,
         on_connect_error: Callable[[Exception], Awaitable[None]] | None = None,
+        allow_plaintext_fallback: bool = False,
     ) -> None:
         """Initialize ReconnectingLogic.
 
         :param client: initialized :class:`APIClient` to reconnect for
         :param on_connect: Coroutine Function to call when connected.
         :param on_disconnect: Coroutine Function to call when disconnected.
+        :param allow_plaintext_fallback: If True and the client has a noise
+            PSK configured, downgrade to plaintext (and log a warning) when
+            the device responds with the plaintext protocol marker, instead
+            of failing repeatedly. Defaults to False so callers must opt in.
+
+            This is a security downgrade: an attacker on the network can
+            impersonate the device in plaintext and strip encryption. Only
+            enable it for connections that are read-only from the client's
+            side — e.g. the logger stream, which only receives data from
+            the device and never sends commands or secrets. Do not enable
+            it for Home Assistant or any integration that issues commands
+            to the device.
         """
         self.loop = asyncio.get_running_loop()
         self._cli = client
@@ -94,6 +108,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._on_connect_cb = on_connect
         self._on_disconnect_cb = on_disconnect
         self._on_connect_error_cb = on_connect_error
+        self._allow_plaintext_fallback = allow_plaintext_fallback
         self._zeroconf_manager = client.zeroconf_manager
         if zeroconf_instance is not None:
             self._zeroconf_manager.set_instance(zeroconf_instance)
@@ -249,6 +264,22 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         if self._on_connect_error_cb is not None:
             await self._on_connect_error_cb(err)
         self._async_log_connection_error(err)
+        if (
+            self._allow_plaintext_fallback
+            and isinstance(err, EncryptionPlaintextAPIError)
+            and self._cli.noise_psk is not None
+        ):
+            # Device firmware is running plaintext but the client has a
+            # PSK configured. Downgrade so subsequent reconnect attempts
+            # use plaintext; warn so the caller sees that it happened.
+            _LOGGER.warning(
+                "%s: Device is using plaintext protocol; disabling "
+                "encryption for this session and retrying",
+                self._cli.log_name,
+            )
+            self._cli.clear_noise_psk()
+            self._tries = 0
+            return
         if isinstance(err, AUTH_EXCEPTIONS):
             # If we get an encryption or password error,
             # backoff for the maximum amount of time

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -18,7 +18,11 @@ from zeroconf import (
 from zeroconf.asyncio import AsyncZeroconf
 from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR
 
-from aioesphomeapi import APIConnectionError, RequiresEncryptionAPIError
+from aioesphomeapi import (
+    APIConnectionError,
+    EncryptionPlaintextAPIError,
+    RequiresEncryptionAPIError,
+)
 from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.client import APIClient
 from aioesphomeapi.core import APIConnectionCancelledError
@@ -1229,6 +1233,104 @@ async def test_backoff_on_encryption_error(
     assert logic._connect_timer.when() - now == pytest.approx(60, 1)
     assert logic._tries == MAXIMUM_BACKOFF_TRIES
     await logic.stop()
+
+
+@pytest.mark.asyncio
+async def test_plaintext_fallback_disabled_by_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """EncryptionPlaintextAPIError does not downgrade when flag is off."""
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    async_zeroconf = get_mock_async_zeroconf()
+    cli = PatchableAPIClient(
+        address="127.0.0.1",
+        port=6052,
+        password=None,
+        noise_psk="BASE64KEY",
+        zeroconf_instance=async_zeroconf.zeroconf,
+    )
+
+    async def on_connect() -> None: ...
+    async def on_disconnect(expected_disconnect: bool) -> None: ...
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        zeroconf_instance=async_zeroconf,
+        name="fake",
+    )
+
+    with (
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection"),
+        patch.object(
+            cli,
+            "finish_connection",
+            side_effect=EncryptionPlaintextAPIError("plaintext"),
+        ),
+    ):
+        await rl.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert cli.noise_psk == "BASE64KEY"
+    # Non-auth error: tries increments by 1, no max backoff.
+    assert rl._tries == 1
+    assert "disabling encryption" not in caplog.text
+    await rl.stop()
+
+
+@pytest.mark.asyncio
+async def test_plaintext_fallback_downgrades_when_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With opt-in, plaintext protocol downgrades the PSK and resets tries."""
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    async_zeroconf = get_mock_async_zeroconf()
+    cli = PatchableAPIClient(
+        address="127.0.0.1",
+        port=6052,
+        password=None,
+        noise_psk="BASE64KEY",
+        zeroconf_instance=async_zeroconf.zeroconf,
+    )
+
+    async def on_connect() -> None: ...
+    async def on_disconnect(expected_disconnect: bool) -> None: ...
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        zeroconf_instance=async_zeroconf,
+        name="fake",
+        allow_plaintext_fallback=True,
+    )
+
+    with (
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection"),
+        patch.object(
+            cli,
+            "finish_connection",
+            side_effect=EncryptionPlaintextAPIError("plaintext"),
+        ),
+    ):
+        await rl.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert cli.noise_psk is None
+    assert rl._tries == 0
+    assert "Device is using plaintext protocol" in caplog.text
+    await rl.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

If a device is flashed with firmware that no longer has the API encryption key, a client configured with a PSK will fail the Noise handshake with EncryptionPlaintextAPIError and keep retrying forever. This adds an opt-in allow_plaintext_fallback flag to ReconnectLogic (plumbed through async_run and the log_reader CLI), so log-stream callers like the ESPHome CLI logs command can downgrade to plaintext and log a warning instead of looping.

The flag defaults to False so existing callers are unaffected; Home Assistant and any other control-plane consumer keep the strict behavior. The logger stream is one-way from device to client, so enabling the fallback there only exposes log output to an on-path attacker, not commands or secrets.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).