### PR TITLE
Bound camera image stream reassembly to prevent memory exhaustion

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -64,10 +64,17 @@ _LOGGER = logging.getLogger(__name__)
 # connection is poor.
 KEEP_ALIVE_FREQUENCY = 20.0
 
+# Caps on the per-subscription camera reassembly buffer. The peer fully
+# controls cam_msg.key and cam_msg.done, so without these limits a single
+# device can stream chunks indefinitely (memory exhaustion DoS) or rotate
+# keys to allocate ~4 billion list entries.
+MAX_CAMERA_FRAME_BYTES = 8 * 1024 * 1024
+MAX_INFLIGHT_CAMERA_KEYS = 4
+
 
 def on_state_msg(
     on_state: Callable[[EntityState], None],
-    image_stream: dict[int, list[bytes]],
+    image_stream: dict[int, bytearray | None],
     msg: message.Message,
 ) -> None:
     """Handle a state message."""
@@ -77,19 +84,50 @@ def on_state_msg(
     elif msg_type is CameraImageResponse:
         cam_msg: CameraImageResponse = msg
         msg_key = cam_msg.key
-        data_parts: list[bytes] | None = image_stream.get(msg_key)
-        if not data_parts:
-            data_parts = []
-            image_stream[msg_key] = data_parts
+        buf = image_stream.get(msg_key)
+        if buf is None:
+            if msg_key in image_stream:
+                # Key was discarded earlier (oversized frame); ignore further
+                # chunks until done=True so the peer can't restart with fresh
+                # data and emit a truncated frame.
+                if cam_msg.done:
+                    del image_stream[msg_key]
+                return
+            if len(image_stream) >= MAX_INFLIGHT_CAMERA_KEYS:
+                _LOGGER.warning(
+                    "Dropping camera frame chunk for key %s: too many in-flight"
+                    " camera streams (%d)",
+                    msg_key,
+                    len(image_stream),
+                )
+                return
+            buf = bytearray()
+            image_stream[msg_key] = buf
 
-        data_parts.append(cam_msg.data)
+        # Check the new size before extending so an oversized chunk can't
+        # transiently grow the buffer past the cap (or duplicate the
+        # peer-controlled bytes into the bytearray) before we drop it.
+        if len(buf) + len(cam_msg.data) > MAX_CAMERA_FRAME_BYTES:
+            if cam_msg.done:
+                # Stream is over — clear the entry instead of leaving a
+                # tombstone, otherwise oversized done=True chunks could
+                # exhaust MAX_INFLIGHT_CAMERA_KEYS until the peer sends
+                # another done=True for the same key.
+                del image_stream[msg_key]
+            else:
+                image_stream[msg_key] = None
+            _LOGGER.warning(
+                "Dropping camera frame for key %s: exceeded %d byte limit",
+                msg_key,
+                MAX_CAMERA_FRAME_BYTES,
+            )
+            return
+        buf.extend(cam_msg.data)
         if cam_msg.done:
-            # Return CameraState with the merged data
-            image_data = b"".join(data_parts)
             del image_stream[msg_key]
             on_state(
                 CameraState(
-                    key=cam_msg.key, data=image_data, device_id=cam_msg.device_id
+                    key=cam_msg.key, data=bytes(buf), device_id=cam_msg.device_id
                 )  # type: ignore[call-arg]
             )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,6 +110,7 @@ from aioesphomeapi.api_pb2 import (
     ZWaveProxyRequest as ZWaveProxyRequestPb,
 )
 from aioesphomeapi.client import APIClient, BluetoothConnectionDroppedError
+from aioesphomeapi.client_base import MAX_CAMERA_FRAME_BYTES, MAX_INFLIGHT_CAMERA_KEYS
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.core import (
     APIConnectionError,
@@ -578,6 +579,85 @@ async def test_subscribe_states_camera_with_device_id(auth_client: APIClient) ->
 
     await send(CameraImageResponse(key=2, data=b"data", done=True, device_id=5))
     on_state.assert_called_once_with(CameraState(key=2, data=b"testdata", device_id=5))
+
+
+async def test_subscribe_states_camera_drops_oversized_frame(
+    auth_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test camera frames exceeding the per-stream byte cap are dropped."""
+    send = patch_response_callback(auth_client)
+    on_state = MagicMock()
+    auth_client.subscribe_states(on_state)
+
+    # First chunk fits under the cap.
+    await send(CameraImageResponse(key=1, data=b"a" * (MAX_CAMERA_FRAME_BYTES - 1)))
+    on_state.assert_not_called()
+
+    # Second chunk pushes us over the cap.
+    caplog.clear()
+    await send(CameraImageResponse(key=1, data=b"bb"))
+    on_state.assert_not_called()
+    assert "exceeded" in caplog.text
+
+    # Further non-done chunks for the same key are silently ignored — the
+    # peer must not be able to restart the stream once we've discarded it.
+    await send(CameraImageResponse(key=1, data=b"x"))
+    on_state.assert_not_called()
+
+    # done=True for the discarded key clears tracking but emits no frame,
+    # so a peer can't flush a truncated frame after we drop the buffer.
+    await send(CameraImageResponse(key=1, data=b"y", done=True))
+    on_state.assert_not_called()
+
+    # A new stream on the same key is accepted normally afterwards.
+    await send(CameraImageResponse(key=1, data=b"hi", done=True))
+    on_state.assert_called_once_with(CameraState(key=1, data=b"hi"))
+
+
+async def test_subscribe_states_camera_drops_when_too_many_inflight_keys(
+    auth_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a peer rotating cam_msg.key cannot grow image_stream without bound."""
+    send = patch_response_callback(auth_client)
+    on_state = MagicMock()
+    auth_client.subscribe_states(on_state)
+
+    # Fill the in-flight slots without ever sending done=True.
+    for k in range(MAX_INFLIGHT_CAMERA_KEYS):
+        await send(CameraImageResponse(key=k, data=b"chunk"))
+    on_state.assert_not_called()
+
+    # A new key beyond the cap is dropped at the warn level.
+    caplog.clear()
+    await send(CameraImageResponse(key=999, data=b"chunk", done=True))
+    on_state.assert_not_called()
+    assert "too many in-flight" in caplog.text
+
+
+async def test_subscribe_states_camera_oversized_done_chunk_does_not_tombstone(
+    auth_client: APIClient,
+) -> None:
+    """Test single-chunk oversized done=True frames don't fill image_stream with tombstones."""
+    send = patch_response_callback(auth_client)
+    on_state = MagicMock()
+    auth_client.subscribe_states(on_state)
+
+    # Send MAX_INFLIGHT_CAMERA_KEYS distinct keys, each as a single oversized
+    # done=True chunk. If we left tombstones, image_stream would fill up and
+    # subsequent legitimate streams would all be dropped at the in-flight cap.
+    for k in range(MAX_INFLIGHT_CAMERA_KEYS):
+        await send(
+            CameraImageResponse(
+                key=k, data=b"x" * (MAX_CAMERA_FRAME_BYTES + 1), done=True
+            )
+        )
+    on_state.assert_not_called()
+
+    # A legitimate stream on a fresh key must still be accepted.
+    await send(CameraImageResponse(key=42, data=b"ok", done=True))
+    on_state.assert_called_once_with(CameraState(key=42, data=b"ok"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

`on_state_msg` reassembles `CameraImageResponse` chunks in a per-subscription `image_stream` dict keyed by `cam_msg.key`. Both `cam_msg.key` and `cam_msg.done` are peer-controlled fields, so without limits a single misbehaving or compromised device can:

1. Stream chunks with `done=False` indefinitely, growing one entry in `image_stream` without bound, **or**
2. Vary `cam_msg.key` (a 32-bit field) to allocate up to ~4 billion separate buffers.

Either path OOMs the host process of every state subscriber — most notably Home Assistant, which subscribes whenever an ESPHome integration has a camera.

This caps the per-stream byte total at **8 MiB** (generous headroom over the largest realistic ESP32-S3 5MP JPEG) and the number of concurrent in-flight keys at **4**. When either bound is exceeded the partial buffer is dropped and a warning is logged, so a later `done=True` for the same key cannot flush an oversized frame.

Also switches the accumulator from `list[bytes]` to `bytearray` so the per-chunk size check is O(1) instead of summing the list every chunk — without that, an attacker could force quadratic work by sending many small chunks just under the cap.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1643

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A (client-side only)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. (N/A — api.proto unchanged)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
