### PR TITLE
Add flag to suppress time updates by client

### DIFF
--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -308,6 +308,7 @@ class APIClientBase:
         addresses: list[str_] | None = None,
         expected_mac: str_ | None = None,
         timezone: str_ | None = None,
+        provide_time: bool = True,
     ) -> None:
         """Create a client, this object is shared across sessions.
 
@@ -349,6 +350,7 @@ class APIClientBase:
             expected_name=_stringify_or_none(expected_name) or None,
             expected_mac=_stringify_or_none(expected_mac) or None,
             timezone=_stringify_or_none(timezone) or None,
+            provide_time=provide_time,
         )
         self._connection: APIConnection | None = None
         self._cached_device_info: DeviceInfo | None = None

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -334,6 +334,8 @@ class APIClientBase:
         :param timezone: Optional IANA timezone name to send to ESPHome devices.
             If not provided, the system timezone will be detected automatically.
             Example: 'America/Chicago' or 'Europe/London'
+        :param provide_time: If True, the client will respond to a server
+            request for the current time and timezone.
         """
         self._debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         self._params = ConnectionParams(

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -94,7 +94,6 @@ cdef class ConnectionParams:
     cdef public bint provide_time
 
 
-
 cdef class APIConnection:
 
     cdef ConnectionParams _params

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -91,6 +91,8 @@ cdef class ConnectionParams:
     cdef public object expected_name
     cdef public object expected_mac
     cdef public object timezone
+    cdef public bint provide_time
+
 
 
 cdef class APIConnection:

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -151,6 +151,7 @@ class ConnectionParams:
     expected_name: str | None
     expected_mac: str | None
     timezone: str | None = None
+    provide_time: bool = True
 
 
 class ConnectionState(enum.Enum):
@@ -1140,9 +1141,10 @@ class APIConnection:
         self._add_message_callback_without_remove(
             self._handle_ping_request_internal, (PingRequest,)
         )
-        self._add_message_callback_without_remove(
-            self._handle_get_time_request_internal, (GetTimeRequest,)
-        )
+        if self._params.provide_time:
+            self._add_message_callback_without_remove(
+                self._handle_get_time_request_internal, (GetTimeRequest,)
+            )
         self._add_message_callback_without_remove(
             self._handle_login_response, (AuthenticationResponse,)
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,7 +61,7 @@ def get_mock_connection_params() -> ConnectionParams:
         expected_name=None,
         expected_mac=None,
         timezone=None,
-        provide_time=True
+        provide_time=True,
     )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,6 +61,7 @@ def get_mock_connection_params() -> ConnectionParams:
         expected_name=None,
         expected_mac=None,
         timezone=None,
+        provide_time=True
     )
 
 

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -47,7 +47,7 @@ async def _make_connected_conn(
     provide_time: bool,
     resolve_host,
     aiohappyeyeballs_start_connection,
-) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
+) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
     """Set up a plaintext-connected PatchableAPIConnection with provide_time set."""
     loop = asyncio.get_running_loop()
     transport = MagicMock()

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -41,7 +41,9 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
+    cli = PatchableAPIClient(
+        address="127.0.0.1", port=6052, password=None, provide_time=False
+    )
     assert cli._params.provide_time is False
 
 
@@ -118,4 +120,3 @@ async def test_get_time_response_not_sent_when_provide_time_false(
         transport.writelines.assert_not_called()
     finally:
         conn.force_disconnect()
-

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -10,7 +10,7 @@ import asyncio
 from dataclasses import replace
 from functools import partial
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     GetTimeRequest,
@@ -50,7 +50,7 @@ async def _make_connected_conn(
     provide_time: bool,
     resolve_host,
     aiohappyeyeballs_start_connection,
-) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
+) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
     """Set up a plaintext-connected PatchableAPIConnection with provide_time set."""
     loop = asyncio.get_running_loop()
     transport = MagicMock()
