### PR TITLE
Replace flag based cleanup in bluetooth_device_connect with per branch cleanup

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -859,7 +859,7 @@ class APIClient(APIClientBase):
         """Set the Bluetooth scanner mode."""
         self._get_connection().send_message(BluetoothScannerSetModeRequest(mode=mode))
 
-    async def bluetooth_device_connect(  # noqa: C901  # pylint: disable=too-many-locals, too-many-branches
+    async def bluetooth_device_connect(  # noqa: C901  # pylint: disable=too-many-locals
         self,
         address: int,
         on_bluetooth_connection_state: Callable[[bool, int, int], None],
@@ -923,22 +923,16 @@ class APIClient(APIClientBase):
         timeout_handle = loop.call_at(
             loop.time() + timeout, handle_timeout, connect_future
         )
-        timeout_expired = False
-        connect_ok = False
-        unhandled_exception = False
         try:
             await connect_future
-            connect_ok = True
         except TimeoutError as err:
-            # If the timeout expires, make sure
-            # to unsub before calling _bluetooth_device_disconnect_guard_timeout
-            # so that the disconnect message is not propagated back to the caller
-            # since we are going to raise a TimeoutAPIError.
+            # Unsub before disconnecting so the disconnect message is not
+            # propagated back to the caller — we are going to raise a
+            # TimeoutAPIError instead.
             unsub()
-            timeout_expired = True
-            # Disconnect before raising the exception to ensure
-            # the slot is recovered before the timeout is raised
-            # to avoid race were we run out even though we have a slot.
+            # Disconnect before raising the exception so the slot is
+            # recovered before the timeout is raised, avoiding a race
+            # where we run out of slots even though we have one.
             addr = to_human_readable_address(address)
             if self._debug_enabled:
                 _LOGGER.debug("%s: Connecting timed out, waiting for disconnect", addr)
@@ -954,13 +948,14 @@ class APIClient(APIClientBase):
             )
             raise TimeoutAPIError(msg) from err
         except asyncio.CancelledError:
-            unhandled_exception = True
-            # Distinguish an outside cancellation of our task from
-            # a cancellation of the connect_future itself. If the
-            # current task is not actually being cancelled, convert
-            # the CancelledError into an APIConnectionError so that
-            # callers (and their retry logic) can handle it as a
-            # normal connection failure instead of aborting.
+            unsub()
+            self._bluetooth_disconnect_no_wait(address)
+            # Distinguish an outside cancellation of our task from a
+            # cancellation of the connect_future itself. If the current
+            # task is not actually being cancelled, convert the
+            # CancelledError into an APIConnectionError so callers (and
+            # their retry logic) can treat it as a normal connection
+            # failure instead of aborting.
             current_task = asyncio.current_task()
             if current_task is None or not current_task.cancelling():
                 addr = to_human_readable_address(address)
@@ -968,17 +963,11 @@ class APIClient(APIClientBase):
                 raise APIConnectionError(msg) from None
             raise
         except BaseException:
-            unhandled_exception = True
+            unsub()
+            self._bluetooth_disconnect_no_wait(address)
             raise
         finally:
-            if unhandled_exception or (not connect_ok and not timeout_expired):
-                unsub()
-            if not timeout_expired:
-                timeout_handle.cancel()
-            if unhandled_exception:
-                # Make sure to disconnect if we had an unhandled exception
-                # as otherwise the connection will be left open.
-                self._bluetooth_disconnect_no_wait(address)
+            timeout_handle.cancel()
 
         return unsub
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Replaces the flag based cleanup in `bluetooth_device_connect` with explicit per branch cleanup; each `except` handler now releases its own resources, the `finally` clause is reduced to `timeout_handle.cancel()`, and the three booleans (`connect_ok`, `timeout_expired`, `unhandled_exception`) are gone. The behavior is pinned by `test_bluetooth_device_connect_cleanup_contract`, which already landed in #1761.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1754

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
