### PR TITLE
Bound plaintext varuint length and frame size to prevent buffer-growth DoS

### DIFF
--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -6,6 +6,12 @@ from .packets cimport make_plain_text_packets
 
 cdef bint TYPE_CHECKING
 
+cdef int _MAX_VARUINT_BYTES
+cdef unsigned int _MAX_VARUINT_BITPOS
+cdef int _MAX_PLAINTEXT_FRAME_SIZE
+cdef int _VARUINT_INCOMPLETE
+cdef int _VARUINT_PROTOCOL_ERROR
+
 
 cdef class APIPlaintextFrameHelper(APIFrameHelper):
 

--- a/aioesphomeapi/_frame_helper/plain_text.pxd
+++ b/aioesphomeapi/_frame_helper/plain_text.pxd
@@ -19,6 +19,8 @@ cdef class APIPlaintextFrameHelper(APIFrameHelper):
 
     cdef void _error_on_incorrect_preamble(self, int preamble) except *
 
+    cdef void _close_on_oversized_varuint(self) except *
+
     @cython.locals(
         result="unsigned int",
         bitpos="unsigned int",

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -55,10 +55,15 @@ class APIPlaintextFrameHelper(APIFrameHelper):
     def _read_varuint(self) -> _int:
         """Read a varuint from the buffer.
 
-        Returns the decoded value, or _VARUINT_INCOMPLETE if more bytes are
-        needed. If the varuint exceeds _MAX_VARUINT_BYTES the connection is
-        closed and _VARUINT_PROTOCOL_ERROR is returned, so the caller can
-        treat any negative value as "stop processing this frame".
+        Pure C path with no Python calls. Returns one of:
+          * the decoded value (>= 0), if a complete varuint was read;
+          * _VARUINT_INCOMPLETE, if the buffer ran out mid-varuint;
+          * _VARUINT_PROTOCOL_ERROR, if the varuint exceeds
+            _MAX_VARUINT_BYTES (the caller is responsible for closing the
+            connection).
+
+        Callers must check for both sentinels explicitly rather than
+        treating any negative value generically.
         """
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"
@@ -75,34 +80,42 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             # Check after the byte read so the common 1-byte varuint path
             # (high bit unset on the first byte) skips this branch entirely.
             if bitpos >= _MAX_VARUINT_BITPOS:
-                self._handle_error_and_close(
-                    ProtocolAPIError(
-                        f"{self._log_name}: varuint exceeds "
-                        f"{_MAX_VARUINT_BYTES}-byte limit"
-                    )
-                )
                 return _VARUINT_PROTOCOL_ERROR
         return _VARUINT_INCOMPLETE
+
+    def _close_on_oversized_varuint(self) -> None:
+        """Close the connection on a varuint that exceeds the byte cap."""
+        self._handle_error_and_close(
+            ProtocolAPIError(
+                f"{self._log_name}: varuint exceeds {_MAX_VARUINT_BYTES}-byte limit"
+            )
+        )
 
     def data_received(self, data: bytes | bytearray | memoryview) -> None:
         self._add_to_buffer(data)
         # Message header is at least 3 bytes, empty length allowed
         while self._buffer_len >= 3:
             self._pos = 0
-            # _read_varuint's contract is: a non-negative decoded value, or
-            # one of the two negative sentinels (_VARUINT_INCOMPLETE /
-            # _VARUINT_PROTOCOL_ERROR). The 4-byte cap on _MAX_VARUINT_BYTES
-            # keeps decoded values in [0, 2**28 - 1], well clear of the
-            # unsigned -> signed int cast boundary (2**31), so no other
-            # negative is reachable.
+            # _read_varuint is pure C and returns either a non-negative
+            # decoded value or one of the two negative sentinels —
+            # _VARUINT_INCOMPLETE (wait for more data) or
+            # _VARUINT_PROTOCOL_ERROR (varuint too long; close the
+            # connection here since _read_varuint can't safely call into
+            # Python from a noexcept cdef path).
             preamble = self._read_varuint()
             if preamble != 0x00:
-                if preamble in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
+                if preamble == _VARUINT_PROTOCOL_ERROR:
+                    self._close_on_oversized_varuint()
+                    return
+                if preamble == _VARUINT_INCOMPLETE:
                     return
                 self._error_on_incorrect_preamble(preamble)
                 return
             length = self._read_varuint()
-            if length in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
+            if length == _VARUINT_PROTOCOL_ERROR:
+                self._close_on_oversized_varuint()
+                return
+            if length == _VARUINT_INCOMPLETE:
                 return
             if length > _MAX_PLAINTEXT_FRAME_SIZE:
                 self._handle_error_and_close(
@@ -113,7 +126,10 @@ class APIPlaintextFrameHelper(APIFrameHelper):
                 )
                 return
             msg_type = self._read_varuint()
-            if msg_type in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
+            if msg_type == _VARUINT_PROTOCOL_ERROR:
+                self._close_on_oversized_varuint()
+                return
+            if msg_type == _VARUINT_INCOMPLETE:
                 return
 
             if length == 0:
@@ -142,5 +158,5 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             )
             return
         self._handle_error_and_close(
-            ProtocolAPIError(f"{self._log_name}: Invalid preamble {preamble!r}")
+            ProtocolAPIError(f"{self._log_name}: Invalid preamble 0x{preamble:02x}")
         )

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -9,6 +9,26 @@ from .packets import make_plain_text_packets
 
 _int = int
 
