### PR TITLE
Fix example of how to connect with encryption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ The sample code below will connect to the device and retrieve details.
        api = aioesphomeapi.APIClient(
            "api_test.local",
            6053,
+           password=None,  # https://github.com/esphome/aioesphomeapi/pull/1725
            noise_psk="YOUR_ENCRYPTION_KEY",  # Remove if not using encryption
        )
        await api.connect(login=True)
@@ -110,6 +111,7 @@ Subscribe to state changes of an ESPHome device.
        api = aioesphomeapi.APIClient(
            "api_test.local",
            6053,
+           password=None,  # https://github.com/esphome/aioesphomeapi/pull/1725
            noise_psk="YOUR_ENCRYPTION_KEY",  # Remove if not using encryption
        )
        await api.connect(login=True)


### PR DESCRIPTION
# What does this implement/fix?

AFAICT, the example code here was just bogus.

- `APIClient` doesn't define a `__init__`, it defers to its parent `APIClientBase`, whose `__init__` expects a positional argument for password: <https://github.com/esphome/aioesphomeapi/blob/v45.0.4/aioesphomeapi/client_base.py#L301>
- ESPHome itself passes `password=""`: <https://github.com/esphome/esphome/blob/2026.5.0/esphome/components/api/client.py#L100>

I opted to use `password=None`, which feels a little more explicit than the nameless `""`.

Of course, it would be great if the api would change to make password not required at all, but I thought it would be good to document the status quo correctly. Happy to make that change if preferable though. Just let me know!


## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other (documentation fix)

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
