### PR TITLE
Run pytest in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           name: genrated-proto-files
           path: aioesphomeapi/*pb2.py
         if: ${{ failure() && matrix.python-version == '3.14' && matrix.extension == 'skip_cython' && matrix.os == 'ubuntu-latest' }}
-      - run: pytest -vv --cov=aioesphomeapi --cov-report=xml --timeout=4 --tb=native tests
+      - run: pytest -q -n auto --cov=aioesphomeapi --cov-report=xml --timeout=4 --tb=native --ignore=tests/benchmarks tests
         name: Run tests with pytest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,3 +9,4 @@ pytest-asyncio==1.3.0
 pytest-codspeed==4.5.0
 pytest-cov>=7.1.0
 pytest-timeout==2.4.0
+pytest-xdist==3.8.0


### PR DESCRIPTION
# What does this implement/fix?

CI test runs are serial today, which makes the matrix slow; this enables pytest-xdist with `-n auto` so the suite spreads across all logical CPUs on each runner. Benchmarks stay in their separate CodSpeed job and are excluded from the parallel run via `--ignore=tests/benchmarks` so their timings remain comparable.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).