### PR TITLE
Don't let zeroconf init failure block the connect attempt

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -453,7 +453,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 async_zc = self._zeroconf_manager.get_async_zeroconf()
                 async_zc.zeroconf.async_add_listener(self, None)
             except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.warning(
+                _LOGGER.log(
+                    logging.WARNING if self._tries == 0 else logging.DEBUG,
                     "Could not start zeroconf listener for %s: %s (%s); "
                     "continuing without mDNS-triggered reconnects",
                     self._cli.log_name,

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -180,6 +180,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         """
         self._connection_state = state
 
+    def _first_try_log_level(self) -> int:
+        """WARNING on the first attempt of a reconnect cycle, DEBUG after."""
+        return logging.WARNING if self._tries == 0 else logging.DEBUG
+
     def _async_log_connection_error(self, err: Exception) -> None:
         """Log connection errors."""
         # UnhandledAPIConnectionError is a special case in client
@@ -194,10 +198,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         elif isinstance(err, APIConnectionCancelledError):
             # APIConnectionCancelledError is harmless and should always be DEBUG
             level = logging.DEBUG
-        elif self._tries == 0:
-            level = logging.WARNING
         else:
-            level = logging.DEBUG
+            level = self._first_try_log_level()
         _LOGGER.log(
             level,
             "Can't connect to ESPHome API for %s: %s (%s)",
@@ -454,7 +456,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 async_zc.zeroconf.async_add_listener(self, None)
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.log(
-                    logging.WARNING if self._tries == 0 else logging.DEBUG,
+                    self._first_try_log_level(),
                     "Could not start zeroconf listener for %s: %s (%s); "
                     "continuing without mDNS-triggered reconnects",
                     self._cli.log_name,

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -439,15 +439,28 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         """Listen for mDNS records.
 
         This listener allows us to schedule a connect as soon as a
-        received mDNS record indicates the node is up again.
+        received mDNS record indicates the node is up again. Failures
+        to start the zeroconf stack (e.g. port 5353 already bound on
+        BSD-derived systems running avahi) must not prevent the
+        connect attempt; the listener is a reconnect-speed
+        optimisation, not a requirement for connecting.
         """
         if not self._zc_listening and self.name and not self._is_ip_address:
             _LOGGER.debug("Starting zeroconf listener for %s", self.name)
             self._ptr_alias = f"{self.name}._esphomelib._tcp.local."
             self._a_name = f"{self.name}.local."
-            self._zeroconf_manager.get_async_zeroconf().zeroconf.async_add_listener(
-                self, None
-            )
+            try:
+                async_zc = self._zeroconf_manager.get_async_zeroconf()
+                async_zc.zeroconf.async_add_listener(self, None)
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Could not start zeroconf listener for %s: %s (%s); "
+                    "continuing without mDNS-triggered reconnects",
+                    self._cli.log_name,
+                    err,
+                    type(err).__name__,
+                )
+                return
             self._zc_listening = True
 
     def _stop_zc_listen(self) -> None:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1499,3 +1499,52 @@ async def test_resolved_log_level_changes_after_first_attempt(
     assert log_record.levelno == logging.DEBUG
 
     await logic.stop()
+
+
+@pytest.mark.asyncio
+async def test_zc_listen_failure_does_not_block_connect(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Connect must proceed when zeroconf init fails (issue #1613, BSD port 5353)."""
+    cli = patchable_api_client
+    on_connect = AsyncMock()
+    on_disconnect = AsyncMock()
+    on_connect_fail = AsyncMock()
+
+    logic = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        on_connect_error=on_connect_fail,
+        name="mydevice",
+    )
+
+    caplog.clear()
+    with (
+        patch.object(
+            cli.zeroconf_manager,
+            "get_async_zeroconf",
+            side_effect=OSError(48, "Address already in use"),
+        ),
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection"),
+        patch.object(cli, "finish_connection"),
+    ):
+        await logic.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    # The connection should have succeeded despite the zeroconf failure.
+    assert on_connect.call_count == 1
+    assert on_connect_fail.call_count == 0
+    assert logic._connection_state is ReconnectLogicState.READY
+    # The zeroconf failure should have been logged as a warning.
+    log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
+    assert log_record is not None, "Expected zeroconf failure warning was not logged"
+    assert log_record.levelno == logging.WARNING
+    # _zc_listening must remain False so stop() doesn't try to remove a listener
+    # we never added.
+    assert logic._zc_listening is False
+
+    await logic.stop()

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1539,12 +1539,55 @@ async def test_zc_listen_failure_does_not_block_connect(
     assert on_connect.call_count == 1
     assert on_connect_fail.call_count == 0
     assert logic._connection_state is ReconnectLogicState.READY
-    # The zeroconf failure should have been logged as a warning.
+    # The zeroconf failure should have been logged as a warning on the first try.
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
     assert log_record is not None, "Expected zeroconf failure warning was not logged"
     assert log_record.levelno == logging.WARNING
     # _zc_listening must remain False so stop() doesn't try to remove a listener
     # we never added.
     assert logic._zc_listening is False
+
+    await logic.stop()
+
+
+@pytest.mark.asyncio
+async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeated zeroconf init failures must not spam WARNING (Copilot review on #1652)."""
+    cli = patchable_api_client
+    logic = ReconnectLogic(
+        client=cli,
+        on_connect=AsyncMock(),
+        on_disconnect=AsyncMock(),
+        on_connect_error=AsyncMock(),
+        name="mydevice",
+    )
+
+    # Drive a non-zero _tries by failing the first resolve; this mirrors the
+    # "zeroconf keeps failing across reconnect attempts" scenario.
+    with (
+        patch.object(
+            cli.zeroconf_manager,
+            "get_async_zeroconf",
+            side_effect=OSError(48, "Address already in use"),
+        ),
+        patch.object(cli, "start_resolve_host", side_effect=APIConnectionError),
+    ):
+        await logic.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert logic._tries == 1
+
+        caplog.clear()
+        assert logic._connect_timer is not None
+        logic._connect_timer._run()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
+    assert log_record is not None, "Expected zeroconf failure log was not emitted"
+    assert log_record.levelno == logging.DEBUG
 
     await logic.stop()


### PR DESCRIPTION
# What does this implement/fix?

When `ReconnectLogic._start_zc_listen()` constructed the
`AsyncZeroconf` instance on a host where port 5353 was already
bound (e.g. FreeBSD running avahi, per issue #1613), the
`OSError: [Errno 48] Address already in use` propagated out of
`_connect_once_or_reschedule` and the connect task died silently
— no further log output, no retry, no connection.

The mDNS listener is purely a reconnect-speed optimisation: it
lets us trigger an immediate connect attempt when the device's
mDNS records reappear. It is not required to connect at all. This
change wraps the zeroconf init + listener registration in a
try/except inside `_start_zc_listen`, logs a single WARNING
describing the failure, and continues. `_zc_listening` stays
`False` on failure so `_stop_zc_listen` won't try to remove a
listener that was never added, and the next reconnect cycle will
retry the zeroconf init (in case the conflicting process has
since exited).

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1613

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
