### PR TITLE
Suppress unretrieved Future exception warning in singleton

### DIFF
--- a/aioesphomeapi/singleton.py
+++ b/aioesphomeapi/singleton.py
@@ -41,6 +41,9 @@ def singleton(
                     # On exception, remove the future so next call can retry
                     # Set exception first so waiters get it, then remove from cache
                     future.set_exception(e)
+                    # Suppress "Future exception was never retrieved" when there
+                    # are no concurrent waiters; awaiters still receive it.
+                    future.exception()
                     del _SINGLETON_CACHE[key]
                     raise
                 else:


### PR DESCRIPTION
# What does this implement/fix?

When a function decorated with `@singleton` raises and no concurrent waiters are attached, the placeholder future is garbage collected with its exception unretrieved, so asyncio logs a noisy "Future exception was never retrieved" line during CI runs (visible in `test_singleton_with_exception`). Calling `future.exception()` right after `set_exception` consumes the traceback flag without affecting waiters, who still receive the exception via `await`.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).