### PR TITLE
Sanitize unauthenticated noise hello fields before logging

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -16,6 +16,12 @@ cdef bytes NOISE_HELLO
 cdef object InvalidTag
 cdef object ESPHOME_NOISE_BACKEND
 
+cdef int _MAX_NAME_LEN
+cdef int _MAX_MAC_LEN
+cdef int _MAX_EXPLANATION_LEN
+
+cdef str _safe_label(bytes raw, int limit)
+
 cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef object _noise_psk

--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -20,7 +20,7 @@ cdef int _MAX_NAME_LEN
 cdef int _MAX_MAC_LEN
 cdef int _MAX_EXPLANATION_LEN
 
-cdef str _safe_label(bytes raw, int limit)
+cdef str _safe_label_str(str raw, int limit)
 
 cdef class APINoiseFrameHelper(APIFrameHelper):
 
@@ -55,7 +55,9 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
         server_name_i=int,
         mac_address_i=int,
         mac_address=str,
+        mac_address_raw=str,
         server_name=str,
+        server_name_raw=str,
     )
     cdef void _handle_hello(self, bytes server_hello) except *
 

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -44,6 +44,34 @@ NOISE_HELLO = b"\x01\x00\x00"
 
 int_ = int
 
+# Caps match the firmware's actual wire-format limits:
+#   - name: ESPHOME_DEVICE_NAME_MAX_LEN = 31 (validate_hostname in core/config.py)
+#   - mac: MAC_ADDRESS_BUFFER_SIZE - 1 = 12 (lowercase hex, no separator)
+#   - explanation: 32-byte handshake-reject buffer minus the 1-byte failure code
+# A small extra margin on each lets benign forward-compat tweaks (e.g. firmware
+# bumping the max name length by a few chars) through without breaking clients.
+# MAX_* are the Python-importable forms (used by tests); _MAX_* are the cdef
+# int aliases used internally per the .pxd.
+MAX_NAME_LEN = 32
+MAX_MAC_LEN = 16
+MAX_EXPLANATION_LEN = 64
+_MAX_NAME_LEN = MAX_NAME_LEN
+_MAX_MAC_LEN = MAX_MAC_LEN
+_MAX_EXPLANATION_LEN = MAX_EXPLANATION_LEN
+
+
+def _safe_label(raw: bytes, limit: int_) -> str:
+    """Decode and sanitize a peer-supplied label for safe inclusion in logs.
+
+    The Noise hello phase exchanges the server name, MAC address, and
+    handshake-failure explanation as raw bytes before the PSK-authenticated
+    handshake completes. An on-path attacker can put anything in those
+    fields. Strip non-printable characters (newlines, ANSI escapes, NULs,
+    bell, etc.) so they can't inject log lines, smuggle terminal escape
+    sequences into operator-visible logs, or crash a strict UTF-8 decoder.
+    """
+    return "".join(c for c in raw.decode("utf-8", "replace") if c.isprintable())[:limit]
+
 
 class APINoiseFrameHelper(APIFrameHelper):
     """Frame helper for noise encrypted connections."""
@@ -191,7 +219,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         server_name_i = server_hello.find(b"\0", 1)
         if server_name_i != -1:
             # server name found, this extension was added in 2022.2
-            server_name = server_hello[1:server_name_i].decode()
+            server_name = _safe_label(server_hello[1:server_name_i], _MAX_NAME_LEN)
             self._server_name = server_name
 
             if self._expected_name is not None and self._expected_name != server_name:
@@ -206,7 +234,9 @@ class APINoiseFrameHelper(APIFrameHelper):
             mac_address_i = server_hello.find(b"\0", server_name_i + 1)
             if mac_address_i != -1:
                 # mac address found, this extension was added in 2025.4
