### PR TITLE
Enable ruff PT006/PT007 parametrize tuple rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ select = [
   "PERF", # Perflint
   "PIE", # flake8-pie
   "PL", # pylint
+  "PT006", # pytest-parametrize-names-wrong-type
+  "PT007", # pytest-parametrize-values-wrong-type
   "PTH", # flake8-use-pathlib
   "UP", # pyupgrade
   "RET", # flake8-return

--- a/tests/test__frame_helper.py
+++ b/tests/test__frame_helper.py
@@ -99,7 +99,7 @@ if sys.platform != "win32":
 
 
 @pytest.mark.parametrize(
-    "in_bytes, pkt_data, pkt_type",
+    ("in_bytes", "pkt_data", "pkt_type"),
     _PLAINTEXT_TESTS,
 )
 async def test_plaintext_frame_helper(
@@ -132,7 +132,7 @@ async def test_plaintext_frame_helper(
 
 
 @pytest.mark.parametrize(
-    "in_bytes, pkt_data, pkt_type",
+    ("in_bytes", "pkt_data", "pkt_type"),
     _PLAINTEXT_TESTS,
 )
 async def test_plaintext_frame_helper_multiple_payloads_single_packet(
@@ -167,7 +167,7 @@ async def test_plaintext_frame_helper_multiple_payloads_single_packet(
 
 @pytest.mark.parametrize(
     "byte_type",
-    (bytes, bytearray, memoryview),
+    [bytes, bytearray, memoryview],
 )
 async def test_plaintext_frame_helper_protractor_event_loop(byte_type: Any) -> None:
     """Test the plaintext frame helper with the protractor event loop.
@@ -207,7 +207,7 @@ async def test_plaintext_frame_helper_protractor_event_loop(byte_type: Any) -> N
 
 @pytest.mark.parametrize(
     "byte_type",
-    (bytes, bytearray, memoryview),
+    [bytes, bytearray, memoryview],
 )
 async def test_noise_protector_event_loop(byte_type: Any) -> None:
     """Test the noise frame helper with the protractor event loop.
@@ -418,7 +418,7 @@ VARUINT_TESTCASES = [
 ]
 
 
-@pytest.mark.parametrize("val, encoded", VARUINT_TESTCASES)
+@pytest.mark.parametrize(("val", "encoded"), VARUINT_TESTCASES)
 def test_varuint_to_bytes(val, encoded):
     assert varuint_to_bytes(val) == encoded
     assert cached_varuint_to_bytes(val) == encoded
@@ -1373,10 +1373,10 @@ async def test_connection_lost_closes_connection_and_logs(
 
 @pytest.mark.parametrize(
     ("bad_psk", "error"),
-    (
+    [
         ("dGhpc2lzbm90MzJieXRlcw==", "expected base64-encoded 32-byte value"),
         ("QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc", "Malformed PSK"),
-    ),
+    ],
 )
 async def test_noise_bad_psks(bad_psk: str, error: str) -> None:
     """Test we raise on bad psks."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -666,7 +666,7 @@ async def test_subscribe_states_camera_oversized_done_chunk_does_not_tombstone(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (
@@ -700,7 +700,7 @@ async def test_cover_command_legacy(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (dict(key=1, position=0.5), dict(key=1, has_position=True, position=0.5)),
@@ -723,7 +723,7 @@ async def test_cover_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (dict(key=1, state=True), dict(key=1, has_state=True, state=True)),
@@ -759,7 +759,7 @@ async def test_fan_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (dict(key=1, state=True), dict(key=1, has_state=True, state=True)),
@@ -822,7 +822,7 @@ async def test_light_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, state=False), dict(key=1, state=False)),
         (dict(key=1, state=True), dict(key=1, state=True)),
@@ -942,7 +942,7 @@ async def test_water_heater_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, preset=ClimatePreset.HOME),
@@ -965,7 +965,7 @@ async def test_climate_command_legacy(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, mode=ClimateMode.HEAT),
@@ -1020,7 +1020,7 @@ async def test_climate_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, state=0.0), dict(key=1, state=0.0)),
         (dict(key=1, state=100.0), dict(key=1, state=100.0)),
@@ -1036,7 +1036,7 @@ async def test_number_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, year=2024, month=2, day=29),
@@ -1061,7 +1061,7 @@ async def test_date_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, hour=12, minute=30, second=30),
@@ -1086,7 +1086,7 @@ async def test_time_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, epoch_seconds=1735648230),
@@ -1108,7 +1108,7 @@ async def test_datetime_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, command=LockCommand.LOCK), dict(key=1, command=LockCommand.LOCK)),
         (
@@ -1132,7 +1132,7 @@ async def test_lock_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (dict(key=1, position=1.0), dict(key=1, position=1.0, has_position=True)),
@@ -1150,7 +1150,7 @@ async def test_valve_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
         (dict(key=1, position=0.5), dict(key=1, has_position=True, position=0.5)),
@@ -1173,7 +1173,7 @@ async def test_valve_command_version_1_1(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, state="One"), dict(key=1, state="One")),
         (dict(key=1, state="Two"), dict(key=1, state="Two")),
@@ -1189,7 +1189,7 @@ async def test_select_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, command=MediaPlayerCommand.MUTE),
@@ -1225,7 +1225,7 @@ async def test_media_player_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1), dict(key=1)),
     ],
@@ -1240,7 +1240,7 @@ async def test_button_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, state=True), dict(key=1, state=True, has_state=True)),
         (dict(key=1, state=False), dict(key=1, state=False, has_state=True)),
@@ -1473,7 +1473,7 @@ async def test_request_image_stream(auth_client: APIClient) -> None:
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, command=AlarmControlPanelCommand.ARM_AWAY),
@@ -1499,7 +1499,7 @@ async def test_alarm_panel_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (dict(key=1, state="hello world"), dict(key=1, state="hello world")),
         (dict(key=1, state="goodbye"), dict(key=1, state="goodbye")),
@@ -1515,7 +1515,7 @@ async def test_text_command(
 
 
 @pytest.mark.parametrize(
-    "cmd, req",
+    ("cmd", "req"),
     [
         (
             dict(key=1, command=UpdateCommand.INSTALL),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -186,7 +186,7 @@ class DummyIntEnum(APIIntEnum):
 
 
 @pytest.mark.parametrize(
-    "input, output",
+    ("input", "output"),
     [
         (0, DummyIntEnum.DEFAULT),
         (1, DummyIntEnum.MY_VAL),
@@ -203,7 +203,7 @@ def test_api_int_enum_convert(input, output):
 
 
 @pytest.mark.parametrize(
-    "input, output",
+    ("input", "output"),
     [
         ([], []),
         ([1], [DummyIntEnum.MY_VAL]),
@@ -299,7 +299,7 @@ def test_api_version_ord():
 
 
 @pytest.mark.parametrize(
-    "model, pb",
+    ("model", "pb"),
     [
         (DeviceInfo, DeviceInfoResponse),
         (BinarySensorInfo, ListEntitiesBinarySensorResponse),
@@ -362,7 +362,7 @@ def test_basic_pb_conversions(model, pb):
 
 
 @pytest.mark.parametrize(
-    "state, version, out",
+    ("state", "version", "out"),
     [
         (CoverState(legacy_state=LegacyCoverState.OPEN), (1, 0), False),
         (CoverState(legacy_state=LegacyCoverState.CLOSED), (1, 0), True),
@@ -376,7 +376,7 @@ def test_cover_state_legacy_state(state, version, out):
 
 
 @pytest.mark.parametrize(
-    "state, version, out",
+    ("state", "version", "out"),
     [
         (
             ClimateInfo(supports_current_temperature=True),
@@ -415,7 +415,7 @@ def test_climate_info_supported_feature_flags_compat(state, version, out):
 
 
 @pytest.mark.parametrize(
-    "state, version, out",
+    ("state", "version", "out"),
     [
         (ClimateInfo(legacy_supports_away=False), (1, 4), []),
         (
@@ -437,7 +437,7 @@ def test_climate_info_supported_presets_compat(state, version, out):
 
 
 @pytest.mark.parametrize(
-    "state, version, out",
+    ("state", "version", "out"),
     [
         (ClimateState(unused_legacy_away=False), (1, 4), ClimatePreset.HOME),
         (ClimateState(unused_legacy_away=True), (1, 4), ClimatePreset.AWAY),
@@ -1822,7 +1822,7 @@ def test_event_entity_state_device_id():
 
 
 @pytest.mark.parametrize(
-    "input, output",
+    ("input", "output"),
     [
         (0, SupportsResponseType.NONE),
         (1, SupportsResponseType.OPTIONAL),

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -373,7 +373,7 @@ DNS_POINTER = DNSPointer(
 
 @pytest.mark.parametrize(
     ("record", "should_trigger_zeroconf", "expected_state_after_trigger", "log_text"),
-    (
+    [
         (
             DNS_POINTER,
             True,
@@ -416,7 +416,7 @@ DNS_POINTER = DNSPointer(
             ReconnectLogicState.READY,
             "received mDNS record",
         ),
-    ),
+    ],
 )
 async def test_reconnect_zeroconf(
     patchable_api_client: APIClient,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ from aioesphomeapi import util
 
 
 @pytest.mark.parametrize(
-    "input, output",
+    ("input", "output"),
     [
         (0, 0),
         (float("inf"), float("inf")),


### PR DESCRIPTION
# What does this implement/fix?

Turns on ruff `PT006` and `PT007` so `pytest.mark.parametrize` argument names are always a tuple, never a comma string, and value sets stay a list of tuples; existing call sites have been normalized to match.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
