### PR TITLE
Parallelize Cython extension compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup_kwargs = {
 
 class OptionalBuildExt(build_ext):
     def build_extensions(self) -> None:
+        if self.parallel is None:
+            self.parallel = os.cpu_count() or 1
         with contextlib.suppress(Exception):
             super().build_extensions()
 


### PR DESCRIPTION
# What does this implement/fix?

Default `OptionalBuildExt.parallel` to `os.cpu_count()` so per-module `gcc` compilations of the Cythonized hot paths run in parallel instead of one at a time. The QEMU emulated wheel jobs are the biggest beneficiary.

Mirrors [Bluetooth-Devices/habluetooth#421](https://github.com/Bluetooth-Devices/habluetooth/pull/421), which mirrors [python-zeroconf/python-zeroconf#1689](https://github.com/python-zeroconf/python-zeroconf/pull/1689).

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