-                mac_address = server_hello[server_name_i + 1 : mac_address_i].decode()
+                mac_address = _safe_label(
+                    server_hello[server_name_i + 1 : mac_address_i], _MAX_MAC_LEN
+                )
                 self._server_mac = mac_address
                 if self._expected_mac is not None and self._expected_mac != mac_address:
                     self._handle_error_and_close(
@@ -256,7 +286,7 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def _error_on_incorrect_preamble(self, msg: bytes) -> None:
         """Handle an incorrect preamble."""
-        explanation = msg[1:].decode()
+        explanation = _safe_label(msg[1:], _MAX_EXPLANATION_LEN)
         if explanation != "Handshake MAC failure":
             exc = HandshakeAPIError(
                 f"{self._log_name}: Handshake failure: {explanation}"

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -60,17 +60,18 @@ _MAX_MAC_LEN = MAX_MAC_LEN
 _MAX_EXPLANATION_LEN = MAX_EXPLANATION_LEN
 
 
-def _safe_label(raw: bytes, limit: int_) -> str:
-    """Decode and sanitize a peer-supplied label for safe inclusion in logs.
+def _safe_label_str(raw: str, limit: int_) -> str:
+    """Strip non-printables and length-cap a peer-supplied label for log output.
 
-    The Noise hello phase exchanges the server name, MAC address, and
-    handshake-failure explanation as raw bytes before the PSK-authenticated
-    handshake completes. An on-path attacker can put anything in those
-    fields. Strip non-printable characters (newlines, ANSI escapes, NULs,
-    bell, etc.) so they can't inject log lines, smuggle terminal escape
-    sequences into operator-visible logs, or crash a strict UTF-8 decoder.
+    Used for the unauthenticated server name, MAC address, and handshake-
+    failure explanation a peer puts on the wire before the PSK-authenticated
+    handshake completes. Callers keep the raw decoded value for protocol
+    comparisons (so a peer can't bypass `expected_name` by appending
+    `\\r\\n`) and use the sanitized value only for storage and log/error
+    formatting, where CRLF and ANSI escapes would otherwise let an on-path
+    attacker forge log lines or hijack terminals.
     """
-    return "".join(c for c in raw.decode("utf-8", "replace") if c.isprintable())[:limit]
+    return "".join(c for c in raw if c.isprintable())[:limit]
 
 
 class APINoiseFrameHelper(APIFrameHelper):
@@ -218,11 +219,19 @@ class APINoiseFrameHelper(APIFrameHelper):
         # Server name is encoded as a string followed by a zero byte after the chosen proto byte
         server_name_i = server_hello.find(b"\0", 1)
         if server_name_i != -1:
-            # server name found, this extension was added in 2022.2
-            server_name = _safe_label(server_hello[1:server_name_i], _MAX_NAME_LEN)
+            # server name found, this extension was added in 2022.2.
+            # Compare against the raw decoded value so a peer can't sneak
+            # past expected_name by appending non-printable bytes that the
+            # sanitizer would strip; only the value used for logs and for
+            # later self-storage gets sanitized + length-capped.
+            server_name_raw = server_hello[1:server_name_i].decode("utf-8", "replace")
+            server_name = _safe_label_str(server_name_raw, _MAX_NAME_LEN)
             self._server_name = server_name
 
-            if self._expected_name is not None and self._expected_name != server_name:
+            if (
+                self._expected_name is not None
+                and self._expected_name != server_name_raw
+            ):
                 self._handle_error_and_close(
                     BadNameAPIError(
                         f"{self._log_name}: Server sent a different name '{server_name}'",
@@ -233,12 +242,17 @@ class APINoiseFrameHelper(APIFrameHelper):
 
             mac_address_i = server_hello.find(b"\0", server_name_i + 1)
             if mac_address_i != -1:
-                # mac address found, this extension was added in 2025.4
-                mac_address = _safe_label(
-                    server_hello[server_name_i + 1 : mac_address_i], _MAX_MAC_LEN
-                )
+                # mac address found, this extension was added in 2025.4.
+                # Same raw-vs-sanitized split as the name field above.
+                mac_address_raw = server_hello[
+                    server_name_i + 1 : mac_address_i
+                ].decode("utf-8", "replace")
+                mac_address = _safe_label_str(mac_address_raw, _MAX_MAC_LEN)
                 self._server_mac = mac_address
-                if self._expected_mac is not None and self._expected_mac != mac_address:
+                if (
+                    self._expected_mac is not None
+                    and self._expected_mac != mac_address_raw
+                ):
                     self._handle_error_and_close(
                         BadMACAddressAPIError(
                             f"{self._log_name}: Server sent a different mac '{mac_address}'",
@@ -286,8 +300,13 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def _error_on_incorrect_preamble(self, msg: bytes) -> None:
         """Handle an incorrect preamble."""
-        explanation = _safe_label(msg[1:], _MAX_EXPLANATION_LEN)
-        if explanation != "Handshake MAC failure":
+        # Compare against the raw decoded value so a peer can't get itself
+        # mis-classified as InvalidEncryptionKeyAPIError by appending
+        # non-printable bytes to the canonical "Handshake MAC failure" string;
+        # only the text included in the error message gets sanitized.
+        explanation_raw = msg[1:].decode("utf-8", "replace")
+        explanation = _safe_label_str(explanation_raw, _MAX_EXPLANATION_LEN)
+        if explanation_raw != "Handshake MAC failure":
             exc = HandshakeAPIError(
                 f"{self._log_name}: Handshake failure: {explanation}"
             )

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aioesphomeapi import APIConnection, EncryptionPlaintextAPIError
-from aioesphomeapi._frame_helper.noise import APINoiseFrameHelper
+from aioesphomeapi._frame_helper.noise import MAX_NAME_LEN, APINoiseFrameHelper
 from aioesphomeapi._frame_helper.noise_encryption import EncryptCipher
 from aioesphomeapi._frame_helper.packets import (
     _cached_varuint_to_bytes as cached_varuint_to_bytes,
@@ -987,6 +987,118 @@ async def test_noise_frame_helper_wrong_protocol():
         HandshakeAPIError, match="Unknown protocol selected by client 5"
     ):
         await helper.ready_future
+
+
+async def test_noise_frame_helper_sanitizes_server_name_in_error() -> None:
+    """Test control chars in the unauthenticated server_name are stripped from logs."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    # Inject CRLF + ANSI escape into the unauthenticated name field. These
+    # would otherwise land in operator-visible logs unfiltered.
+    nasty_name = b"evil\r\nFAKE LOG LINE\x1b[31m"
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01" + nasty_name + b"\0")
+
+    mock_data_received(helper, hello_pkt_with_header)
+
+    with pytest.raises(BadNameAPIError) as exc_info:
+        await helper.ready_future
+    msg = str(exc_info.value)
+    for ch in ("\r", "\n", "\x1b"):
+        assert ch not in msg
+    # The sanitized name still survives so operators can see what happened,
+    # and the structured received_name field on the exception is sanitized too.
+    assert "evilFAKE LOG LINE[31m" in msg
+    for ch in ("\r", "\n", "\x1b"):
+        assert ch not in exc_info.value.received_name
+
+
+async def test_noise_frame_helper_sanitizes_server_mac_in_error() -> None:
+    """Test control chars in the unauthenticated mac field are stripped from logs."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac="aabbccddeeff",
+    )
+
+    nasty_mac = b"112233\r\nFAKE\x1bbad"
+    hello_pkt_with_header = _make_noise_hello_pkt(
+        b"\x01servicetest\0" + nasty_mac + b"\0"
+    )
+
+    mock_data_received(helper, hello_pkt_with_header)
+
+    with pytest.raises(BadMACAddressAPIError) as exc_info:
+        await helper.ready_future
+    msg = str(exc_info.value)
+    for ch in ("\r", "\n", "\x1b"):
+        assert ch not in msg
+    for ch in ("\r", "\n", "\x1b"):
+        assert ch not in exc_info.value.received_mac
+
+
+async def test_noise_frame_helper_sanitizes_handshake_explanation() -> None:
+    """Test control chars in the handshake-failure explanation are stripped from logs."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    # Get past the hello phase so the next preamble triggers
+    # _error_on_incorrect_preamble.
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01servicetest\0")
+    mock_data_received(helper, hello_pkt_with_header)
+
+    nasty_explanation = b"boom\r\nFAKE LOG\x1b[31m"
+    error_pkt = b"\x01" + nasty_explanation
+    error_pkg_length = len(error_pkt)
+    error_header = bytes((1, (error_pkg_length >> 8) & 0xFF, error_pkg_length & 0xFF))
+    mock_data_received(helper, error_header + error_pkt)
+
+    with pytest.raises(HandshakeAPIError) as exc_info:
+        await helper.ready_future
+    msg = str(exc_info.value)
+    for ch in ("\r", "\n", "\x1b"):
+        assert ch not in msg
+
+
+async def test_noise_frame_helper_caps_server_name_length() -> None:
+    """Test an oversized name field is truncated rather than logged in full."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    # 4 KiB of 'a' as the "name" — would otherwise end up in logs verbatim.
+    huge = b"a" * 4096
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01" + huge + b"\0")
+
+    mock_data_received(helper, hello_pkt_with_header)
+
+    with pytest.raises(BadNameAPIError) as exc_info:
+        await helper.ready_future
+    assert len(exc_info.value.received_name) == MAX_NAME_LEN
 
 
 async def test_init_noise_attempted_when_esp_uses_plaintext(

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -1078,6 +1078,81 @@ async def test_noise_frame_helper_sanitizes_handshake_explanation() -> None:
         assert ch not in msg
 
 
+async def test_noise_frame_helper_name_check_uses_raw_value() -> None:
+    """Test sanitization can't be used to bypass the expected_name check."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    # "servicetest\r\n" sanitizes to "servicetest" — but the expected_name
+    # comparison must run against the raw decoded value, so this peer should
+    # be rejected, not accepted.
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01servicetest\r\n\0")
+
+    mock_data_received(helper, hello_pkt_with_header)
+
+    with pytest.raises(BadNameAPIError):
+        await helper.ready_future
+
+
+async def test_noise_frame_helper_mac_check_uses_raw_value() -> None:
+    """Test sanitization can't be used to bypass the expected_mac check."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac="aabbccddeeff",
+    )
+
+    # "aabbccddeeff\n" sanitizes to "aabbccddeeff" — but the expected_mac
+    # comparison must use the raw value and reject this peer.
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01servicetest\0aabbccddeeff\n\0")
+
+    mock_data_received(helper, hello_pkt_with_header)
+
+    with pytest.raises(BadMACAddressAPIError):
+        await helper.ready_future
+
+
+async def test_noise_frame_helper_handshake_explanation_uses_raw_value() -> None:
+    """Test sanitization can't smuggle Handshake-MAC-failure misclassification."""
+    connection, _ = _make_mock_connection()
+    helper = MockAPINoiseFrameHelper(
+        connection=connection,
+        noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc=",
+        expected_name="servicetest",
+        client_info="my client",
+        log_name="test",
+        expected_mac=None,
+    )
+
+    hello_pkt_with_header = _make_noise_hello_pkt(b"\x01servicetest\0")
+    mock_data_received(helper, hello_pkt_with_header)
+
+    # "Handshake MAC failure\0extra" sanitizes to "Handshake MAC failure" but
+    # the raw value differs, so it must be classified as a generic handshake
+    # error rather than InvalidEncryptionKeyAPIError.
+    explanation = b"Handshake MAC failure\0extra"
+    error_pkt = b"\x01" + explanation
+    error_pkg_length = len(error_pkt)
+    error_header = bytes((1, (error_pkg_length >> 8) & 0xFF, error_pkg_length & 0xFF))
+    mock_data_received(helper, error_header + error_pkt)
+
+    with pytest.raises(HandshakeAPIError) as exc_info:
+        await helper.ready_future
+    # Not the dedicated InvalidEncryptionKeyAPIError, just a HandshakeAPIError.
+    assert not isinstance(exc_info.value, InvalidEncryptionKeyAPIError)
+
+
 async def test_noise_frame_helper_caps_server_name_length() -> None:
     """Test an oversized name field is truncated rather than logged in full."""
     connection, _ = _make_mock_connection()


### PR DESCRIPTION
# What does this implement/fix?

The noise hello phase exchanges `server_name`, `mac_address`, and a handshake-failure `explanation` as raw bytes **before** the PSK-authenticated handshake completes. The previous code interpolated those attacker-controlled strings unescaped into log/error messages (`f"... Server sent a different name '{server_name}'"`) and stored them on `self` for reuse by every later error path (`_decode_noise_psk`, `_error_on_incorrect_preamble`, `EncryptionErrorAPIError`).

An on-path attacker (ARP spoof, compromised VLAN device) could inject CRLF + ANSI escape sequences into operator-visible logs (HA UI, syslog, monitoring webhooks) — forging fake log lines, hijacking terminals via CSI sequences, and impersonating a different device's identity in alert messages.

This adds a `_safe_label()` helper that decodes with `errors="replace"` and strips any non-printable character, then caps the length to the firmware's actual wire-format limits (verified against `esphome/core/{config.py,helpers.h,entity_base.h}` and `api_frame_helper_noise.cpp`):

- **name**: 32 (firmware `ESPHOME_DEVICE_NAME_MAX_LEN = 31` from `validate_hostname`; allowed chars are `[a-z0-9_-]`)
- **mac**: 16 (firmware `MAC_ADDRESS_BUFFER_SIZE - 1 = 12` lowercase hex chars from `format_hex_to`)
- **explanation**: 64 (firmware reject buffer is 32 bytes minus the 1-byte failure code)

Margins on each let benign forward-compat tweaks through without breaking clients.

The constants and helper are `cdef`-typed in the `.pxd` for hot-path performance; `MAX_NAME_LEN` / `MAX_MAC_LEN` / `MAX_EXPLANATION_LEN` are re-exported as Python-importable aliases so tests can reference them, following the same pattern as `MAX_PLAINTEXT_FRAME_SIZE` in `plain_text.py`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1655

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A (client-side only)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes. (N/A — api.proto unchanged)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
