### PR TITLE
CLAUDE.md: fix inaccurate ruff target-version and future-import claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,13 +62,16 @@ production wheels ship compiled and benchmarks track that path.
 - **Method order**: public API at the top, private helpers
   (`_underscore_prefixed`) at the bottom.
 
-- **Line length**: ruff default. `python_requires = ">=3.11"`,
-  `target-version = "py311"` for ruff.
+- **Line length**: ruff default. Python 3.11+ only
+  (`python_requires = ">=3.11"`).
 
 - **Imports**: ruff/isort sorted (`force-sort-within-sections`,
   `combine-as-imports`, `split-on-trailing-comma = false`).
-  `from __future__ import annotations` at the top of every module
-  so we can use modern type syntax.
+  `from __future__ import annotations` at the top of regular
+  source modules so we can use modern type syntax. Known
+  exceptions: generated `*_pb2.py`, the re-export `__init__.py`,
+  and `_frame_helper/packets.py` (Cython needs annotations
+  evaluated at runtime).
 
 - **Generated files are excluded from lint.** `api_pb2.py` and
   `api_options_pb2.py` are ruff-excluded — never hand-edit them;


### PR DESCRIPTION
## Summary

Follow-up to #1646 addressing the [Copilot review comments](https://github.com/esphome/aioesphomeapi/pull/1646#pullrequestreview):

- **Ruff target-version claim (line 66)**: dropped the `target-version = "py311"` line — `pyproject.toml` doesn't actually pin it. Replaced with a Python-3.11+ note tied to `python_requires`. (Tried adding the pin to `pyproject.toml` instead, but it activated `ASYNC109` across many pre-existing `timeout: float` async signatures, which is well out of scope for a docs follow-up.)
- **`from __future__ import annotations` rule (line 71)**: reworded to call out the real exceptions — generated `*_pb2.py`, the re-export `__init__.py`, and `_frame_helper/packets.py` (Cython needs annotations evaluated at runtime).

The third Copilot comment (line 152, "double leading pipes in the table") was a false positive — the merged file uses standard single-pipe Markdown table syntax.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Follow-up to #1646

## Test plan

- [x] CLAUDE.md changes are docs-only; verified `ruff format --check .` is clean.