### PR TITLE
Add benchmarks for hot paths affecting real users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,4 +151,4 @@ jobs:
         with:
           mode: instrumentation
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: pytest tests/benchmarks --codspeed
+          run: pytest tests/benchmarks --codspeed --durations=10

--- a/tests/benchmarks/helpers.py
+++ b/tests/benchmarks/helpers.py
@@ -1,0 +1,51 @@
+"""Shared helpers for the benchmark suite."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+from google.protobuf import message
+
+from aioesphomeapi import APIConnection
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.client_base import on_state_msg
+
+
+def noop(msg: object) -> None:
+    """No-op message callback."""
+
+
+def make_connection() -> APIConnection:
+    """Build an APIConnection suitable for benchmarking process_packet."""
+    client = APIClient("fake.address", 6052, None)
+    return APIConnection(client._params, lambda expected_disconnect: None, False, None)
+
+
+def bench_process_packet(
+    msg: message.Message,
+    msg_type: int,
+    handler: Callable[[Any], None] | None = None,
+) -> Callable[[], None]:
+    """Return a 0-arg callable that drives APIConnection.process_packet.
+
+    A fresh connection is created and ``handler`` (default: no-op) is
+    registered for the message's protobuf type. Bytes are serialized once;
+    each invocation only exercises the receive path.
+    """
+    data = msg.SerializeToString()
+    connection = make_connection()
+    connection.add_message_callback(handler or noop, (type(msg),))
+    return partial(connection.process_packet, msg_type, data)
+
+
+def bench_state_process_packet(
+    msg: message.Message, msg_type: int
+) -> Callable[[], None]:
+    """Build a process_packet bench wired through ``on_state_msg``.
+
+    Mirrors what ``APIClient.subscribe_states`` does, so the benchmark covers
+    the full user-visible path from packet bytes to ``EntityState`` object.
+    """
+    return bench_process_packet(msg, msg_type, partial(on_state_msg, noop, {}))

--- a/tests/benchmarks/test_list_entities.py
+++ b/tests/benchmarks/test_list_entities.py
@@ -1,0 +1,233 @@
+"""Benchmarks for ListEntities response decoding.
+
+When Home Assistant connects (or reconnects) to an ESPHome device, every
+entity definition is sent as a ``ListEntities*Response``. Devices with many
+entities (Bluetooth proxies, status panels, multi-sensor boards) make HA
+startup feel slow if this path regresses.
+
+These cover both ``process_packet`` (parse + dispatch) and the subsequent
+``EntityInfo.from_pb`` conversion that the client does after collecting all
+list-entities messages.
+"""
+
+from functools import partial
+
+from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+
+from aioesphomeapi import APIConnection
+from aioesphomeapi.api_pb2 import (
+    ListEntitiesBinarySensorResponse,
+    ListEntitiesClimateResponse,
+    ListEntitiesLightResponse,
+    ListEntitiesSensorResponse,
+    ListEntitiesSwitchResponse,
+)
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.model import (
+    BinarySensorInfo,
+    ClimateInfo,
+    LightInfo,
+    SensorInfo,
+    SwitchInfo,
+)
+
+
+def _make_connection() -> APIConnection:
+    client = APIClient("fake.address", 6052, None)
+    return APIConnection(client._params, lambda expected_disconnect: None, False, None)
+
+
+def _noop(msg: object) -> None:
+    """No-op callback."""
+
+
+def _build_sensor_info() -> ListEntitiesSensorResponse:
+    return ListEntitiesSensorResponse(
+        object_id="living_room_temperature",
+        key=12345678,
+        name="Living Room Temperature",
+        icon="mdi:thermometer",
+        unit_of_measurement="°C",
+        accuracy_decimals=2,
+        force_update=False,
+        device_class="temperature",
+        state_class=1,
+        disabled_by_default=False,
+        entity_category=0,
+    )
+
+
+def _build_binary_sensor_info() -> ListEntitiesBinarySensorResponse:
+    return ListEntitiesBinarySensorResponse(
+        object_id="motion_sensor",
+        key=12345679,
+        name="Motion Sensor",
+        device_class="motion",
+        is_status_binary_sensor=False,
+        disabled_by_default=False,
+        icon="mdi:motion-sensor",
+        entity_category=0,
+    )
+
+
+def _build_switch_info() -> ListEntitiesSwitchResponse:
+    return ListEntitiesSwitchResponse(
+        object_id="relay_1",
+        key=12345680,
+        name="Relay 1",
+        icon="mdi:power-socket",
+        assumed_state=False,
+        disabled_by_default=False,
+        entity_category=0,
+        device_class="outlet",
+    )
+
+
+def _build_light_info() -> ListEntitiesLightResponse:
+    return ListEntitiesLightResponse(
+        object_id="rgbww_light",
+        key=12345681,
+        name="RGBWW Light",
+        supported_color_modes=[1, 3, 11, 35, 47],
+        min_mireds=153.0,
+        max_mireds=500.0,
+        effects=["None", "Rainbow", "Color Wipe", "Random", "Strobe"],
+        legacy_supports_brightness=True,
+        legacy_supports_rgb=True,
+        legacy_supports_white_value=True,
+        legacy_supports_color_temperature=True,
+        disabled_by_default=False,
+        icon="mdi:lightbulb",
+        entity_category=0,
+    )
+
+
+def _build_climate_info() -> ListEntitiesClimateResponse:
+    return ListEntitiesClimateResponse(
+        object_id="hvac",
+        key=12345682,
+        name="HVAC",
+        supports_current_temperature=True,
+        supports_two_point_target_temperature=True,
+        supported_modes=[0, 1, 2, 3, 4, 5],
+        visual_min_temperature=10.0,
+        visual_max_temperature=32.0,
+        visual_target_temperature_step=0.5,
+        visual_current_temperature_step=0.1,
+        supports_action=True,
+        supported_fan_modes=[0, 1, 2, 3, 4, 5, 6],
+        supported_swing_modes=[0, 1, 2, 3],
+        supported_custom_fan_modes=["quiet", "turbo"],
+        supported_presets=[0, 1, 2, 3, 4, 5, 6, 7],
+        supported_custom_presets=["sleep", "vacation"],
+        disabled_by_default=False,
+        icon="mdi:hvac",
+        entity_category=0,
+        supports_current_humidity=True,
+        supports_target_humidity=True,
+        visual_min_humidity=30.0,
+        visual_max_humidity=70.0,
+        feature_flags=0,
+        temperature_unit=0,
+    )
+
+
+def test_list_entities_sensor_from_pb(benchmark: BenchmarkFixture) -> None:
+    """Benchmark SensorInfo.from_pb (model construction cost only)."""
+    msg = _build_sensor_info()
+    benchmark(partial(SensorInfo.from_pb, msg))
+
+
+def test_list_entities_binary_sensor_from_pb(benchmark: BenchmarkFixture) -> None:
+    """Benchmark BinarySensorInfo.from_pb."""
+    msg = _build_binary_sensor_info()
+    benchmark(partial(BinarySensorInfo.from_pb, msg))
+
+
+def test_list_entities_switch_from_pb(benchmark: BenchmarkFixture) -> None:
+    """Benchmark SwitchInfo.from_pb."""
+    msg = _build_switch_info()
+    benchmark(partial(SwitchInfo.from_pb, msg))
+
+
+def test_list_entities_light_from_pb(benchmark: BenchmarkFixture) -> None:
+    """Benchmark LightInfo.from_pb (lists + enum convert)."""
+    msg = _build_light_info()
+    benchmark(partial(LightInfo.from_pb, msg))
+
+
+def test_list_entities_climate_from_pb(benchmark: BenchmarkFixture) -> None:
+    """Benchmark ClimateInfo.from_pb (widest entity info, many list converts)."""
+    msg = _build_climate_info()
+    benchmark(partial(ClimateInfo.from_pb, msg))
+
+
+async def test_list_entities_sensor_process_packet(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark process_packet for a sensor list entities response.
+
+    Covers protobuf class lookup, instantiation, parse, and handler dispatch.
+    """
+    data = _build_sensor_info().SerializeToString()
+    connection = _make_connection()
+    connection.add_message_callback(_noop, (ListEntitiesSensorResponse,))
+    process = partial(connection.process_packet, 16, data)
+    benchmark(process)
+
+
+async def test_list_entities_climate_process_packet(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark process_packet for a climate list entities response."""
+    data = _build_climate_info().SerializeToString()
+    connection = _make_connection()
+    connection.add_message_callback(_noop, (ListEntitiesClimateResponse,))
+    process = partial(connection.process_packet, 46, data)
+    benchmark(process)
+
+
+async def test_list_entities_typical_device_batch(
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark a realistic device entity dump.
+
+    Models a moderately complex ESPHome device (e.g. multi sensor board with a
+    relay, a climate component, and an RGBWW light) that emits a mix of list
+    entities responses at connect time.
+    """
+    sensor_msg = _build_sensor_info().SerializeToString()
+    binary_msg = _build_binary_sensor_info().SerializeToString()
+    switch_msg = _build_switch_info().SerializeToString()
+    light_msg = _build_light_info().SerializeToString()
+    climate_msg = _build_climate_info().SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        _noop,
+        (
+            ListEntitiesSensorResponse,
+            ListEntitiesBinarySensorResponse,
+            ListEntitiesSwitchResponse,
+            ListEntitiesLightResponse,
+            ListEntitiesClimateResponse,
+        ),
+    )
+
+    process_packet = connection.process_packet
+    batch = (
+        (16, sensor_msg),
+        (16, sensor_msg),
+        (16, sensor_msg),
+        (12, binary_msg),
+        (12, binary_msg),
+        (17, switch_msg),
+        (17, switch_msg),
+        (15, light_msg),
+        (46, climate_msg),
+    )
+
+    @benchmark
+    def process_batch() -> None:
+        for msg_type, data in batch:
+            process_packet(msg_type, data)