+# Cap at 4 bytes so the decoded value (max 2**28 - 1) always fits in a signed
+# 32-bit int. Under Cython, `result` is `unsigned int` and the function returns
+# `int`; a 5-byte varuint could decode to a value >= 2**31 that would cast to a
+# *negative* int and silently hit the < 0 sentinel branch in data_received,
+# leaving the buffer-growth DoS open. 4 bytes is well above any value used by
+# the protocol (length is capped at 65535 = 17 bits; msg_type fits in 1 byte).
+_MAX_VARUINT_BYTES = 4
+# bitpos is incremented by 7 after each continuation byte, so 28 bits means we
+# have already consumed 4 continuation bytes — one more would be the 5th byte.
+_MAX_VARUINT_BITPOS = 7 * _MAX_VARUINT_BYTES
+
+# Bounds the per-frame allocation a peer can request via the length varuint.
+# Matches the firmware's uint16_t wire-format max (65535), which is the same
+# absolute cap the noise path gets for free from its fixed 16-bit length header.
+_MAX_PLAINTEXT_FRAME_SIZE = 65535
+
+# _read_varuint return sentinels (negative because varuints are non-negative).
+_VARUINT_INCOMPLETE = -1
+_VARUINT_PROTOCOL_ERROR = -2
+
 
 class APIPlaintextFrameHelper(APIFrameHelper):
     """Frame helper for plaintext API connections."""
@@ -30,7 +50,13 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         self._write_bytes(make_plain_text_packets(packets), debug_enabled)
 
     def _read_varuint(self) -> _int:
-        """Read a varuint from the buffer or -1 if the buffer runs out of bytes."""
+        """Read a varuint from the buffer.
+
+        Returns the decoded value, or _VARUINT_INCOMPLETE if more bytes are
+        needed. If the varuint exceeds _MAX_VARUINT_BYTES the connection is
+        closed and _VARUINT_PROTOCOL_ERROR is returned, so the caller can
+        treat any negative value as "stop processing this frame".
+        """
         if TYPE_CHECKING:
             assert self._buffer is not None, "Buffer should be set"
         result = 0
@@ -43,20 +69,48 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             if (val & 0x80) == 0:
                 return result
             bitpos += 7
-        return -1
+            # Check after the byte read so the common 1-byte varuint path
+            # (high bit unset on the first byte) skips this branch entirely.
+            if bitpos >= _MAX_VARUINT_BITPOS:
+                self._handle_error_and_close(
+                    ProtocolAPIError(
+                        f"{self._log_name}: varuint exceeds "
+                        f"{_MAX_VARUINT_BYTES}-byte limit"
+                    )
+                )
+                return _VARUINT_PROTOCOL_ERROR
+        return _VARUINT_INCOMPLETE
 
     def data_received(self, data: bytes | bytearray | memoryview) -> None:
         self._add_to_buffer(data)
         # Message header is at least 3 bytes, empty length allowed
         while self._buffer_len >= 3:
             self._pos = 0
-            # Read preamble, which should always 0x00
-            if (preamble := self._read_varuint()) != 0x00:
+            # _read_varuint's contract is: a non-negative decoded value, or
+            # one of the two negative sentinels (_VARUINT_INCOMPLETE /
+            # _VARUINT_PROTOCOL_ERROR). The 4-byte cap on _MAX_VARUINT_BYTES
+            # keeps decoded values in [0, 2**28 - 1], well clear of the
+            # unsigned -> signed int cast boundary (2**31), so no other
+            # negative is reachable.
+            preamble = self._read_varuint()
+            if preamble != 0x00:
+                if preamble in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
+                    return
                 self._error_on_incorrect_preamble(preamble)
                 return
