### PR TITLE
Enable ruff PTH rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ select = [
   "PERF", # Perflint
   "PIE", # flake8-pie
   "PL", # pylint
+  "PTH", # flake8-use-pathlib
   "UP", # pyupgrade
   "RET", # flake8-return
   "RUF", # ruff

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import contextlib
 from distutils.command.build_ext import build_ext
 import os
+from pathlib import Path
 from typing import Any
 
 from setuptools import find_packages, setup
@@ -35,9 +36,9 @@ EXTENSIONS = [
 ]
 
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = Path(__file__).parent.resolve()
 
-with open(os.path.join(here, "README.rst"), encoding="utf-8") as readme_file:
+with (here / "README.rst").open(encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
@@ -59,7 +60,7 @@ GITHUB_URL = f"https://github.com/{GITHUB_PATH}"
 
 DOWNLOAD_URL = f"{GITHUB_URL}/archive/{VERSION}.zip"
 
-with open(os.path.join(here, "requirements/base.txt")) as requirements_txt:
+with (here / "requirements" / "base.txt").open() as requirements_txt:
     REQUIRES = requirements_txt.read().splitlines()
 
 pkgs = find_packages(exclude=["tests", "tests.*"])


### PR DESCRIPTION
# What does this implement/fix?

Enables the ruff `PTH` (flake8-use-pathlib) rule set so future patches keep paths on `pathlib.Path` instead of `os.path`; the only place currently using `os.path` is `setup.py`, which has been ported over.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
