### PR TITLE
Use specific rule code on test_log_reader type-ignore

### DIFF
--- a/tests/test_log_reader.py
+++ b/tests/test_log_reader.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aioesphomeapi.api_pb2 import SubscribeLogsResponse  # type: ignore
+from aioesphomeapi.api_pb2 import SubscribeLogsResponse  # type: ignore[attr-defined]
 from aioesphomeapi.log_reader import main
 
 


### PR DESCRIPTION
# What does this implement/fix?

PGH003 (enabled in #1684) flags bare `# type: ignore` comments, but the existing one on the protobuf import in `tests/test_log_reader.py` was missed in the rollout; `ruff check` now fails on main and on every open PR. Switching the comment to `# type: ignore[attr-defined]` matches the dynamic-attribute shape of `api_pb2.SubscribeLogsResponse` and unblocks CI.

One-line change, lint-only.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- n/a, no protocol changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
