### PR TITLE
Add missing mapping for water_heater in COMPONENT_TYPE_TO_INFO

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1384,6 +1384,7 @@ COMPONENT_TYPE_TO_INFO: dict[str, type[EntityInfo]] = {
     "valve": ValveInfo,
     "event": EventInfo,
     "update": UpdateInfo,
+    "water_heater": WaterHeaterInfo,
     "infrared": InfraredInfo,
     "radio_frequency": RadioFrequencyInfo,
 }

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -78,6 +78,7 @@ from aioesphomeapi.api_pb2 import (
 )
 from aioesphomeapi.model import (
     _TYPE_TO_NAME,
+    COMPONENT_TYPE_TO_INFO,
     AlarmControlPanelEntityState,
     AlarmControlPanelInfo,
     APIIntEnum,
@@ -106,6 +107,7 @@ from aioesphomeapi.model import (
     DateTimeInfo,
     DateTimeState,
     DeviceInfo,
+    EntityInfo,
     EntityState,
     Event,
     EventInfo,
@@ -2349,4 +2351,21 @@ def test_lock_state_enum_is_dense_and_unique() -> None:
     assert len(values) == len(set(values)), f"LockState has duplicate values: {values}"
     assert values == list(range(len(values))), (
         f"LockState must be contiguous from 0; got {values}"
+    )
+
+
+def test_all_entity_info_subclasses_registered() -> None:
+    """Every EntityInfo subclass must be registered in COMPONENT_TYPE_TO_INFO
+    and _TYPE_TO_NAME so external consumers (e.g. Home Assistant) and unique-id
+    generation can resolve every entity type."""
+    subclass_names = {cls.__name__ for cls in EntityInfo.__subclasses__()}
+    component_names = {cls.__name__ for cls in COMPONENT_TYPE_TO_INFO.values()}
+    type_to_name_names = {cls.__name__ for cls in _TYPE_TO_NAME}
+    assert subclass_names <= component_names, (
+        f"EntityInfo subclasses missing from COMPONENT_TYPE_TO_INFO: "
+        f"{sorted(subclass_names - component_names)}"
+    )
+    assert subclass_names <= type_to_name_names, (
+        f"EntityInfo subclasses missing from _TYPE_TO_NAME: "
+        f"{sorted(subclass_names - type_to_name_names)}"
     )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add missing mapping for water_heater in COMPONENT_TYPE_TO_INFO to fix #1631

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #1631

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
