### PR TITLE
Fix UTF-8 unique id collisions with version 3 unique id format

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1988,8 +1988,13 @@ def build_unique_id(
     if version == 2:
         # Version 2: use name directly to avoid mangling/collisions
         return f"{formatted_mac}-{entity_type}-{entity_info.name}"
-    # Version 3: slash separated with sub-device id and unmangled name
-    return f"{formatted_mac}/{entity_info.device_id}/{entity_type}/{entity_info.name}"
+    if version == 3:
+        # Version 3: slash separated with sub-device id and unmangled name
+        return (
+            f"{formatted_mac}/{entity_info.device_id}/{entity_type}/{entity_info.name}"
+        )
+    msg = f"Unsupported unique id version: {version}"
+    raise ValueError(msg)
 
 
 def build_device_unique_id(

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1982,7 +1982,6 @@ def build_unique_id(
     entities so two sub-devices can share an entity name without colliding,
     while the unmangled name keeps UTF-8 names distinct.
     """
-    # <mac>-<entity type>-<object_id or name>
     entity_type = _TYPE_TO_NAME[type(entity_info)]
     if version == 1:
         return f"{formatted_mac}-{entity_type}-{entity_info.object_id}"

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1971,13 +1971,42 @@ def build_unique_id(
     device names can change or be duplicated across devices. For ESPHome
     entity names within a single device (identified by MAC), they ARE stable
     unique identifiers explicitly chosen by the user in their configuration.
+
+    **Version 3:** Slash separated, includes the sub-device id and the
+    unmangled entity name.
+
+        Format: `{mac}/{device_id}/{entity_type}/{name}`
+        Example: `aabbccddeeff/0/sensor/Temperature Sensor`
+
+    The main device uses `device_id` 0. Including the sub-device id namespaces
+    entities so two sub-devices can share an entity name without colliding,
+    while the unmangled name keeps UTF-8 names distinct.
     """
     # <mac>-<entity type>-<object_id or name>
     entity_type = _TYPE_TO_NAME[type(entity_info)]
     if version == 1:
         return f"{formatted_mac}-{entity_type}-{entity_info.object_id}"
-    # Version 2: use name directly to avoid mangling/collisions
-    return f"{formatted_mac}-{entity_type}-{entity_info.name}"
+    if version == 2:
+        # Version 2: use name directly to avoid mangling/collisions
+        return f"{formatted_mac}-{entity_type}-{entity_info.name}"
+    # Version 3: slash separated with sub-device id and unmangled name
+    return f"{formatted_mac}/{entity_info.device_id}/{entity_type}/{entity_info.name}"
+
+
+def build_device_unique_id(
+    formatted_mac: str, entity_info: EntityInfo, *, version: int = 3
+) -> str:
+    """Build a device-aware unique id for an entity.
+
+    Version 3 already encodes the sub-device id in the unique id, so the
+    result of build_unique_id is returned unchanged. For the legacy versions
+    1 and 2 the sub-device id is appended as `@{device_id}` so that entities
+    belonging to a sub-device migrate correctly when they move between devices.
+    """
+    base_unique_id = build_unique_id(formatted_mac, entity_info, version=version)
+    if version != 3 and entity_info.device_id:
+        return f"{base_unique_id}@{entity_info.device_id}"
+    return base_unique_id
 
 
 def message_types_to_names(msg_types: Iterable[type[message.Message]]) -> str:
@@ -2138,5 +2167,6 @@ __all__ = (
     "ZWaveProxyFrame",
     "ZWaveProxyRequest",
     "ZWaveProxyRequestType",
+    "build_device_unique_id",
     "build_unique_id",
 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -190,6 +190,7 @@ from aioesphomeapi.model import (
     ZWaveProxyFrame,
     ZWaveProxyRequest,
     ZWaveProxyRequestType,
+    build_device_unique_id,
     build_unique_id,
     converter_field,
 )
@@ -550,7 +551,7 @@ def test_user_service_conversion():
         WaterHeaterInfo,
     ],
 )
-def test_build_unique_id(model):
+def test_build_unique_id(model: type[EntityInfo]) -> None:
     obj = model(object_id="id", name="My Sensor")
     # Version 1 (default): uses object_id
     assert build_unique_id("mac", obj) == f"mac-{_TYPE_TO_NAME[type(obj)]}-id"
@@ -561,6 +562,46 @@ def test_build_unique_id(model):
     assert (
         build_unique_id("mac", obj, version=2)
         == f"mac-{_TYPE_TO_NAME[type(obj)]}-My Sensor"
+    )
+    # Version 3: slash separated with sub-device id and unmangled name
+    assert (
+        build_unique_id("mac", obj, version=3)
+        == f"mac/0/{_TYPE_TO_NAME[type(obj)]}/My Sensor"
+    )
+    sub_device = model(object_id="id", name="My Sensor", device_id=5)
+    assert (
+        build_unique_id("mac", sub_device, version=3)
+        == f"mac/5/{_TYPE_TO_NAME[type(obj)]}/My Sensor"
+    )
+    # Version 3: UTF-8 names are preserved instead of mangled to underscores
+    utf8 = model(object_id="___", name="温度传感器")
+    assert (
+        build_unique_id("mac", utf8, version=3)
+        == f"mac/0/{_TYPE_TO_NAME[type(obj)]}/温度传感器"
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        BinarySensorInfo,
+        SensorInfo,
+        SwitchInfo,
+    ],
+)
+def test_build_device_unique_id(model: type[EntityInfo]) -> None:
+    entity_type = _TYPE_TO_NAME[model]
+    main = model(object_id="id", name="My Sensor")
+    sub = model(object_id="id", name="My Sensor", device_id=5)
+    # Version 3 (default): sub-device id is part of the slash format, no @ suffix
+    assert build_device_unique_id("mac", main) == f"mac/0/{entity_type}/My Sensor"
+    assert build_device_unique_id("mac", sub) == f"mac/5/{entity_type}/My Sensor"
+    # Legacy versions append @device_id for sub-devices to match existing ids
+    assert build_device_unique_id("mac", main, version=1) == f"mac-{entity_type}-id"
+    assert build_device_unique_id("mac", sub, version=1) == f"mac-{entity_type}-id@5"
+    assert (
+        build_device_unique_id("mac", sub, version=2)
+        == f"mac-{entity_type}-My Sensor@5"
     )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -579,6 +579,9 @@ def test_build_unique_id(model: type[EntityInfo]) -> None:
         build_unique_id("mac", utf8, version=3)
         == f"mac/0/{_TYPE_TO_NAME[type(obj)]}/温度传感器"
     )
