### PR TITLE
[ci] Use uv for pip installs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,34 +53,26 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: Restore PIP cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip-${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('requirements/base.txt', 'requirements/test.txt') }}
-          restore-keys: |
-            pip-${{ steps.python.outputs.python-version }}-${{ matrix.extension }}-
+          enable-cache: true
       - name: Set up Python environment (no cython)
         if: ${{ matrix.extension == 'skip_cython' }}
         env:
           SKIP_CYTHON: 1
         shell: bash
         run: |
-          pip3 install -r requirements/base.txt -r requirements/test.txt
-          pip3 install -e .
+          uv pip install --system -r requirements/base.txt -r requirements/test.txt
+          uv pip install --system -e .
       - name: Set up Python environment (cython)
         if: ${{ matrix.extension == 'use_cython' }}
         env:
           REQUIRE_CYTHON: 1
         shell: bash
         run: |
-          pip3 install -r requirements/base.txt -r requirements/test.txt
-          pip3 install -e .
+          uv pip install --system -r requirements/base.txt -r requirements/test.txt
+          uv pip install --system -e .
       - name: Register problem matchers
         shell: bash
         run: |
@@ -138,14 +130,17 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.14"
-          cache: 'pip' # caching pip dependencies
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
       - name: Set up Python environment (cython)
         env:
             REQUIRE_CYTHON: 1
         shell: bash
         run: |
-            pip3 install -r requirements/base.txt -r requirements/test.txt
-            pip3 install -e .
+            uv pip install --system -r requirements/base.txt -r requirements/test.txt
+            uv pip install --system -e .
       - name: Run benchmarks
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd  # v4.15.1
         with:


### PR DESCRIPTION
# What does this implement/fix?

Mirror of esphome/esphome#16451 for the `aioesphomeapi` side.

`.github/workflows/ci.yml` was the only place still calling raw
`pip3 install`. Both matrix entries in the `ci` job (skip_cython
/ use_cython) and the standalone `benchmarks` job now go through
`uv pip install --system`, with `astral-sh/setup-uv@v8.1.0`
(SHA-pinned, `enable-cache: true`) added beforehand.

Changes:

- **`ci` job** — drops the manual `pip cache dir` + `actions/cache`
  pair (redundant once `uv` has its own cache) and rewrites the
  two `Set up Python environment (...)` steps to use `uv pip
  install --system`. There is no venv in this workflow, so
  `--system` lands the install in the `setup-python` interpreter,
  matching the previous `pip3 install` shape.
- **`benchmarks` job** — drops `cache: 'pip'` from `setup-python`
  for the same reason and switches its `pip3 install` calls to
  `uv pip install --system`.

No production code is touched; this is workflow-only. Steady-state
behaviour is identical to today — the speed-up shows up on cache
misses (requirements change, new Python version, etc.) and on the
first run after the cache key rotates.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Mirrors esphome/esphome#16451.

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#16451

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
