### PR TITLE
Pin ruff target-version to py311

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,9 @@ production wheels ship compiled and benchmarks track that path.
 - **Method order**: public API at the top, private helpers
   (`_underscore_prefixed`) at the bottom.
 
-- **Line length**: ruff default. Python 3.11+ only
-  (`python_requires = ">=3.11"`).
+- **Line length**: ruff default. Python 3.11+
+  (`python_requires = ">=3.11"`, `target-version = "py311"`
+  for ruff).
 
 - **Imports**: ruff/isort sorted (`force-sort-within-sections`,
   `combine-as-imports`, `split-on-trailing-comma = false`).

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -464,7 +464,7 @@ class APIConnection:
                 self._socket.setsockopt(
                     socket.SOL_SOCKET, socket.SO_RCVBUF, new_buffer_size
                 )
-            except OSError as err:  # noqa: PERF203
+            except OSError as err:
                 if new_buffer_size <= MIN_BUFFER_SIZE:
                     _LOGGER.warning(
                         "%s: Unable to increase the socket receive buffer size to %s; "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
 required-version = ">=0.5.0"
+target-version = "py311"
 exclude = [
   "aioesphomeapi/api_pb2.py",
   "aioesphomeapi/api_options_pb2.py",
@@ -28,6 +29,7 @@ select = [
 ]
 
 ignore = [
+  "ASYNC109", # `timeout` parameters are part of the public async API
   "E501", # line too long
   "E721", # We want type() check for protobuf messages
   "PLR0911", # Too many return statements ({returns} > {max_returns})

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import partial
 import time
 from typing import Any
@@ -31,7 +31,6 @@ from aioesphomeapi.client import ConnectionParams
 from aioesphomeapi.core import MESSAGE_TYPE_TO_PROTO, SocketClosedAPIError
 from aioesphomeapi.zeroconf import ZeroconfManager
 
-UTC = timezone.utc
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 # We use a partial here since it is implemented in native code
 # and avoids the global lookup of UTC


### PR DESCRIPTION
## Summary

Follow-up to #1647. That PR documented in `CLAUDE.md` that this project is Python-3.11-only; this PR makes the lint config match by pinning `target-version = "py311"` in `pyproject.toml`.

### Consequences of pinning the target version

- **`ASYNC109` (`timeout` parameter on async function)** fires on every public async method that takes a `timeout: float`. These are deliberate public-API surface — Home Assistant and other callers pass timeouts as kwargs — so rewriting them to `asyncio.timeout` would be a breaking change. Ignored project-wide with a comment recording the intent.
- ruff auto-removes a now-stale `# noqa: PERF203` in `aioesphomeapi/connection.py`.
- ruff auto-rewrites `from datetime import timezone; UTC = timezone.utc` to `from datetime import UTC` in `tests/common.py`. Dropped the now-redundant `UTC = UTC` self-assignment.
- Reworded the CLAUDE.md note from #1647 to once again describe the `target-version` pin.

### Test plan

- [x] `ruff check . && ruff format --check .` is clean.
- [x] Full test suite (excluding CodSpeed benchmarks): 948 passed, 1 skipped.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #1647