+    # Unsupported versions raise instead of silently picking a format
+    with pytest.raises(ValueError, match="Unsupported unique id version"):
+        build_unique_id("mac", obj, version=4)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -76,6 +76,7 @@ def test_representative_model_classes_stay_exported() -> None:
         "MediaPlayerInfo",
         "BluetoothGATTService",
         "UserService",
+        "build_device_unique_id",
         "build_unique_id",
     ):
         assert hasattr(aioesphomeapi, name)


### PR DESCRIPTION
# What does this implement/fix?

Adds a version 3 unique id format to fix UTF-8 unique id collisions. The legacy object_id mangling lowercases the name, swaps spaces for underscores, and replaces every non ASCII character with an underscore, so any UTF-8 name collapses to underscores and distinct entities collide; for example 温度传感器 and 湿度传感器 both become ___. Version 3 is slash separated and uses the unmangled entity name plus the sub-device id, so UTF-8 names stay distinct and same-named entities on different sub-devices no longer collide.

Format: `{mac}/{device_id}/{entity_type}/{name}`, the main device uses device_id 0.

Also adds `build_device_unique_id` so the device aware id handling lives in the library instead of Home Assistant; for the legacy versions 1 and 2 it appends `@device_id` for sub-devices to match the ids that already shipped.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/backlog/issues/85
- Home Assistant PR: https://github.com/home-assistant/core/pull/174814

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