@@ -67,7 +67,7 @@ async def _make_connected_conn(
 
 
 def patch_create_connection(loop, transport, connected):
-    return __import__("unittest.mock", fromlist=["patch"]).patch.object(
+    return patch.object(
         loop,
         "create_connection",
         side_effect=partial(_create_mock_transport_protocol, transport, connected),

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -11,18 +11,16 @@ should not override timezone settings managed by Home Assistant.
 
 from __future__ import annotations
 
-import time
 from dataclasses import replace
-from unittest.mock import MagicMock
+import time
 
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     GetTimeRequest,
     GetTimeResponse,
 )
 
-from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 from .common import get_mock_connection_params
-
+from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 
 # ---------------------------------------------------------------------------
 # Tests: APIClient stores the flag correctly on _params
@@ -37,7 +35,9 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
+    cli = PatchableAPIClient(
+        address="127.0.0.1", port=6052, password=None, provide_time=False
+    )
     assert cli._params.provide_time is False
 
 
@@ -106,4 +106,3 @@ async def test_handle_get_time_request_sends_response() -> None:
     assert before <= response.epoch_seconds <= after + 1, (
         f"epoch_seconds {response.epoch_seconds} not in expected range [{before}, {after}]"
     )
-

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -12,7 +12,10 @@ from functools import partial
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-from aioesphomeapi.api_pb2 import GetTimeRequest  # type: ignore[attr-defined]
+from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
+    GetTimeRequest,
+    GetTimeResponse,
+)
 
 from .common import (
     _create_mock_transport_protocol,
@@ -37,9 +40,7 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(
-        address="127.0.0.1", port=6052, password=None, provide_time=False
-    )
+    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
     assert cli._params.provide_time is False
 
 
@@ -47,7 +48,7 @@ async def _make_connected_conn(
     provide_time: bool,
     resolve_host,
     aiohappyeyeballs_start_connection,
-) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
+) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
     """Set up a plaintext-connected PatchableAPIConnection with provide_time set."""
     loop = asyncio.get_running_loop()
     transport = MagicMock()
@@ -88,8 +89,14 @@ async def test_get_time_response_sent_when_provide_time_true(
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
-        assert transport.write.called or transport.writelines.called, (
-            "Expected transport.write to be called with a GetTimeResponse"
+        assert transport.writelines.call_count == 1, (
+            "Expected exactly one frame to be written (the GetTimeResponse)"
+        )
+        raw = b"".join(transport.writelines.call_args[0][0])
+        resp = GetTimeResponse()
+        resp.ParseFromString(raw[3:])  # strip 3-byte plaintext frame header
+        assert resp.epoch_seconds > 0, (
+            f"Expected a valid epoch_seconds in GetTimeResponse, got {resp.epoch_seconds}"
         )
     finally:
         conn.force_disconnect()

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -40,7 +40,9 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
+    cli = PatchableAPIClient(
+        address="127.0.0.1", port=6052, password=None, provide_time=False
+    )
     assert cli._params.provide_time is False
 
 

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -17,6 +17,7 @@ from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
 from .common import get_mock_connection_params
 from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 
+
 async def test_api_client_provide_time_default() -> None:
     """provide_time should default to True."""
     cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None)

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -1,21 +1,36 @@
 """Tests for the provide_time flag on APIClient / ConnectionParams.
 
 When provide_time=True (the default) the connection registers a handler
-device's clock in sync with the client, otherwise ignores time requests.
+for GetTimeRequest and responds to it, otherwise ignores the request.
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
-import time
+from functools import partial
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
 
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     GetTimeRequest,
-    GetTimeResponse,
 )
+from aioesphomeapi.connection import APIConnection
 
-from .common import get_mock_connection_params
+from .common import (
+    _create_mock_transport_protocol,
+    connect,
+    generate_plaintext_packet,
+    get_mock_connection_params,
+    mock_data_received,
+    send_plaintext_hello,
+)
 from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
+
+if TYPE_CHECKING:
+    from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 
 
 async def test_api_client_provide_time_default() -> None:
@@ -26,64 +41,81 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(
-        address="127.0.0.1", port=6052, password=None, provide_time=False
-    )
+    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
     assert cli._params.provide_time is False
 
 
-async def test_get_time_handler_registered_when_provide_time_true() -> None:
-    """When provide_time=True the GetTimeRequest callback should be registered."""
-    params = replace(get_mock_connection_params(), provide_time=True)
+async def _make_connected_conn(
+    provide_time: bool,
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper, asyncio.Task]:
+    """Set up a plaintext-connected PatchableAPIConnection with provide_time set."""
+    loop = asyncio.get_running_loop()
+    transport = MagicMock()
+    connected = asyncio.Event()
+    params = replace(get_mock_connection_params(), provide_time=provide_time)
     conn = PatchableAPIConnection(params, mock_on_stop, True, None)
 
-    registered_types: list[type] = []
+    with patch_create_connection(loop, transport, connected):
+        connect_task = asyncio.create_task(connect(conn, login=False))
+        await connected.wait()
+        send_plaintext_hello(conn._frame_helper)
+        await connect_task
+        return conn, transport, conn._frame_helper
 
-    def capture(callback, msg_types):
-        registered_types.extend(msg_types)
 
-    conn._add_message_callback_without_remove = capture  # type: ignore[method-assign]
-    conn._register_internal_message_handlers()
-
-    assert GetTimeRequest in registered_types, (
-        "GetTimeRequest handler should be registered when provide_time=True"
+def patch_create_connection(loop, transport, connected):
+    return __import__("unittest.mock", fromlist=["patch"]).patch.object(
+        loop,
+        "create_connection",
+        side_effect=partial(_create_mock_transport_protocol, transport, connected),
     )
 
 
-async def test_get_time_handler_not_registered_when_provide_time_false() -> None:
-    """When provide_time=False the GetTimeRequest callback must NOT be registered."""
-    params = replace(get_mock_connection_params(), provide_time=False)
-    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
-
-    registered_types: list[type] = []
-
-    def capture(callback, msg_types):
-        registered_types.extend(msg_types)
-
-    conn._add_message_callback_without_remove = capture  # type: ignore[method-assign]
-    conn._register_internal_message_handlers()
-
-    assert GetTimeRequest not in registered_types, (
-        "GetTimeRequest handler must not be registered when provide_time=False"
+async def test_get_time_response_sent_when_provide_time_true(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """A GetTimeRequest should produce a GetTimeResponse when provide_time=True."""
+    conn, transport, protocol = await _make_connected_conn(
+        provide_time=True,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
     )
 
+    try:
+        transport.reset_mock()
+        mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-async def test_handle_get_time_request_sends_response() -> None:
-    """_handle_get_time_request_internal should send a GetTimeResponse with current time."""
-    params = replace(get_mock_connection_params(), provide_time=True)
-    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
-    conn._handshake_complete = True
+        assert transport.write.called or transport.writelines.called, (
+            "Expected transport.write to be called with a GetTimeResponse"
+        )
+    finally:
+        conn.force_disconnect()
 
-    sent_messages: list = []
-    conn.send_messages = sent_messages.extend  # type: ignore[method-assign]
 
-    before = int(time.time())
-    conn._handle_get_time_request_internal(GetTimeRequest())
-    after = int(time.time())
-
-    assert len(sent_messages) == 1
-    response = sent_messages[0]
-    assert isinstance(response, GetTimeResponse)
-    assert before <= response.epoch_seconds <= after + 1, (
-        f"epoch_seconds {response.epoch_seconds} not in expected range [{before}, {after}]"
+async def test_get_time_response_not_sent_when_provide_time_false(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """A GetTimeRequest should produce no response when provide_time=False."""
+    conn, transport, protocol = await _make_connected_conn(
+        provide_time=False,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
     )
+
+    try:
+        transport.reset_mock()
+        mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        transport.write.assert_not_called()
+        transport.writelines.assert_not_called()
+    finally:
+        conn.force_disconnect()
+

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 from aioesphomeapi.api_pb2 import GetTimeRequest  # type: ignore[attr-defined]
-from aioesphomeapi.connection import APIConnection
 
 from .common import (
     _create_mock_transport_protocol,
@@ -27,6 +26,7 @@ from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 
 if TYPE_CHECKING:
     from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
+    from aioesphomeapi.connection import APIConnection
 
 
 async def test_api_client_provide_time_default() -> None:

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -94,7 +94,7 @@ async def test_handle_get_time_request_sends_response() -> None:
     conn._handshake_complete = True
 
     sent_messages: list = []
-    conn.send_messages = lambda msgs: sent_messages.extend(msgs)  # type: ignore[method-assign]
+    conn.send_messages = sent_messages.extend  # type: ignore[method-assign]
 
     before = int(time.time())
     conn._handle_get_time_request_internal(GetTimeRequest())
@@ -106,4 +106,3 @@ async def test_handle_get_time_request_sends_response() -> None:
     assert before <= response.epoch_seconds <= after + 1, (
         f"epoch_seconds {response.epoch_seconds} not in expected range [{before}, {after}]"
     )
-

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -12,11 +12,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-import pytest
-
-from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
-    GetTimeRequest,
-)
+from aioesphomeapi.api_pb2 import GetTimeRequest  # type: ignore[attr-defined]
 from aioesphomeapi.connection import APIConnection
 
 from .common import (
@@ -41,7 +37,9 @@ async def test_api_client_provide_time_default() -> None:
 
 async def test_api_client_provide_time_false() -> None:
     """provide_time=False should be stored on _params."""
-    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
+    cli = PatchableAPIClient(
+        address="127.0.0.1", port=6052, password=None, provide_time=False
+    )
     assert cli._params.provide_time is False
 
 
@@ -118,4 +116,3 @@ async def test_get_time_response_not_sent_when_provide_time_false(
         transport.writelines.assert_not_called()
     finally:
         conn.force_disconnect()
-

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -1,0 +1,109 @@
+"""Tests for the provide_time flag on APIClient / ConnectionParams.
+
+When provide_time=True (the default) the connection registers a handler
+for GetTimeRequest and responds with the current epoch time, keeping the
+device's clock in sync with the client.
+
+When provide_time=False the handler is not registered, leaving the
+device's clock untouched — useful for ESPHome's own log runner which
+should not override timezone settings managed by Home Assistant.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
+    GetTimeRequest,
+    GetTimeResponse,
+)
+
+from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
+from .common import get_mock_connection_params
+
+
+# ---------------------------------------------------------------------------
+# Tests: APIClient stores the flag correctly on _params
+# ---------------------------------------------------------------------------
+
+
+async def test_api_client_provide_time_default() -> None:
+    """provide_time should default to True."""
+    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None)
+    assert cli._params.provide_time is True
+
+
+async def test_api_client_provide_time_false() -> None:
+    """provide_time=False should be stored on _params."""
+    cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None, provide_time=False)
+    assert cli._params.provide_time is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _register_internal_message_handlers respects the flag
+# ---------------------------------------------------------------------------
+
+
+async def test_get_time_handler_registered_when_provide_time_true() -> None:
+    """When provide_time=True the GetTimeRequest callback should be registered."""
+    params = replace(get_mock_connection_params(), provide_time=True)
+    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
+
+    registered_types: list[type] = []
+
+    def capture(callback, msg_types):
+        registered_types.extend(msg_types)
+
+    conn._add_message_callback_without_remove = capture  # type: ignore[method-assign]
+    conn._register_internal_message_handlers()
+
+    assert GetTimeRequest in registered_types, (
+        "GetTimeRequest handler should be registered when provide_time=True"
+    )
+
+
+async def test_get_time_handler_not_registered_when_provide_time_false() -> None:
+    """When provide_time=False the GetTimeRequest callback must NOT be registered."""
+    params = replace(get_mock_connection_params(), provide_time=False)
+    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
+
+    registered_types: list[type] = []
+
+    def capture(callback, msg_types):
+        registered_types.extend(msg_types)
+
+    conn._add_message_callback_without_remove = capture  # type: ignore[method-assign]
+    conn._register_internal_message_handlers()
+
+    assert GetTimeRequest not in registered_types, (
+        "GetTimeRequest handler must not be registered when provide_time=False"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: the time response handler sends a plausible epoch value
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_get_time_request_sends_response() -> None:
+    """_handle_get_time_request_internal should send a GetTimeResponse with current time."""
+    params = replace(get_mock_connection_params(), provide_time=True)
+    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
+    conn._handshake_complete = True
+
+    sent_messages: list = []
+    conn.send_messages = lambda msgs: sent_messages.extend(msgs)  # type: ignore[method-assign]
+
+    before = int(time.time())
+    conn._handle_get_time_request_internal(GetTimeRequest())
+    after = int(time.time())
+
+    assert len(sent_messages) == 1
+    response = sent_messages[0]
+    assert isinstance(response, GetTimeResponse)
+    assert before <= response.epoch_seconds <= after + 1, (
+        f"epoch_seconds {response.epoch_seconds} not in expected range [{before}, {after}]"
+    )
+

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -1,12 +1,7 @@
 """Tests for the provide_time flag on APIClient / ConnectionParams.
 
 When provide_time=True (the default) the connection registers a handler
-for GetTimeRequest and responds with the current epoch time, keeping the
-device's clock in sync with the client.
-
-When provide_time=False the handler is not registered, leaving the
-device's clock untouched — useful for ESPHome's own log runner which
-should not override timezone settings managed by Home Assistant.
+device's clock in sync with the client, otherwise ignores time requests.
 """
 
 from __future__ import annotations
@@ -22,11 +17,6 @@ from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
 from .common import get_mock_connection_params
 from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 
-# ---------------------------------------------------------------------------
-# Tests: APIClient stores the flag correctly on _params
-# ---------------------------------------------------------------------------
-
-
 async def test_api_client_provide_time_default() -> None:
     """provide_time should default to True."""
     cli = PatchableAPIClient(address="127.0.0.1", port=6052, password=None)
@@ -39,11 +29,6 @@ async def test_api_client_provide_time_false() -> None:
         address="127.0.0.1", port=6052, password=None, provide_time=False
     )
     assert cli._params.provide_time is False
-
-
-# ---------------------------------------------------------------------------
-# Tests: _register_internal_message_handlers respects the flag
-# ---------------------------------------------------------------------------
 
 
 async def test_get_time_handler_registered_when_provide_time_true() -> None:
@@ -80,11 +65,6 @@ async def test_get_time_handler_not_registered_when_provide_time_false() -> None
     assert GetTimeRequest not in registered_types, (
         "GetTimeRequest handler must not be registered when provide_time=False"
     )
-
-
-# ---------------------------------------------------------------------------
-# Tests: the time response handler sends a plausible epoch value
-# ---------------------------------------------------------------------------
 
 
 async def test_handle_get_time_request_sends_response() -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Related to:

https://github.com/home-assistant/core/issues/171846
https://github.com/esphome/esphome/issues/14658
https://github.com/esphome/esphome/pull/16583

Adds a flag to APIClient that will cause the connection to ignore time sync requests. The default value maintains the existing behaviour so is non-breaking.


## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14658

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