--- a/tests/benchmarks/test_list_entities.py
+++ b/tests/benchmarks/test_list_entities.py
@@ -14,7 +14,6 @@ from functools import partial
 
 from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 
-from aioesphomeapi import APIConnection
 from aioesphomeapi.api_pb2 import (
     ListEntitiesBinarySensorResponse,
     ListEntitiesClimateResponse,
@@ -22,7 +21,6 @@ from aioesphomeapi.api_pb2 import (
     ListEntitiesSensorResponse,
     ListEntitiesSwitchResponse,
 )
-from aioesphomeapi.client import APIClient
 from aioesphomeapi.model import (
     BinarySensorInfo,
     ClimateInfo,
@@ -31,17 +29,10 @@ from aioesphomeapi.model import (
     SwitchInfo,
 )
 
-
-def _make_connection() -> APIConnection:
-    client = APIClient("fake.address", 6052, None)
-    return APIConnection(client._params, lambda expected_disconnect: None, False, None)
+from .helpers import bench_process_packet, make_connection, noop
 
 
-def _noop(msg: object) -> None:
-    """No-op callback."""
-
-
-def _build_sensor_info() -> ListEntitiesSensorResponse:
+def _sensor_info() -> ListEntitiesSensorResponse:
     return ListEntitiesSensorResponse(
         object_id="living_room_temperature",
         key=12345678,
@@ -57,7 +48,7 @@ def _build_sensor_info() -> ListEntitiesSensorResponse:
     )
 
 
-def _build_binary_sensor_info() -> ListEntitiesBinarySensorResponse:
+def _binary_sensor_info() -> ListEntitiesBinarySensorResponse:
     return ListEntitiesBinarySensorResponse(
         object_id="motion_sensor",
         key=12345679,
@@ -70,7 +61,7 @@ def _build_binary_sensor_info() -> ListEntitiesBinarySensorResponse:
     )
 
 
-def _build_switch_info() -> ListEntitiesSwitchResponse:
+def _switch_info() -> ListEntitiesSwitchResponse:
     return ListEntitiesSwitchResponse(
         object_id="relay_1",
         key=12345680,
@@ -83,7 +74,7 @@ def _build_switch_info() -> ListEntitiesSwitchResponse:
     )
 
 
-def _build_light_info() -> ListEntitiesLightResponse:
+def _light_info() -> ListEntitiesLightResponse:
     return ListEntitiesLightResponse(
         object_id="rgbww_light",
         key=12345681,
@@ -102,7 +93,7 @@ def _build_light_info() -> ListEntitiesLightResponse:
     )
 
 
-def _build_climate_info() -> ListEntitiesClimateResponse:
+def _climate_info() -> ListEntitiesClimateResponse:
     return ListEntitiesClimateResponse(
         object_id="hvac",
         key=12345682,
@@ -134,57 +125,41 @@ def _build_climate_info() -> ListEntitiesClimateResponse:
 
 def test_list_entities_sensor_from_pb(benchmark: BenchmarkFixture) -> None:
     """Benchmark SensorInfo.from_pb (model construction cost only)."""
-    msg = _build_sensor_info()
-    benchmark(partial(SensorInfo.from_pb, msg))
+    benchmark(partial(SensorInfo.from_pb, _sensor_info()))
 
 
 def test_list_entities_binary_sensor_from_pb(benchmark: BenchmarkFixture) -> None:
     """Benchmark BinarySensorInfo.from_pb."""
-    msg = _build_binary_sensor_info()
-    benchmark(partial(BinarySensorInfo.from_pb, msg))
+    benchmark(partial(BinarySensorInfo.from_pb, _binary_sensor_info()))
 
 
 def test_list_entities_switch_from_pb(benchmark: BenchmarkFixture) -> None:
     """Benchmark SwitchInfo.from_pb."""
-    msg = _build_switch_info()
-    benchmark(partial(SwitchInfo.from_pb, msg))
+    benchmark(partial(SwitchInfo.from_pb, _switch_info()))
 
 
 def test_list_entities_light_from_pb(benchmark: BenchmarkFixture) -> None:
     """Benchmark LightInfo.from_pb (lists + enum convert)."""
-    msg = _build_light_info()
-    benchmark(partial(LightInfo.from_pb, msg))
+    benchmark(partial(LightInfo.from_pb, _light_info()))
 
 
 def test_list_entities_climate_from_pb(benchmark: BenchmarkFixture) -> None:
     """Benchmark ClimateInfo.from_pb (widest entity info, many list converts)."""
-    msg = _build_climate_info()
-    benchmark(partial(ClimateInfo.from_pb, msg))
+    benchmark(partial(ClimateInfo.from_pb, _climate_info()))
 
 
 async def test_list_entities_sensor_process_packet(
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark process_packet for a sensor list entities response.
-
-    Covers protobuf class lookup, instantiation, parse, and handler dispatch.
-    """
-    data = _build_sensor_info().SerializeToString()
-    connection = _make_connection()
-    connection.add_message_callback(_noop, (ListEntitiesSensorResponse,))
-    process = partial(connection.process_packet, 16, data)
-    benchmark(process)
+    """Benchmark process_packet for a sensor list entities response."""
+    benchmark(bench_process_packet(_sensor_info(), 16))
 
 
 async def test_list_entities_climate_process_packet(
     benchmark: BenchmarkFixture,
 ) -> None:
     """Benchmark process_packet for a climate list entities response."""
-    data = _build_climate_info().SerializeToString()
-    connection = _make_connection()
-    connection.add_message_callback(_noop, (ListEntitiesClimateResponse,))
-    process = partial(connection.process_packet, 46, data)
-    benchmark(process)
+    benchmark(bench_process_packet(_climate_info(), 46))
 
 
 async def test_list_entities_typical_device_batch(
@@ -196,15 +171,15 @@ async def test_list_entities_typical_device_batch(
     relay, a climate component, and an RGBWW light) that emits a mix of list
     entities responses at connect time.
     """
-    sensor_msg = _build_sensor_info().SerializeToString()
-    binary_msg = _build_binary_sensor_info().SerializeToString()
-    switch_msg = _build_switch_info().SerializeToString()
-    light_msg = _build_light_info().SerializeToString()
-    climate_msg = _build_climate_info().SerializeToString()
+    sensor_msg = _sensor_info().SerializeToString()
+    binary_msg = _binary_sensor_info().SerializeToString()
+    switch_msg = _switch_info().SerializeToString()
+    light_msg = _light_info().SerializeToString()
+    climate_msg = _climate_info().SerializeToString()
 
-    connection = _make_connection()
+    connection = make_connection()
     connection.add_message_callback(
-        _noop,
+        noop,
         (
             ListEntitiesSensorResponse,
             ListEntitiesBinarySensorResponse,
@@ -213,7 +188,6 @@ async def test_list_entities_typical_device_batch(
             ListEntitiesClimateResponse,
         ),
     )
-
     process_packet = connection.process_packet
     batch = (
         (16, sensor_msg),

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -2,9 +2,10 @@
 
 import asyncio
 import base64
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
 
 import pytest
+import pytest_asyncio
 from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 
 from aioesphomeapi._frame_helper.noise_encryption import EncryptCipher
@@ -20,6 +21,8 @@ from ..common import (
     _mock_responder_proto,
     mock_data_received,
 )
+
+NOISE_PAYLOAD_SIZES = [0, 64, 128, 1024, 16 * 1024]
 
 
 async def _make_ready_helper(
@@ -65,7 +68,20 @@ async def _make_ready_helper(
     return helper, responder_encrypt
 
 
-@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+@pytest_asyncio.fixture
+async def ready_noise_helper() -> AsyncIterator[
+    tuple[MockAPINoiseFrameHelper, EncryptCipher]
+]:
+    """Hand back a handshaken noise helper paired with a responder cipher."""
+    writes: list[bytes] = []
+    helper, encrypt_cipher = await _make_ready_helper(writes)
+    try:
+        yield helper, encrypt_cipher
+    finally:
+        helper.close()
+
+
+@pytest.mark.parametrize("payload_size", NOISE_PAYLOAD_SIZES)
 async def test_noise_messages(benchmark: BenchmarkFixture, payload_size: int) -> None:
     """Benchmark raw noise protocol."""
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
@@ -134,16 +150,17 @@ async def test_noise_messages(benchmark: BenchmarkFixture, payload_size: int) ->
     helper.close()
 
 
-@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+@pytest.mark.parametrize("payload_size", NOISE_PAYLOAD_SIZES)
 async def test_noise_encrypt_cipher(
-    benchmark: BenchmarkFixture, payload_size: int
+    benchmark: BenchmarkFixture,
+    payload_size: int,
+    ready_noise_helper: tuple[MockAPINoiseFrameHelper, EncryptCipher],
 ) -> None:
     """Benchmark raw EncryptCipher.encrypt across payload sizes.
 
     Isolates ChaCha20Poly1305 + nonce packing cost from framing overhead.
     """
-    writes: list[bytes] = []
-    helper, encrypt_cipher = await _make_ready_helper(writes)
+    _, encrypt_cipher = ready_noise_helper
     payload = b"x" * payload_size
 
     @benchmark
@@ -151,16 +168,15 @@ async def test_noise_encrypt_cipher(
         for _ in range(100):
             encrypt_cipher.encrypt(payload)
 
-    helper.close()
 
-
-@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+@pytest.mark.parametrize("payload_size", NOISE_PAYLOAD_SIZES)
 async def test_noise_make_packets(
-    benchmark: BenchmarkFixture, payload_size: int
+    benchmark: BenchmarkFixture,
+    payload_size: int,
+    ready_noise_helper: tuple[MockAPINoiseFrameHelper, EncryptCipher],
 ) -> None:
     """Benchmark make_noise_packets, the full encrypt + framing cost."""
-    writes: list[bytes] = []
-    helper, encrypt_cipher = await _make_ready_helper(writes)
+    _, encrypt_cipher = ready_noise_helper
     packet = (42, b"x" * payload_size)
 
     @benchmark
@@ -168,20 +184,19 @@ async def test_noise_make_packets(
         for _ in range(100):
             make_noise_packets([packet], encrypt_cipher)
 
-    helper.close()
 
-
-@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+@pytest.mark.parametrize("payload_size", NOISE_PAYLOAD_SIZES)
 async def test_noise_write_packets(
-    benchmark: BenchmarkFixture, payload_size: int
+    benchmark: BenchmarkFixture,
+    payload_size: int,
+    ready_noise_helper: tuple[MockAPINoiseFrameHelper, EncryptCipher],
 ) -> None:
     """Benchmark APINoiseFrameHelper.write_packets, the user-visible send path.
 
     This mirrors what happens for every command (light, switch, climate, etc.)
     sent over a noise connection.
     """
-    writes: list[bytes] = []
-    helper, _ = await _make_ready_helper(writes)
+    helper, _ = ready_noise_helper
 
     def _drop(data: Iterable[bytes]) -> None:
         """Skip the actual write so we measure only frame construction."""
@@ -193,5 +208,3 @@ async def test_noise_write_packets(
     def write_packets() -> None:
         for _ in range(100):
             helper.write_packets(packets, False)
-
-    helper.close()

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 
 from aioesphomeapi._frame_helper.noise_encryption import EncryptCipher
+from aioesphomeapi._frame_helper.packets import make_noise_packets
 
 from ..common import (
     MockAPINoiseFrameHelper,
@@ -19,6 +20,49 @@ from ..common import (
     _mock_responder_proto,
     mock_data_received,
 )
+
+
+async def _make_ready_helper(
+    writes: list[bytes],
+) -> tuple[MockAPINoiseFrameHelper, EncryptCipher]:
+    """Drive a noise frame helper through handshake, returning ready helper + a
+    paired encrypt cipher for the responder side (used for decrypt benches)."""
+    noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
+    psk_bytes = base64.b64decode(noise_psk)
+
+    def _writelines(data: Iterable[bytes]) -> None:
+        writes.append(b"".join(data))
+
+    connection, _packets = _make_mock_connection()
+
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk=noise_psk,
+        expected_name="servicetest",
+        expected_mac=None,
+        client_info="my client",
+        log_name="test",
+        writer=_writelines,
+    )
+
+    proto = _mock_responder_proto(psk_bytes)
+
+    await asyncio.sleep(0)
+    assert len(writes) == 1
+    handshake_pkt = writes.pop()
+    encrypted_payload = _extract_encrypted_payload_from_handshake(handshake_pkt)
+    assert proto.read_message(encrypted_payload) == b""
+
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01servicetest\0")
+    mock_data_received(helper, hello_pkt_with_header)
+
+    handshake_with_header = _make_noise_handshake_pkt(proto)
+    mock_data_received(helper, handshake_with_header)
+
+    await helper.ready_future
+
+    responder_encrypt = EncryptCipher(proto.noise_protocol.cipher_state_encrypt)
+    return helper, responder_encrypt
 
 
 @pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
@@ -86,5 +130,68 @@ async def test_noise_messages(benchmark: BenchmarkFixture, payload_size: int) ->
     def process_encrypted_packets():
         for _ in range(100):
             helper.data_received(_make_encrypted_packet(encrypt_cipher, 42, payload))
+
+    helper.close()
+
+
+@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+async def test_noise_encrypt_cipher(
+    benchmark: BenchmarkFixture, payload_size: int
+) -> None:
+    """Benchmark raw EncryptCipher.encrypt across payload sizes.
+
+    Isolates ChaCha20Poly1305 + nonce packing cost from framing overhead.
+    """
+    writes: list[bytes] = []
+    helper, encrypt_cipher = await _make_ready_helper(writes)
+    payload = b"x" * payload_size
+
+    @benchmark
+    def encrypt_packets() -> None:
+        for _ in range(100):
+            encrypt_cipher.encrypt(payload)
+
+    helper.close()
+
+
+@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+async def test_noise_make_packets(
+    benchmark: BenchmarkFixture, payload_size: int
+) -> None:
+    """Benchmark make_noise_packets, the full encrypt + framing cost."""
+    writes: list[bytes] = []
+    helper, encrypt_cipher = await _make_ready_helper(writes)
+    packet = (42, b"x" * payload_size)
+
+    @benchmark
+    def build_noise_packets() -> None:
+        for _ in range(100):
+            make_noise_packets([packet], encrypt_cipher)
+
+    helper.close()
+
+
+@pytest.mark.parametrize("payload_size", [0, 64, 128, 1024, 16 * 1024])
+async def test_noise_write_packets(
+    benchmark: BenchmarkFixture, payload_size: int
+) -> None:
+    """Benchmark APINoiseFrameHelper.write_packets, the user-visible send path.
+
+    This mirrors what happens for every command (light, switch, climate, etc.)
+    sent over a noise connection.
+    """
+    writes: list[bytes] = []
+    helper, _ = await _make_ready_helper(writes)
+
+    def _drop(data: Iterable[bytes]) -> None:
+        """Skip the actual write so we measure only frame construction."""
+
+    helper._writelines = _drop
+    packets: list[tuple[int, bytes]] = [(42, b"x" * payload_size)]
+
+    @benchmark
+    def write_packets() -> None:
+        for _ in range(100):
+            helper.write_packets(packets, False)
 
     helper.close()

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -28,8 +28,14 @@ NOISE_PAYLOAD_SIZES = [0, 64, 128, 1024, 16 * 1024]
 async def _make_ready_helper(
     writes: list[bytes],
 ) -> tuple[MockAPINoiseFrameHelper, EncryptCipher]:
-    """Drive a noise frame helper through handshake, returning ready helper + a
-    paired encrypt cipher for the responder side (used for decrypt benches)."""
+    """Drive a noise frame helper through handshake.
+
+    Returns the ready helper plus the responder side's encrypt cipher. The
+    cipher is returned so encrypt-path benchmarks can exercise the underlying
+    ChaCha20Poly1305 (and framing) without having to reach into the helper's
+    private cdef state for its own encrypt cipher; either side's cipher does
+    the same work per call.
+    """
     noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     psk_bytes = base64.b64decode(noise_psk)
 

--- a/tests/benchmarks/test_state_messages.py
+++ b/tests/benchmarks/test_state_messages.py
@@ -10,7 +10,6 @@ from functools import partial
 
 from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 
-from aioesphomeapi import APIConnection
 from aioesphomeapi.api_pb2 import (
     BinarySensorStateResponse,
     ClimateStateResponse,
@@ -18,62 +17,27 @@ from aioesphomeapi.api_pb2 import (
     SensorStateResponse,
     SwitchStateResponse,
 )
-from aioesphomeapi.client import APIClient
 from aioesphomeapi.client_base import on_state_msg
 
-
-def _make_connection() -> APIConnection:
-    client = APIClient("fake.address", 6052, None)
-    return APIConnection(client._params, lambda expected_disconnect: None, False, None)
-
-
-def _noop_on_state(state: object) -> None:
-    """No-op state callback."""
+from .helpers import bench_state_process_packet, make_connection, noop
 
 
 async def test_sensor_state_response(benchmark: BenchmarkFixture) -> None:
     """Benchmark sensor state response decode (highest volume message)."""
     msg = SensorStateResponse(key=12345678, state=23.456, missing_state=False)
-    data = msg.SerializeToString()
-
-    connection = _make_connection()
-    connection.add_message_callback(
-        partial(on_state_msg, _noop_on_state, {}),
-        (SensorStateResponse,),
-    )
-
-    process = partial(connection.process_packet, 25, data)
-    benchmark(process)
+    benchmark(bench_state_process_packet(msg, 25))
 
 
 async def test_binary_sensor_state_response(benchmark: BenchmarkFixture) -> None:
     """Benchmark binary sensor state response decode."""
     msg = BinarySensorStateResponse(key=12345678, state=True, missing_state=False)
-    data = msg.SerializeToString()
-
-    connection = _make_connection()
-    connection.add_message_callback(
-        partial(on_state_msg, _noop_on_state, {}),
-        (BinarySensorStateResponse,),
-    )
-
-    process = partial(connection.process_packet, 21, data)
-    benchmark(process)
+    benchmark(bench_state_process_packet(msg, 21))
 
 
 async def test_switch_state_response(benchmark: BenchmarkFixture) -> None:
     """Benchmark switch state response decode."""
     msg = SwitchStateResponse(key=12345678, state=True)
-    data = msg.SerializeToString()
-
-    connection = _make_connection()
-    connection.add_message_callback(
-        partial(on_state_msg, _noop_on_state, {}),
-        (SwitchStateResponse,),
-    )
-
-    process = partial(connection.process_packet, 26, data)
-    benchmark(process)
+    benchmark(bench_state_process_packet(msg, 26))
 
 
 async def test_light_state_response(benchmark: BenchmarkFixture) -> None:
@@ -93,16 +57,7 @@ async def test_light_state_response(benchmark: BenchmarkFixture) -> None:
         warm_white=0.0,
         effect="None",
     )
-    data = msg.SerializeToString()
-
-    connection = _make_connection()
-    connection.add_message_callback(
-        partial(on_state_msg, _noop_on_state, {}),
-        (LightStateResponse,),
-    )
-
-    process = partial(connection.process_packet, 24, data)
-    benchmark(process)
+    benchmark(bench_state_process_packet(msg, 24))
 
 
 async def test_climate_state_response(benchmark: BenchmarkFixture) -> None:
@@ -123,16 +78,7 @@ async def test_climate_state_response(benchmark: BenchmarkFixture) -> None:
         current_humidity=45.0,
         target_humidity=50.0,
     )
-    data = msg.SerializeToString()
-
-    connection = _make_connection()
-    connection.add_message_callback(
-        partial(on_state_msg, _noop_on_state, {}),
-        (ClimateStateResponse,),
-    )
-
-    process = partial(connection.process_packet, 47, data)
-    benchmark(process)
+    benchmark(bench_state_process_packet(msg, 47))
 
 
 async def test_mixed_state_responses(benchmark: BenchmarkFixture) -> None:
@@ -141,21 +87,22 @@ async def test_mixed_state_responses(benchmark: BenchmarkFixture) -> None:
     Real installs interleave sensor/binary/switch/light updates; this measures
     dispatch lookup cost across multiple registered message types.
     """
-    sensor_data = SensorStateResponse(
-        key=1, state=23.456, missing_state=False
-    ).SerializeToString()
-    binary_data = BinarySensorStateResponse(
-        key=2, state=True, missing_state=False
-    ).SerializeToString()
-    switch_data = SwitchStateResponse(key=3, state=True).SerializeToString()
-    light_data = LightStateResponse(
-        key=4, state=True, brightness=0.75
-    ).SerializeToString()
+    batch = (
+        tuple(
+            (msg_type, msg.SerializeToString())
+            for msg, msg_type in (
+                (SensorStateResponse(key=1, state=23.456, missing_state=False), 25),
+                (BinarySensorStateResponse(key=2, state=True, missing_state=False), 21),
+                (SwitchStateResponse(key=3, state=True), 26),
+                (LightStateResponse(key=4, state=True, brightness=0.75), 24),
+            )
+        )
+        * 25
+    )
 
-    connection = _make_connection()
-    handler = partial(on_state_msg, _noop_on_state, {})
+    connection = make_connection()
     connection.add_message_callback(
-        handler,
+        partial(on_state_msg, noop, {}),
         (
             SensorStateResponse,
             BinarySensorStateResponse,
@@ -163,14 +110,7 @@ async def test_mixed_state_responses(benchmark: BenchmarkFixture) -> None:
             LightStateResponse,
         ),
     )
-
     process_packet = connection.process_packet
-    batch = (
-        (25, sensor_data),
-        (21, binary_data),
-        (26, switch_data),
-        (24, light_data),
-    ) * 25
 
     @benchmark
     def process_batch() -> None:

--- a/tests/benchmarks/test_state_messages.py
+++ b/tests/benchmarks/test_state_messages.py
@@ -1,0 +1,178 @@
+"""Benchmarks for entity state message decoding.
+
+These cover the hottest non-BLE path: every sensor reading, switch toggle,
+light brightness change, climate update, etc., flows through
+``APIConnection.process_packet`` -> protobuf parse -> handler dispatch ->
+``on_state_msg`` -> ``EntityState.from_pb`` -> user callback.
+"""
+
+from functools import partial
+
+from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+
+from aioesphomeapi import APIConnection
+from aioesphomeapi.api_pb2 import (
+    BinarySensorStateResponse,
+    ClimateStateResponse,
+    LightStateResponse,
+    SensorStateResponse,
+    SwitchStateResponse,
+)
+from aioesphomeapi.client import APIClient
+from aioesphomeapi.client_base import on_state_msg
+
+
+def _make_connection() -> APIConnection:
+    client = APIClient("fake.address", 6052, None)
+    return APIConnection(client._params, lambda expected_disconnect: None, False, None)
+
+
+def _noop_on_state(state: object) -> None:
+    """No-op state callback."""
+
+
+async def test_sensor_state_response(benchmark: BenchmarkFixture) -> None:
+    """Benchmark sensor state response decode (highest volume message)."""
+    msg = SensorStateResponse(key=12345678, state=23.456, missing_state=False)
+    data = msg.SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        partial(on_state_msg, _noop_on_state, {}),
+        (SensorStateResponse,),
+    )
+
+    process = partial(connection.process_packet, 25, data)
+    benchmark(process)
+
+
+async def test_binary_sensor_state_response(benchmark: BenchmarkFixture) -> None:
+    """Benchmark binary sensor state response decode."""
+    msg = BinarySensorStateResponse(key=12345678, state=True, missing_state=False)
+    data = msg.SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        partial(on_state_msg, _noop_on_state, {}),
+        (BinarySensorStateResponse,),
+    )
+
+    process = partial(connection.process_packet, 21, data)
+    benchmark(process)
+
+
+async def test_switch_state_response(benchmark: BenchmarkFixture) -> None:
+    """Benchmark switch state response decode."""
+    msg = SwitchStateResponse(key=12345678, state=True)
+    data = msg.SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        partial(on_state_msg, _noop_on_state, {}),
+        (SwitchStateResponse,),
+    )
+
+    process = partial(connection.process_packet, 26, data)
+    benchmark(process)
+
+
+async def test_light_state_response(benchmark: BenchmarkFixture) -> None:
+    """Benchmark light state response decode (many float fields)."""
+    msg = LightStateResponse(
+        key=12345678,
+        state=True,
+        brightness=0.75,
+        color_mode=35,
+        color_brightness=1.0,
+        red=0.5,
+        green=0.25,
+        blue=0.125,
+        white=0.0,
+        color_temperature=350.0,
+        cold_white=0.0,
+        warm_white=0.0,
+        effect="None",
+    )
+    data = msg.SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        partial(on_state_msg, _noop_on_state, {}),
+        (LightStateResponse,),
+    )
+
+    process = partial(connection.process_packet, 24, data)
+    benchmark(process)
+
+
+async def test_climate_state_response(benchmark: BenchmarkFixture) -> None:
+    """Benchmark climate state response decode (widest entity state)."""
+    msg = ClimateStateResponse(
+        key=12345678,
+        mode=3,
+        action=2,
+        current_temperature=21.5,
+        target_temperature=22.0,
+        target_temperature_low=20.0,
+        target_temperature_high=24.0,
+        fan_mode=3,
+        swing_mode=1,
+        custom_fan_mode="quiet",
+        preset=1,
+        custom_preset="",
+        current_humidity=45.0,
+        target_humidity=50.0,
+    )
+    data = msg.SerializeToString()
+
+    connection = _make_connection()
+    connection.add_message_callback(
+        partial(on_state_msg, _noop_on_state, {}),
+        (ClimateStateResponse,),
+    )
+
+    process = partial(connection.process_packet, 47, data)
+    benchmark(process)
+
+
+async def test_mixed_state_responses(benchmark: BenchmarkFixture) -> None:
+    """Benchmark a realistic mix of state types in one batch.
+
+    Real installs interleave sensor/binary/switch/light updates; this measures
+    dispatch lookup cost across multiple registered message types.
+    """
+    sensor_data = SensorStateResponse(
+        key=1, state=23.456, missing_state=False
+    ).SerializeToString()
+    binary_data = BinarySensorStateResponse(
+        key=2, state=True, missing_state=False
+    ).SerializeToString()
+    switch_data = SwitchStateResponse(key=3, state=True).SerializeToString()
+    light_data = LightStateResponse(
+        key=4, state=True, brightness=0.75
+    ).SerializeToString()
+
+    connection = _make_connection()
+    handler = partial(on_state_msg, _noop_on_state, {})
+    connection.add_message_callback(
+        handler,
+        (
+            SensorStateResponse,
+            BinarySensorStateResponse,
+            SwitchStateResponse,
+            LightStateResponse,
+        ),
+    )
+
+    process_packet = connection.process_packet
+    batch = (
+        (25, sensor_data),
+        (21, binary_data),
+        (26, switch_data),
+        (24, light_data),
+    ) * 25
+
+    @benchmark
+    def process_batch() -> None:
+        for msg_type, data in batch:
+            process_packet(msg_type, data)


### PR DESCRIPTION
# What does this implement/fix?

Adds codspeed benchmarks for code paths that affect real users but were not previously measured; entity state decode for sensor, binary sensor, switch, light, and climate; noise encrypt and write_packets across payload sizes; ListEntities decode plus from_pb for a realistic device mix.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).