### PR TITLE
Expand CLAUDE.md and add pr-workflow skill

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pr-workflow
+description: Create pull requests for esphome/aioesphomeapi. Use when creating PRs, submitting changes, or preparing contributions.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# aioesphomeapi PR Workflow
+
+When creating a pull request for `esphome/aioesphomeapi`, follow
+these steps. Repo-wide conventions live in
+[CLAUDE.md](../../../CLAUDE.md); this skill summarises the parts
+that matter at PR-creation time.
+
+## 1. Create branch from origin/main
+
+There is no fork in this workflow — `origin` already points at
+`esphome/aioesphomeapi`. Always re-fetch first so the branch is
+based on the latest `main`:
+
+```bash
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+## 2. Read the PR template
+
+Before creating a PR, read `.github/PULL_REQUEST_TEMPLATE.md` and
+fill in **every** section. The template asks for:
+
+- **What does this implement/fix?** — prose description.
+- **Types of changes** — tick exactly one of: `Bugfix`,
+  `New feature`, `Breaking change`,
+  `Code quality improvements to existing code or addition of tests`,
+  or `Other`. Pick the one a future release-notes reader would
+  expect; release-drafter slots PRs by label
+  (`breaking-change`, `new-feature`, `bugfix`, `enhancement`,
+  `documentation`, `dependencies`).
+- **Related issue or feature** — `fixes <link>` syntax if
+  applicable.
+- **Pull request in esphome** — link the companion PR if the
+  change requires firmware-side work; mandatory if `api.proto`
+  is modified (see step 3).
+- **Checklist** — only tick boxes you've actually verified.
+
+## 3. api.proto changes need an upstream PR first
+
+The protocol is defined firmware-side. If the PR modifies
+`aioesphomeapi/api.proto`, the matching change MUST land in
+`esphome/esphome` first; link the esphome PR in the body and tick
+the "linked pull request has been made to esphome" checkbox. After
+modifying the proto, regenerate the bindings with the docker image
+documented in [CLAUDE.md](../../../CLAUDE.md#regenerating-protobuf-files)
+so `api_pb2.py` stays in sync with the protobuf runtime version.
+
+## 4. Commit message conventions
+
+- **Imperative-mood subject line** — "Add X", not "Added X".
+- **No `Co-Authored-By: Claude` trailer.** Project preference.
+- One logical change per commit; let pre-commit run (ruff lint +
+  format). If a hook auto-fixes something, re-stage and re-commit.
+
+## 5. Push and create the PR
+
+**Read `.github/PULL_REQUEST_TEMPLATE.md` from the repo at
+PR-creation time and use it verbatim as the body** — do not
+reproduce, paraphrase, or trim the template anywhere else, or it
+will silently drift out of sync as the template evolves.
+
+When filling in the template:
+
+- Replace the `<!-- ... -->` prompt comments with the actual prose
+  for that section. Do not delete anything else.
+- **Leave all the checkboxes in place.** Do not remove rows you
+  aren't ticking — the auto-labeller and the human reviewer both
+  rely on the full list being present.
+- Tick exactly one "Types of changes" box. For the Checklist
+  section, only tick boxes you have actually verified; leave the
+  rest as `- [ ]`.
+- **Do not escape characters from the template.** Backticks,
+  asterisks, angle brackets, etc. must be passed through verbatim.
+  The template is already valid Markdown; do not rewrite it for
+  shell quoting. Use `--body-file`, never `--body "..."` with
+  shell-escaping.
+
+```bash
+git push -u origin <branch-name>
+# Read .github/PULL_REQUEST_TEMPLATE.md, fill it in as above,
+# write the result to a temp file, then:
+gh pr create --repo esphome/aioesphomeapi --base main \
+  --title "Imperative subject under 70 chars" \
+  --body-file /tmp/pr-body.md
+```
+
+The keep-the-checklist-honest rule applies — only tick a checklist
+box you've actually verified. "Tests have been added" is verified
+by pointing at the new test file in the diff; "linked PR to
+esphome" is verified by clicking the link.
+
+## 6. After the PR is open
+
+CI runs ruff (lint + format), the test matrix, and the file-glob
+labeller (`.github/workflows/labeler.yml` only auto-labels
+`dependencies` based on changed files; the other release-drafter
+labels — `bugfix`, `new-feature`, `breaking-change`,
+`enhancement`, `documentation` — are applied by maintainers from
+the Types-of-changes tick). If a maintainer relabels, that's not
+a sign your tick was wrong — it's the editorial slotting for the
+release notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,177 @@
-# Claude Code Instructions for aioesphomeapi
+# Notes for Claude
 
-## Code Formatting
+A short orientation file for an LLM working in this repo. Skim
+before making changes; keep edits consistent with what's described
+here. Read [README.rst](README.rst) for the user-facing intro.
 
-Always use `ruff` to ensure Python code formatting is correct before committing:
+## What this project is
 
-```bash
-# Check and fix linting issues
-./venv/bin/ruff check --fix .
+`aioesphomeapi` is the asyncio Python client for the ESPHome
+[Native API](https://esphome.io/components/api/). It talks
+length-prefixed protobuf frames over TCP — either plaintext or
+Noise (`Noise_NNpsk0_25519_ChaChaPoly_SHA256`) — to ESPHome-flashed
+devices. Used directly by the Home Assistant `esphome` integration
+and by anything else that wants to drive an ESPHome device from
+Python.
 
-# Format code
-./venv/bin/ruff format .
-```
+The protocol is defined firmware-side in `esphome/esphome`'s
+`api.proto`; this repo's `aioesphomeapi/api.proto` is the
+matching client view. Any protocol change lands in the firmware
+repo *first* (see PR workflow).
 
-## Regenerating Protobuf Files
+Hot paths (`connection.py`, `client_base.py`, `_frame_helper/*`)
+are Cythonized at build time for throughput. They keep working as
+pure Python — `SKIP_CYTHON=1` disables the extension build — but
+production wheels ship compiled and benchmarks track that path.
 
-When modifying `api.proto`, regenerate the protobuf bindings using the official docker image with docker/podman (depending on what is available on your system):
+## Code style
 
-```bash
-docker run --rm -v $PWD:/aioesphomeapi ghcr.io/esphome/aioesphomeapi-proto-builder:latest
-```
+- **Docstrings: terse, default to single-line.** A docstring is
+  the function's *contract*, not its narrative. Almost every
+  docstring should be one line — `"""Summary."""` — describing
+  what the function does and what the caller can pass. Multi-line
+  is the exception, only justified when there is non-obvious
+  caller-visible behaviour the type signature and parameter names
+  don't already convey.
 
-```bash
-podman run --rm -v $PWD:/aioesphomeapi --userns=keep-id ghcr.io/esphome/aioesphomeapi-proto-builder:latest
-```
+  **What does NOT belong in docstrings or comments:**
+  * Rationale / motivation / "why we used to do X" — that's the
+    PR description and the commit message. Git already remembers.
+  * Cross-references to issue numbers ("closes #N", "follow-up
+    to #M") — the PR body carries those.
+  * Restatement of the function body in prose. If the next line
+    of the docstring is just describing what the next line of
+    code does, delete the docstring line.
+  * Test docstrings retelling the production-side story. A test
+    docstring should name what the test pins, in one sentence —
+    not re-explain the bug, the fix, or the surrounding flow.
 
-This ensures the generated `api_pb2.py` is compatible with the protobuf runtime version used in the project.
+- **Comments**: same bar. Default to writing no comments. Add
+  one only when the *why* is non-obvious: a hidden constraint, a
+  subtle invariant, a workaround for a specific bug, behaviour
+  that would surprise a reader. If removing the comment wouldn't
+  confuse a future reader, don't write it.
 
-## Running Tests
+  **Don't remove existing comments** unless the code they
+  describe is gone — the original author left them for a reason.
+
+- **Don't pad commits, docstrings, or comments with cross-
+  references** to old codepaths or issue numbers unless there's
+  a clear reason a future reader needs that link.
+
+- **Method order**: public API at the top, private helpers
+  (`_underscore_prefixed`) at the bottom.
+
+- **Line length**: ruff default. `python_requires = ">=3.11"`,
+  `target-version = "py311"` for ruff.
+
+- **Imports**: ruff/isort sorted (`force-sort-within-sections`,
+  `combine-as-imports`, `split-on-trailing-comma = false`).
+  `from __future__ import annotations` at the top of every module
+  so we can use modern type syntax.
+
+- **Generated files are excluded from lint.** `api_pb2.py` and
+  `api_options_pb2.py` are ruff-excluded — never hand-edit them;
+  regenerate via the docker builder (see *Regenerating protobuf*
+  below).
+
+## Commit / PR conventions
+
+- **No `Co-Authored-By: Claude` trailer.** Project preference.
+- Imperative-mood subject line ("Add X", not "Added X").
+- The PR template lives in `.github/PULL_REQUEST_TEMPLATE.md`;
+  fill in every section, tick exactly one "Types of changes" box.
+  The `pr-workflow` skill (under `.claude/skills/pr-workflow/`)
+  walks through filling it in — branch off `origin/main`, pass
+  the body via `--body-file` so the template's backticks aren't
+  shell-escaped.
+- **`api.proto` changes need an upstream esphome PR first.** The
+  firmware repo owns the protocol; the matching change lands
+  there before the client PR. Link the esphome PR in the body
+  and tick the corresponding checklist row.
+- Pre-commit / CI runs ruff (lint + format). Run
+  `./venv/bin/ruff check --fix . && ./venv/bin/ruff format .`
+  before pushing. Failures auto-fix where possible, then the
+  commit needs to be re-staged.
+
+## Running tests
 
 ```bash
 ./venv/bin/python -m pytest tests/ -v
 ```
+
+The asyncio mode is `auto` (configured in `pyproject.toml`); test
+files don't need an explicit marker. CodSpeed benchmarks live
+under `tests/benchmarks/` and run in CI on a separate path.
+
+## Regenerating protobuf files
+
+When modifying `api.proto`, regenerate the bindings with the
+official docker image (the version-pinned image ensures `api_pb2.py`
+stays compatible with the protobuf runtime used by the project):
+
+```bash
+docker run --rm -v $PWD:/aioesphomeapi \
+  ghcr.io/esphome/aioesphomeapi-proto-builder:latest
+```
+
+Or with podman:
+
+```bash
+podman run --rm -v $PWD:/aioesphomeapi --userns=keep-id \
+  ghcr.io/esphome/aioesphomeapi-proto-builder:latest
+```
+
+Don't hand-edit `api_pb2.py` / `api_options_pb2.py` — regenerate
+through the builder. They're excluded from ruff for a reason.
+
+## Build conventions
+
+- **Cython is optional but expected in wheels.** `setup.py`
+  cythonizes the hot paths listed in `TO_CYTHONIZE`
+  (`connection.py`, `client_base.py`, `_frame_helper/{base,
+  noise, noise_encryption, packets, plain_text}.py`, plus
+  `_frame_helper/pack.pyx`). `OptionalBuildExt` swallows build
+  failures so source installs fall back to pure Python; CI wheel
+  builds set `REQUIRE_CYTHON=1` to make the build fail loudly if
+  the extension can't be produced.
+- Modules that get Cythonized ship a sibling `.pxd` for type
+  declarations. When changing the signature of a Cythonized
+  function, update its `.pxd` in the same commit, or the
+  extension build will pick up a stale declaration.
+- `language_level = "3"`, `freethreading_compatible = True`
+  (PEP 703). New `.py` / `.pyx` paths added to `TO_CYTHONIZE`
+  must stay free-threading-safe.
+
+## Useful entry points
+
+| Path | What |
+|---|---|
+| `aioesphomeapi/client.py` | High-level `APIClient` — what most callers use |
+| `aioesphomeapi/client_base.py` | Lower-level `APIClientBase` (Cythonized) |
+| `aioesphomeapi/connection.py` | `APIConnection`, framing, handshake (Cythonized) |
+| `aioesphomeapi/_frame_helper/` | Plaintext + Noise frame helpers (Cythonized) |
+| `aioesphomeapi/model.py` | Public dataclasses re-exported via `aioesphomeapi.*` |
+| `aioesphomeapi/core.py` | Exception hierarchy + message-type tables |
+| `aioesphomeapi/reconnect_logic.py` | `ReconnectLogic` retry/backoff helper |
+| `aioesphomeapi/host_resolver.py` | DNS / mDNS resolution for connect |
+| `aioesphomeapi/discover.py` | `aioesphomeapi-discover` CLI |
+| `aioesphomeapi/log_reader.py` | `aioesphomeapi-logs` CLI |
+| `aioesphomeapi/api.proto` | Client-side protocol definition (mirror of firmware) |
+| `aioesphomeapi/api_pb2.py` | **Generated** — do not hand-edit |
+| `tests/` | Pytest suite (asyncio_mode=auto) |
+| `tests/benchmarks/` | CodSpeed benchmarks |
+
+## Things not to do
+
+- **Don't hand-edit `api_pb2.py` / `api_options_pb2.py`.**
+  Regenerate via the docker builder.
+- **Don't land an `api.proto` change without the matching
+  esphome PR.** The firmware side is the source of truth.
+- **Don't add `Co-Authored-By: Claude` to commits** in this repo.
+- **Don't change Cythonized module signatures without updating
+  the `.pxd`** — the extension build will silently pick up a
+  stale declaration.
+- **Don't bypass `OptionalBuildExt`'s exception swallowing in
+  setup.py without thought.** Pure-Python fallback is a feature
+  for source installs on platforms without a compiler.


### PR DESCRIPTION
# What does this implement/fix?

Replaces the 32-line `CLAUDE.md` stub with a structured
orientation file for LLM contributors (shaped after the
`esphome/device-builder` `CLAUDE.md`), and adds a `pr-workflow`
skill under `.claude/skills/pr-workflow/SKILL.md` that walks
through filling in this repo's PR template.

The expanded `CLAUDE.md` covers: what the project is (Native API
client, Cython-on-hot-paths, protocol owned by the firmware
repo), code style (terse docstrings, comment discipline, ruff /
isort settings), commit + PR conventions, how to run tests,
how to regenerate the protobuf bindings (preserved from the old
stub), build conventions (Cython optional, `.pxd` discipline,
free-threading-compatible), a useful-entry-points table, and a
short "things not to do" list.

The `pr-workflow` skill summarises the parts that matter at
PR-creation time — branch from `origin/main` (no fork in this
workflow), tick exactly one "Types of changes" box, link a
matching `esphome/esphome` PR if `api.proto` was modified, pass
the body via `--body-file` so the template's backticks aren't
shell-escaped.

No runtime code changes; this PR only adds contributor-facing
documentation under `CLAUDE.md` and `.claude/`.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