-            if (length := self._read_varuint()) == -1:
+            length = self._read_varuint()
+            if length in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
                 return
-            if (msg_type := self._read_varuint()) == -1:
+            if length > _MAX_PLAINTEXT_FRAME_SIZE:
+                self._handle_error_and_close(
+                    ProtocolAPIError(
+                        f"{self._log_name}: frame length {length} exceeds "
+                        f"{_MAX_PLAINTEXT_FRAME_SIZE}-byte limit"
+                    )
+                )
+                return
+            msg_type = self._read_varuint()
+            if msg_type in (_VARUINT_INCOMPLETE, _VARUINT_PROTOCOL_ERROR):
                 return
 
             if length == 0:
@@ -85,5 +139,5 @@ class APIPlaintextFrameHelper(APIFrameHelper):
             )
             return
         self._handle_error_and_close(
-            ProtocolAPIError(f"{self._log_name}: Invalid preamble {preamble:02x}")
+            ProtocolAPIError(f"{self._log_name}: Invalid preamble {preamble!r}")
         )

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -23,7 +23,10 @@ _MAX_VARUINT_BITPOS = 7 * _MAX_VARUINT_BYTES
 # Bounds the per-frame allocation a peer can request via the length varuint.
 # Matches the firmware's uint16_t wire-format max (65535), which is the same
 # absolute cap the noise path gets for free from its fixed 16-bit length header.
