### PR TITLE
Reject msg_type=0 in process_packet to prevent silent last-class fallback

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -73,6 +73,7 @@ cdef object _handle_timeout
 cdef object _handle_complex_message
 
 cdef tuple MESSAGE_NUMBER_TO_PROTO
+cdef Py_ssize_t _MESSAGE_NUMBER_TO_PROTO_LEN
 
 
 @cython.dataclasses.dataclass

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -66,6 +66,7 @@ _LOGGER = logging.getLogger(__name__)
 MESSAGE_NUMBER_TO_PROTO: tuple[
     tuple[Callable[[], message.Message], Callable[[message.Message, bytes], None]], ...
 ] = tuple((msg, msg.MergeFromString) for msg in MESSAGE_TYPE_TO_PROTO.values())
+_MESSAGE_NUMBER_TO_PROTO_LEN = len(MESSAGE_NUMBER_TO_PROTO)
 
 
 PREFERRED_BUFFER_SIZE = 2097152  # Set buffer limit to 2MB
@@ -1026,25 +1027,25 @@ class APIConnection:
         # This method is HOT and extremely performance critical
         # since its called for every incoming packet. Take
         # extra care when modifying this method.
+        # Bounds-check before indexing: msg_type_proto is attacker-
+        # controlled, and `MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]`
+        # would otherwise wrap (0 -> -1) into the last registered class
+        # or raise an IndexError on every out-of-range value, both of
+        # which are avoidable on a hot path.
+        if msg_type_proto < 1 or msg_type_proto > _MESSAGE_NUMBER_TO_PROTO_LEN:
+            if self._debug_enabled:
+                _LOGGER.debug(
+                    "%s: Skipping unknown message type %s",
+                    self.log_name,
+                    msg_type_proto,
+                )
+            return
+        # MESSAGE_NUMBER_TO_PROTO is 0-indexed but the message type is 1-indexed
+        klass, merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
+        msg = klass()
         try:
-            # MESSAGE_NUMBER_TO_PROTO is 0-indexed
-            # but the message type is 1-indexed
-            klass_merge = MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]
-            klass, merge = klass_merge
-            msg = klass()
             merge(msg, data)
         except Exception as e:
-            # IndexError will be very rare so we check for it
-            # after the broad exception catch to avoid having
-            # to check the exception type twice for the common case
-            if isinstance(e, IndexError):
-                if self._debug_enabled:
-                    _LOGGER.debug(
-                        "%s: Skipping unknown message type %s",
-                        self.log_name,
-                        msg_type_proto,
-                    )
-                return
             _LOGGER.exception(
                 "%s: Invalid protobuf message: type=%s data=%s",
                 self.log_name,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1184,6 +1184,28 @@ async def test_unknown_protobuf_message_type_logged(
     await asyncio.sleep(0)
 
 
+async def test_zero_protobuf_message_type_rejected(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test msg_type_proto=0 is skipped instead of wrapping to the last registered type."""
+    client, connection, _transport, protocol = api_client
+    caplog.set_level(logging.DEBUG)
+    client.set_debug(True)
+    message_with_zero_protobuf_number = (
+        b"\0" + _cached_varuint_to_bytes(0) + _cached_varuint_to_bytes(0)
+    )
+
+    mock_data_received(protocol, message_with_zero_protobuf_number)
+
+    assert "Skipping unknown message type 0" in caplog.text
+    assert connection.is_connected
+    connection.force_disconnect()
+    await asyncio.sleep(0)
+
+
 async def test_bad_protobuf_message_drops_connection(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper


### PR DESCRIPTION
# What does this implement/fix?

`MESSAGE_NUMBER_TO_PROTO[msg_type_proto - 1]` with `msg_type_proto == 0` evaluates to `MESSAGE_NUMBER_TO_PROTO[-1]`, which silently returns the *last* registered protobuf class instead of raising `IndexError`. The `IndexError`-handling branch in `process_packet` exists specifically to drop unknown message types, but it is bypassed for `msg_type=0`, so the attacker-controlled payload is routed to whatever class happens to be last in the registry today (currently `ListEntitiesRadioFrequencyResponse`).

This adds an explicit guard rejecting non-positive message types up front so the "unknown message type → silently ignore" policy applies uniformly. The check is one branch, perfectly predicted in the common case (`msg_type >= 1`), so it preserves the hot-path performance the existing comment calls out.

I confirmed the bug empirically before fixing: with the original code, a `msg_type=0, payload=b""` packet is parsed as `ListEntitiesRadioFrequencyResponse` rather than being rejected. The new regression test (`test_zero_protobuf_message_type_rejected`) fails on the unfixed code and passes with the fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1644

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A (client-side only)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. (N/A — api.proto unchanged)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).