### PR TITLE
Lower cryptography requirement to 47+

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,5 @@ protobuf>=6,<8
 tzlocal>=5.3.1,<6
 zeroconf>=0.148.0,<2.0
 chacha20poly1305-reuseable>=0.13.2
-cryptography>=48.0.0
+cryptography>=47.0.0
 noiseprotocol>=0.3.1,<1.0


### PR DESCRIPTION

# What does this implement/fix?

HA is pinned to 47 right now

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