-_MAX_PLAINTEXT_FRAME_SIZE = 65535
+# MAX_PLAINTEXT_FRAME_SIZE is the Python-importable form (used by tests);
+# _MAX_PLAINTEXT_FRAME_SIZE is the cdef int form used internally per .pxd.
+MAX_PLAINTEXT_FRAME_SIZE = 65535
+_MAX_PLAINTEXT_FRAME_SIZE = MAX_PLAINTEXT_FRAME_SIZE
 
 # _read_varuint return sentinels (negative because varuints are non-negative).
 _VARUINT_INCOMPLETE = -1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.client import APIClient, ConnectionParams
 from aioesphomeapi.connection import APIConnection
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
+from aioesphomeapi.singleton import _SINGLETON_CACHE
 
 from .common import (
     _create_mock_transport_protocol,
@@ -259,6 +260,16 @@ def long_repr_strings() -> Generator[None]:
     finally:
         arepr.maxstring = original_maxstring
         arepr.maxother = original_maxother
+
+
+@pytest.fixture(autouse=True)
+def _clear_singleton_cache() -> Generator[None]:
+    """Reset the global singleton cache so a Future from a previous test's
+    event loop can't be awaited from the current test's loop and trigger
+    'await wasn't used with future' on Python 3.14."""
+    _SINGLETON_CACHE.clear()
+    yield
+    _SINGLETON_CACHE.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -44,6 +44,11 @@ from .common import (
     mock_data_received,
 )
 
+# Mirrored from aioesphomeapi/_frame_helper/plain_text.py — that constant is
+# cdef-typed in the .pxd so it is not importable from Python under Cython.
+_MAX_PLAINTEXT_FRAME_SIZE = 65535
+
+
 _PLAINTEXT_TESTS = [
     (PREAMBLE + varuint_to_bytes(0) + varuint_to_bytes(1), b"", 1),
     (
@@ -757,6 +762,99 @@ async def test_init_plaintext_with_wrong_preamble(
 
     with pytest.raises(ProtocolAPIError):
         await task
+
+
+async def test_plaintext_frame_helper_rejects_overlong_varuint() -> None:
+    """Test a never-terminating varuint is rejected instead of growing the buffer forever."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # Six bytes with the high bit always set — would otherwise be accumulated
+    # into an ever-growing bigint while the varuint is rescanned each chunk.
+    mock_data_received(helper, b"\x80\x80\x80\x80\x80\x80")
+
+    assert not packets
+    assert isinstance(connection._fatal_exception, ProtocolAPIError)
+    assert "varuint exceeds" in str(connection._fatal_exception)
+
+
+async def test_plaintext_frame_helper_rejects_oversized_frame_length() -> None:
+    """Test a length varuint above the per-frame cap closes the connection."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # Valid preamble + a length one byte over the cap + any msg_type.
+    mock_data_received(
+        helper,
+        PREAMBLE
+        + varuint_to_bytes(_MAX_PLAINTEXT_FRAME_SIZE + 1)
+        + varuint_to_bytes(1),
+    )
+
+    assert not packets
+    assert isinstance(connection._fatal_exception, ProtocolAPIError)
+    assert "exceeds" in str(connection._fatal_exception)
+
+
+async def test_plaintext_frame_helper_rejects_overlong_length_varuint() -> None:
+    """Test a never-terminating length varuint after a valid preamble closes the connection."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # Valid 0x00 preamble, then 6 continuation bytes for the length varuint.
+    mock_data_received(helper, PREAMBLE + b"\x80\x80\x80\x80\x80\x80")
+
+    assert not packets
+    assert isinstance(connection._fatal_exception, ProtocolAPIError)
+    assert "varuint exceeds" in str(connection._fatal_exception)
+
+
+async def test_plaintext_frame_helper_rejects_overlong_msg_type_varuint() -> None:
+    """Test a never-terminating msg_type varuint after a valid length closes the connection."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # Valid preamble + valid 1-byte length + 6 continuation bytes for msg_type.
+    mock_data_received(
+        helper, PREAMBLE + varuint_to_bytes(0) + b"\x80\x80\x80\x80\x80\x80"
+    )
+
+    assert not packets
+    assert isinstance(connection._fatal_exception, ProtocolAPIError)
+    assert "varuint exceeds" in str(connection._fatal_exception)
+
+
+async def test_plaintext_frame_helper_accepts_max_frame_length() -> None:
+    """Test a frame at the size cap is still accepted (off-by-one guard)."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    payload = b"\x42" * _MAX_PLAINTEXT_FRAME_SIZE
+    mock_data_received(
+        helper,
+        PREAMBLE
+        + varuint_to_bytes(_MAX_PLAINTEXT_FRAME_SIZE)
+        + varuint_to_bytes(42)
+        + payload,
+    )
+
+    assert connection._fatal_exception is None
+    assert packets == [(42, payload)]
 
 
 async def test_init_noise_with_wrong_byte_marker(noise_conn: APIConnection) -> None:

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -16,7 +16,10 @@ from aioesphomeapi._frame_helper.packets import (
     _cached_varuint_to_bytes as cached_varuint_to_bytes,
     _varuint_to_bytes as varuint_to_bytes,
 )
-from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
+from aioesphomeapi._frame_helper.plain_text import (
+    MAX_PLAINTEXT_FRAME_SIZE,
+    APIPlaintextFrameHelper,
+)
 from aioesphomeapi.connection import ConnectionState
 from aioesphomeapi.core import (
     APIConnectionError,
@@ -43,11 +46,6 @@ from .common import (
     get_mock_protocol,
     mock_data_received,
 )
-
-# Mirrored from aioesphomeapi/_frame_helper/plain_text.py — that constant is
-# cdef-typed in the .pxd so it is not importable from Python under Cython.
-_MAX_PLAINTEXT_FRAME_SIZE = 65535
-
 
 _PLAINTEXT_TESTS = [
     (PREAMBLE + varuint_to_bytes(0) + varuint_to_bytes(1), b"", 1),
@@ -792,14 +790,37 @@ async def test_plaintext_frame_helper_rejects_oversized_frame_length() -> None:
     # Valid preamble + a length one byte over the cap + any msg_type.
     mock_data_received(
         helper,
-        PREAMBLE
-        + varuint_to_bytes(_MAX_PLAINTEXT_FRAME_SIZE + 1)
-        + varuint_to_bytes(1),
+        PREAMBLE + varuint_to_bytes(MAX_PLAINTEXT_FRAME_SIZE + 1) + varuint_to_bytes(1),
     )
 
     assert not packets
     assert isinstance(connection._fatal_exception, ProtocolAPIError)
     assert "exceeds" in str(connection._fatal_exception)
+
+
+async def test_plaintext_frame_helper_rejects_5_byte_high_bit_varuint() -> None:
+    """Test a 5-byte varuint that would decode to a value with bit 31 set is rejected.
+
+    Regression for the Cython unsigned->signed cast trap raised in PR #1651
+    review: with `result="unsigned int"` and `cdef int` return, a value
+    >= 2**31 would otherwise come back negative and silently hit the
+    incomplete-varuint path. The 4-byte cap rejects the 5th byte at the
+    bitpos limit before any cast can happen.
+    """
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # Bytes that would decode to 0xFFFFFFFF (high bit set) under a 5-byte
+    # varuint: \xff\xff\xff\xff\x0f. The 4-byte cap fires before we ever
+    # consume the 5th byte.
+    mock_data_received(helper, PREAMBLE + b"\xff\xff\xff\xff\x0f")
+
+    assert not packets
+    assert isinstance(connection._fatal_exception, ProtocolAPIError)
+    assert "varuint exceeds" in str(connection._fatal_exception)
 
 
 async def test_plaintext_frame_helper_rejects_overlong_length_varuint() -> None:
@@ -844,11 +865,11 @@ async def test_plaintext_frame_helper_accepts_max_frame_length() -> None:
     )
     helper.connection_made(MagicMock())
 
-    payload = b"\x42" * _MAX_PLAINTEXT_FRAME_SIZE
+    payload = b"\x42" * MAX_PLAINTEXT_FRAME_SIZE
     mock_data_received(
         helper,
         PREAMBLE
-        + varuint_to_bytes(_MAX_PLAINTEXT_FRAME_SIZE)
+        + varuint_to_bytes(MAX_PLAINTEXT_FRAME_SIZE)
         + varuint_to_bytes(42)
         + payload,
     )

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -779,6 +779,24 @@ async def test_plaintext_frame_helper_rejects_overlong_varuint() -> None:
     assert "varuint exceeds" in str(connection._fatal_exception)
 
 
+async def test_plaintext_frame_helper_incomplete_preamble_waits() -> None:
+    """Test 3 continuation bytes for the preamble varuint pause parsing rather than close."""
+    connection, packets = _make_mock_connection()
+    helper = APIPlaintextFrameHelper(
+        connection=connection, client_info="my client", log_name="test"
+    )
+    helper.connection_made(MagicMock())
+
+    # 3 continuation bytes meets the loop guard (>= 3) but the preamble
+    # varuint is incomplete — bitpos is 21, still under the 28-bit cap.
+    # _read_varuint should return _VARUINT_INCOMPLETE; data_received must
+    # leave the connection open so the next chunk can finish the varuint.
+    mock_data_received(helper, b"\x80\x80\x80")
+
+    assert not packets
+    assert connection._fatal_exception is None
+
+
 async def test_plaintext_frame_helper_rejects_oversized_frame_length() -> None:
     """Test a length varuint above the per-frame cap closes the connection."""
     connection, packets = _make_mock_connection()


### PR DESCRIPTION
# What does this implement/fix?

`APIPlaintextFrameHelper._read_varuint()` decoded varuints with no upper bound on continuation bytes, and `data_received` had no cap on the length varuint. Two related DoS vectors followed for any peer that can speak to a plaintext-mode client (anyone on the LAN of a device running without `noise_psk`):

1. **Unbounded varuint** — stream `\x80\x80\x80…` forever. The varuint never terminates, `_read_varuint` returns `-1`, `_remove_from_buffer` is never called, so `_add_to_buffer` keeps appending and every chunk re-scans from `self._pos = 0`, rebuilding an ever-larger Python `int`. O(N²) work over the buffer size on top of unbounded memory.
2. **Unbounded frame length** — send a well-formed preamble plus a length varuint of e.g. 4 GiB. `_read()` keeps buffering until that many bytes arrive — easy OOM.

The noise path is incidentally protected because its length is a fixed 16-bit header (max 65535); plaintext had no equivalent cap.

This caps the varuint at **4 bytes** and the per-frame length at **65535**. Both bounds raise `ProtocolAPIError` and close the connection.

The 4-byte varuint cap is intentional — under Cython, `_read_varuint`'s `result` is `unsigned int` and the function returns `cdef int`. A 5-byte varuint can decode up to `0xFFFFFFFF`; values with bit 31 set would come back as a *negative* int and silently hit the sentinel branch in `data_received`, leaving the buffer-growth DoS open. 4 bytes keeps the decoded value in `[0, 2**28 - 1]`, well clear of the unsigned→signed cast boundary, and is well above any value the protocol actually uses (length is bounded at 65535 = 17 bits; msg_type fits in 1 byte).

`data_received` checks for the two explicit sentinels (`_VARUINT_INCOMPLETE` / `_VARUINT_PROTOCOL_ERROR`) rather than `< 0`, so the same trap can't be re-introduced by a future widening of the varuint cap without an accompanying caller change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1642

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A (client-side only)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. (N/A — api.proto unchanged)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).