### PR TITLE
Re-export COMPONENT_TYPE_TO_INFO from the top-level package

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1985,6 +1985,7 @@ def message_types_to_names(msg_types: Iterable[type[message.Message]]) -> str:
 
 
 __all__ = (
+    "COMPONENT_TYPE_TO_INFO",
     "APIIntEnum",
     "APIModelBase",
     "APIVersion",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -28,7 +28,6 @@ def _model_public_defined_names() -> set[str]:
 # __all__ so ``from .model import *`` does not re-export them. Real consumers
 # reach them via explicit imports, which __all__ does not gate.
 _NOT_EXPORTED = {
-    "COMPONENT_TYPE_TO_INFO",
     "cached_fields",
     "converter_field",
     "message_types_to_names",
@@ -70,6 +69,7 @@ def test_representative_model_classes_stay_exported() -> None:
     """Re-exported model classes remain importable from the top-level package."""
     for name in (
         "APIVersion",
+        "COMPONENT_TYPE_TO_INFO",
         "DeviceInfo",
         "EntityInfo",
         "ClimateInfo",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`COMPONENT_TYPE_TO_INFO` is part of the public API; Home Assistant's `esphome/entry_data.py` imports it from the top-level package. PR #1749 added `__all__` to `model.py` to stop leaking stdlib names, but `COMPONENT_TYPE_TO_INFO` was treated as internal and left out, so `from aioesphomeapi import COMPONENT_TYPE_TO_INFO` started failing in 45.3.0. This adds it back to `__all__`, removes it from the `_NOT_EXPORTED` set in the public API test, and pins it via `test_representative_model_classes_stay_exported`.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
