### PR TITLE
Defer noise and cryptography imports until an encrypted connection

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -9,9 +9,20 @@ from .base cimport (
     _MAX_NAME_LEN,
 )
 from .noise_encryption cimport EncryptCipher, DecryptCipher
-from .packets cimport make_noise_packets
 
 cdef bint TYPE_CHECKING
+
+
+@cython.locals(
+    type_="unsigned int",
+    data=bytes,
+    data_header=bytes,
+    packet=tuple,
+    data_len=Py_ssize_t,
+    frame=bytes,
+    frame_len=Py_ssize_t,
+)
+cpdef list make_noise_packets(list packets, EncryptCipher encrypt_cipher) except *
 
 cdef unsigned int NOISE_STATE_HELLO
 cdef unsigned int NOISE_STATE_HANDSHAKE

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -21,7 +21,6 @@ from ..core import (
 )
 from .base import _LOGGER, APIFrameHelper
 from .noise_encryption import ESPHOME_NOISE_BACKEND, DecryptCipher, EncryptCipher
-from .packets import make_noise_packets
 
 if TYPE_CHECKING:
     import asyncio
@@ -52,6 +51,31 @@ int_ = int
 _MAX_NAME_LEN = MAX_NAME_LEN
 _MAX_MAC_LEN = MAX_MAC_LEN
 _MAX_EXPLANATION_LEN = MAX_EXPLANATION_LEN
+
+
+def make_noise_packets(
+    packets: list[tuple[int, bytes]], encrypt_cipher: EncryptCipher
+) -> list[bytes]:
+    """Make a list of noise packet."""
+    out: list[bytes] = []
+    for packet in packets:
+        type_: int = packet[0]
+        data: bytes = packet[1]
+        data_len = len(data)
+        data_header = bytes(
+            (
+                (type_ >> 8) & 0xFF,
+                type_ & 0xFF,
+                (data_len >> 8) & 0xFF,
+                data_len & 0xFF,
+            )
+        )
+        frame = encrypt_cipher.encrypt(data_header + data)
+        frame_len = len(frame)
+        header = bytes((0x01, (frame_len >> 8) & 0xFF, frame_len & 0xFF))
+        out.append(header)
+        out.append(frame)
+    return out
 
 
 class APINoiseFrameHelper(APIFrameHelper):

--- a/aioesphomeapi/_frame_helper/packets.pxd
+++ b/aioesphomeapi/_frame_helper/packets.pxd
@@ -1,7 +1,5 @@
 import cython
 
-from .noise_encryption cimport EncryptCipher
-
 cdef object varuint_to_bytes
 
 cpdef _varuint_to_bytes(int value)
@@ -14,15 +12,3 @@ cpdef _varuint_to_bytes(int value)
     type_=object
 )
 cpdef list make_plain_text_packets(list packets) except *
-
-
-@cython.locals(
-    type_="unsigned int",
-    data=bytes,
-    data_header=bytes,
-    packet=tuple,
-    data_len=Py_ssize_t,
-    frame=bytes,
-    frame_len=Py_ssize_t,
-)
-cpdef list make_noise_packets(list packets, EncryptCipher encrypt_cipher) except *

--- a/aioesphomeapi/_frame_helper/packets.py
+++ b/aioesphomeapi/_frame_helper/packets.py
@@ -1,7 +1,5 @@
 from functools import lru_cache
 
-from .noise_encryption import EncryptCipher
-
 _int = int
 
 
@@ -37,29 +35,4 @@ def make_plain_text_packets(packets: list[tuple[int, bytes]]) -> list[bytes]:
         out.append(varuint_to_bytes(type_))
         if data:
             out.append(data)
-    return out
-
-
-def make_noise_packets(
-    packets: list[tuple[int, bytes]], encrypt_cipher: EncryptCipher
-) -> list[bytes]:
-    """Make a list of noise packet."""
-    out: list[bytes] = []
-    for packet in packets:
-        type_: int = packet[0]
-        data: bytes = packet[1]
-        data_len = len(data)
-        data_header = bytes(
-            (
-                (type_ >> 8) & 0xFF,
-                type_ & 0xFF,
-                (data_len >> 8) & 0xFF,
-                data_len & 0xFF,
-            )
-        )
-        frame = encrypt_cipher.encrypt(data_header + data)
-        frame_len = len(frame)
-        header = bytes((0x01, (frame_len >> 8) & 0xFF, frame_len & 0xFF))
-        out.append(header)
-        out.append(frame)
     return out

--- a/aioesphomeapi/client_base.pxd
+++ b/aioesphomeapi/client_base.pxd
@@ -1,7 +1,6 @@
 import cython
 
 from ._frame_helper.base cimport APIFrameHelper
-from ._frame_helper.noise cimport APINoiseFrameHelper
 from ._frame_helper.plain_text cimport APIPlaintextFrameHelper
 from .connection cimport APIConnection, ConnectionParams
 

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -11,7 +11,6 @@ from ._frame_helper.base import (  # noqa: F401
     APIFrameHelper,
     safe_label_str,
 )
-from ._frame_helper.noise import APINoiseFrameHelper  # noqa: F401
 from ._frame_helper.plain_text import APIPlaintextFrameHelper  # noqa: F401
 from .api_pb2 import (  # type: ignore[attr-defined]
     BluetoothConnectionsFreeResponse,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -73,13 +73,13 @@ _LOGGER = logging.getLogger(__name__)
 # which are only needed for encrypted connections; importing them is deferred
 # until the first noise connection so plaintext-only callers never pay for them.
 # The resolved class is cached here, set only after the import fully completes.
-_noise_frame_helper_cls: Any = None
+_noise_frame_helper_cls: type[APINoiseFrameHelper] | None = None
 # Serializes the cold import so concurrent encrypted connections do not each
 # spawn an executor thread racing to import the same noise stack.
 _noise_import_lock = asyncio.Lock()
 
 
-def _import_noise_frame_helper() -> Any:
+def _import_noise_frame_helper() -> type[APINoiseFrameHelper]:
     global _noise_frame_helper_cls  # noqa: PLW0603
     from ._frame_helper.noise import APINoiseFrameHelper  # noqa: PLC0415
 
@@ -87,7 +87,9 @@ def _import_noise_frame_helper() -> Any:
     return APINoiseFrameHelper
 
 
-async def _async_load_noise_frame_helper(loop: asyncio.AbstractEventLoop) -> Any:
+async def _async_load_noise_frame_helper(
+    loop: asyncio.AbstractEventLoop,
+) -> type[APINoiseFrameHelper]:
     """Load the noise frame helper, importing off the loop on the first cold import.
 
     The import pulls in cryptography and the noise stack, which does blocking file
@@ -551,7 +553,7 @@ class APIConnection:
             )
         else:
             noise_frame_helper = await _async_load_noise_frame_helper(self._loop)
-            _, fh = await self._loop.create_connection(
+            _, fh = await self._loop.create_connection(  # type: ignore[type-var]
                 lambda: noise_frame_helper(
                     noise_psk=noise_psk,
                     expected_name=self._params.expected_name,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -18,7 +18,6 @@ from google.protobuf.json_format import MessageToDict
 import aioesphomeapi.host_resolver as hr
 
 from ._frame_helper.base import MAX_NAME_LEN, safe_label_str
-from ._frame_helper.noise import APINoiseFrameHelper
 from ._frame_helper.plain_text import APIPlaintextFrameHelper
 from .api_pb2 import (  # type: ignore[attr-defined]
     DST_RULE_TYPE_DAY_OF_YEAR as DST_RULE_TYPE_DAY_OF_YEAR_PB,
@@ -65,9 +64,34 @@ if TYPE_CHECKING:
 
     from google.protobuf import message
 
+    from ._frame_helper.noise import APINoiseFrameHelper
     from .zeroconf import ZeroconfManager
 
 _LOGGER = logging.getLogger(__name__)
+
+# The noise frame helper pulls in cryptography and the noise protocol stack,
+# which are only needed for encrypted connections; importing them is deferred
+# until the first noise connection so plaintext-only callers never pay for them.
+_NOISE_FRAME_HELPER_MODULE = "aioesphomeapi._frame_helper.noise"
+
+
+def _import_noise_frame_helper() -> Any:
+    from ._frame_helper.noise import APINoiseFrameHelper  # noqa: PLC0415
+
+    return APINoiseFrameHelper
+
+
+async def _async_load_noise_frame_helper(loop: asyncio.AbstractEventLoop) -> Any:
+    """Load the noise frame helper, importing off the loop on the first cold import.
+
+    The import pulls in cryptography and the noise stack, which does blocking file
+    I/O; running it in the executor keeps the event loop unblocked. Once the module
+    is in sys.modules the import is a cheap dict lookup, so it is bound inline.
+    """
+    if _NOISE_FRAME_HELPER_MODULE not in sys.modules:
+        return await loop.run_in_executor(None, _import_noise_frame_helper)
+    return _import_noise_frame_helper()
+
 
 MESSAGE_NUMBER_TO_PROTO: tuple[
     tuple[Callable[[], message.Message], Callable[[message.Message, bytes], None]], ...
@@ -514,8 +538,9 @@ class APIConnection:
                 sock=self._socket,
             )
         else:
-            _, fh = await self._loop.create_connection(  # type: ignore[type-var]
-                lambda: APINoiseFrameHelper(
+            noise_frame_helper = await _async_load_noise_frame_helper(self._loop)
+            _, fh = await self._loop.create_connection(
+                lambda: noise_frame_helper(
                     noise_psk=noise_psk,
                     expected_name=self._params.expected_name,
                     expected_mac=self._params.expected_mac,

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -73,6 +73,9 @@ _LOGGER = logging.getLogger(__name__)
 # which are only needed for encrypted connections; importing them is deferred
 # until the first noise connection so plaintext-only callers never pay for them.
 _NOISE_FRAME_HELPER_MODULE = "aioesphomeapi._frame_helper.noise"
+# Serializes the cold import so concurrent encrypted connections do not each
+# spawn an executor thread racing to import the same noise stack.
+_noise_import_lock = asyncio.Lock()
 
 
 def _import_noise_frame_helper() -> Any:
@@ -88,9 +91,12 @@ async def _async_load_noise_frame_helper(loop: asyncio.AbstractEventLoop) -> Any
     I/O; running it in the executor keeps the event loop unblocked. Once the module
     is in sys.modules the import is a cheap dict lookup, so it is bound inline.
     """
-    if _NOISE_FRAME_HELPER_MODULE not in sys.modules:
+    if _NOISE_FRAME_HELPER_MODULE in sys.modules:
+        return _import_noise_frame_helper()
+    async with _noise_import_lock:
+        if _NOISE_FRAME_HELPER_MODULE in sys.modules:
+            return _import_noise_frame_helper()
         return await loop.run_in_executor(None, _import_noise_frame_helper)
-    return _import_noise_frame_helper()
 
 
 MESSAGE_NUMBER_TO_PROTO: tuple[

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -72,18 +72,20 @@ _LOGGER = logging.getLogger(__name__)
 # The noise frame helper pulls in cryptography and the noise protocol stack,
 # which are only needed for encrypted connections; importing them is deferred
 # until the first noise connection so plaintext-only callers never pay for them.
-# The resolved class is cached here, set only after the import fully completes.
-_noise_frame_helper_cls: type[APINoiseFrameHelper] | None = None
-# Serializes the cold import so concurrent encrypted connections do not each
-# spawn an executor thread racing to import the same noise stack.
-_noise_import_lock = asyncio.Lock()
+# State lives in module-level containers mutated in place (no global rebinding):
+# the resolved class is cached once after a successful import, and a per-loop
+# lock serializes the cold import so concurrent connections do not each spawn an
+# executor thread. Keying the lock by loop avoids the cross-loop binding error a
+# single shared lock would raise if a later connection ran on a different loop.
+_noise_frame_helper_cache: list[type[APINoiseFrameHelper]] = []
+_noise_import_locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
 
 
 def _import_noise_frame_helper() -> type[APINoiseFrameHelper]:
-    global _noise_frame_helper_cls  # noqa: PLW0603
     from ._frame_helper.noise import APINoiseFrameHelper  # noqa: PLC0415
 
-    _noise_frame_helper_cls = APINoiseFrameHelper
+    if not _noise_frame_helper_cache:
+        _noise_frame_helper_cache.append(APINoiseFrameHelper)
     return APINoiseFrameHelper
 
 
@@ -98,12 +100,15 @@ async def _async_load_noise_frame_helper(
     import entirely and a task racing the first cold import waits on the lock
     instead of re-running the import on the loop thread.
     """
-    if (cls := _noise_frame_helper_cls) is not None:
-        return cls
-    async with _noise_import_lock:
+    if _noise_frame_helper_cache:
+        return _noise_frame_helper_cache[0]
+    lock = _noise_import_locks.get(loop)
+    if lock is None:
+        lock = _noise_import_locks[loop] = asyncio.Lock()
+    async with lock:
         # Another task may have completed the import while we waited.
-        if (cls := _noise_frame_helper_cls) is not None:
-            return cls
+        if _noise_frame_helper_cache:
+            return _noise_frame_helper_cache[0]
         return await loop.run_in_executor(None, _import_noise_frame_helper)
 
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -72,15 +72,18 @@ _LOGGER = logging.getLogger(__name__)
 # The noise frame helper pulls in cryptography and the noise protocol stack,
 # which are only needed for encrypted connections; importing them is deferred
 # until the first noise connection so plaintext-only callers never pay for them.
-_NOISE_FRAME_HELPER_MODULE = "aioesphomeapi._frame_helper.noise"
+# The resolved class is cached here, set only after the import fully completes.
+_noise_frame_helper_cls: Any = None
 # Serializes the cold import so concurrent encrypted connections do not each
 # spawn an executor thread racing to import the same noise stack.
 _noise_import_lock = asyncio.Lock()
 
 
 def _import_noise_frame_helper() -> Any:
+    global _noise_frame_helper_cls  # noqa: PLW0603
     from ._frame_helper.noise import APINoiseFrameHelper  # noqa: PLC0415
 
+    _noise_frame_helper_cls = APINoiseFrameHelper
     return APINoiseFrameHelper
 
 
@@ -88,14 +91,17 @@ async def _async_load_noise_frame_helper(loop: asyncio.AbstractEventLoop) -> Any
     """Load the noise frame helper, importing off the loop on the first cold import.
 
     The import pulls in cryptography and the noise stack, which does blocking file
-    I/O; running it in the executor keeps the event loop unblocked. Once the module
-    is in sys.modules the import is a cheap dict lookup, so it is bound inline.
+    I/O; running it in the executor keeps the event loop unblocked. The resolved
+    class is cached once the import fully completes, so warm connections skip the
+    import entirely and a task racing the first cold import waits on the lock
+    instead of re-running the import on the loop thread.
     """
-    if _NOISE_FRAME_HELPER_MODULE in sys.modules:
-        return _import_noise_frame_helper()
+    if (cls := _noise_frame_helper_cls) is not None:
+        return cls
     async with _noise_import_lock:
-        if _NOISE_FRAME_HELPER_MODULE in sys.modules:
-            return _import_noise_frame_helper()
+        # Another task may have completed the import while we waited.
+        if (cls := _noise_frame_helper_cls) is not None:
+            return cls
         return await loop.run_in_executor(None, _import_noise_frame_helper)
 
 

--- a/tests/benchmarks/test_noise.py
+++ b/tests/benchmarks/test_noise.py
@@ -14,8 +14,8 @@ from aioesphomeapi._frame_helper.base import (
     MAX_NAME_LEN,
     safe_label_str,
 )
+from aioesphomeapi._frame_helper.noise import make_noise_packets
 from aioesphomeapi._frame_helper.noise_encryption import EncryptCipher
-from aioesphomeapi._frame_helper.packets import make_noise_packets
 
 from ..common import (
     MockAPINoiseFrameHelper,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 import pytest_asyncio
 
 from aioesphomeapi.client import APIClient, ConnectionParams
-from aioesphomeapi.connection import APIConnection
+from aioesphomeapi.connection import APIConnection, _import_noise_frame_helper
 from aioesphomeapi.host_resolver import AddrInfo, IPv4Sockaddr
 from aioesphomeapi.singleton import _SINGLETON_CACHE
 
@@ -112,6 +112,9 @@ async def conn_with_password(connection_params: ConnectionParams) -> APIConnecti
 
 @pytest.fixture
 async def noise_conn(connection_params: ConnectionParams) -> APIConnection:
+    # Pre-resolve the noise frame helper so connection setup takes the warm
+    # inline path; the cold executor import is covered in test_lazy_imports.
+    _import_noise_frame_helper()
     connection_params = replace(
         connection_params, noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     )

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from aioesphomeapi import connection as connection_module
 from aioesphomeapi._frame_helper.noise import APINoiseFrameHelper
 
@@ -19,6 +21,12 @@ DEFERRED_MODULES = (
     "aioesphomeapi._frame_helper.noise",
     "aioesphomeapi._frame_helper.noise_encryption",
 )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_noise_import_lock():
+    """Give each test a lock bound to its own event loop."""
+    connection_module._noise_import_lock = asyncio.Lock()
 
 
 def test_import_does_not_load_noise_stack() -> None:
@@ -62,3 +70,39 @@ async def test_load_noise_frame_helper_uses_executor_when_cold(monkeypatch) -> N
     mock_executor.assert_called_once_with(
         None, connection_module._import_noise_frame_helper
     )
+
+
+async def test_concurrent_cold_loads_import_once(monkeypatch) -> None:
+    """Concurrent cold loads import the noise stack once, not once per task."""
+    noise_module = sys.modules[connection_module._NOISE_FRAME_HELPER_MODULE]
+    monkeypatch.delitem(
+        sys.modules, connection_module._NOISE_FRAME_HELPER_MODULE, raising=False
+    )
+    loop = asyncio.get_running_loop()
+    import_started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _slow_import() -> type[APINoiseFrameHelper]:
+        import_started.set()
+        await release.wait()
+        sys.modules[connection_module._NOISE_FRAME_HELPER_MODULE] = noise_module
+        return APINoiseFrameHelper
+
+    def _fake_executor(_executor, func) -> asyncio.Future:
+        nonlocal calls
+        calls += 1
+        return asyncio.ensure_future(_slow_import())
+
+    with patch.object(loop, "run_in_executor", side_effect=_fake_executor):
+        tasks = [
+            asyncio.create_task(connection_module._async_load_noise_frame_helper(loop))
+            for _ in range(5)
+        ]
+        await import_started.wait()  # first task is inside the executor import
+        await asyncio.sleep(0)  # let the others pile up on the lock
+        release.set()
+        results = await asyncio.gather(*tasks)
+
+    assert calls == 1
+    assert all(cls is APINoiseFrameHelper for cls in results)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,64 @@
+"""Pin that the noise/cryptography stack stays off the import path."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from unittest.mock import patch
+
+from aioesphomeapi import connection as connection_module
+from aioesphomeapi._frame_helper.noise import APINoiseFrameHelper
+
+# Modules that must only load for encrypted (noise) connections.
+DEFERRED_MODULES = (
+    "noise",
+    "noise.connection",
+    "chacha20poly1305_reuseable",
+    "cryptography.hazmat.primitives.ciphers.aead",
+    "aioesphomeapi._frame_helper.noise",
+    "aioesphomeapi._frame_helper.noise_encryption",
+)
+
+
+def test_import_does_not_load_noise_stack() -> None:
+    """Importing the package must not pull in the noise/cryptography stack."""
+    script = (
+        "import sys, aioesphomeapi\n"
+        f"loaded = [m for m in {DEFERRED_MODULES!r} if m in sys.modules]\n"
+        "print(','.join(loaded))\n"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", f"unexpectedly loaded: {result.stdout.strip()}"
+
+
+async def test_load_noise_frame_helper_inline_when_already_imported() -> None:
+    """A warm import binds inline without hopping to the executor."""
+    loop = asyncio.get_running_loop()
+    with patch.object(loop, "run_in_executor") as mock_executor:
+        cls = await connection_module._async_load_noise_frame_helper(loop)
+
+    assert cls is APINoiseFrameHelper
+    mock_executor.assert_not_called()
+
+
+async def test_load_noise_frame_helper_uses_executor_when_cold(monkeypatch) -> None:
+    """A cold import is run in the executor so it never blocks the loop."""
+    monkeypatch.delitem(
+        sys.modules, connection_module._NOISE_FRAME_HELPER_MODULE, raising=False
+    )
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    future.set_result(APINoiseFrameHelper)
+    with patch.object(loop, "run_in_executor", return_value=future) as mock_executor:
+        cls = await connection_module._async_load_noise_frame_helper(loop)
+
+    assert cls is APINoiseFrameHelper
+    mock_executor.assert_called_once_with(
+        None, connection_module._import_noise_frame_helper
+    )

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -24,9 +24,15 @@ DEFERRED_MODULES = (
 
 
 @pytest.fixture(autouse=True)
-def _fresh_noise_import_lock():
-    """Give each test a lock bound to its own event loop."""
+def _reset_noise_loader():
+    """Start each test cold with a lock bound to its own event loop."""
+    orig_cls = connection_module._noise_frame_helper_cls
+    orig_lock = connection_module._noise_import_lock
+    connection_module._noise_frame_helper_cls = None
     connection_module._noise_import_lock = asyncio.Lock()
+    yield
+    connection_module._noise_frame_helper_cls = orig_cls
+    connection_module._noise_import_lock = orig_lock
 
 
 def test_import_does_not_load_noise_stack() -> None:
@@ -45,8 +51,17 @@ def test_import_does_not_load_noise_stack() -> None:
     assert result.stdout.strip() == "", f"unexpectedly loaded: {result.stdout.strip()}"
 
 
-async def test_load_noise_frame_helper_inline_when_already_imported() -> None:
-    """A warm import binds inline without hopping to the executor."""
+def test_import_noise_frame_helper_caches_class() -> None:
+    """The import helper resolves and caches the class only on completion."""
+    assert connection_module._noise_frame_helper_cls is None
+    cls = connection_module._import_noise_frame_helper()
+    assert cls is APINoiseFrameHelper
+    assert connection_module._noise_frame_helper_cls is APINoiseFrameHelper
+
+
+async def test_load_noise_frame_helper_returns_cached_without_import() -> None:
+    """A warm load returns the cached class without touching the executor."""
+    connection_module._noise_frame_helper_cls = APINoiseFrameHelper
     loop = asyncio.get_running_loop()
     with patch.object(loop, "run_in_executor") as mock_executor:
         cls = await connection_module._async_load_noise_frame_helper(loop)
@@ -55,11 +70,8 @@ async def test_load_noise_frame_helper_inline_when_already_imported() -> None:
     mock_executor.assert_not_called()
 
 
-async def test_load_noise_frame_helper_uses_executor_when_cold(monkeypatch) -> None:
+async def test_load_noise_frame_helper_uses_executor_when_cold() -> None:
     """A cold import is run in the executor so it never blocks the loop."""
-    monkeypatch.delitem(
-        sys.modules, connection_module._NOISE_FRAME_HELPER_MODULE, raising=False
-    )
     loop = asyncio.get_running_loop()
     future = loop.create_future()
     future.set_result(APINoiseFrameHelper)
@@ -72,12 +84,8 @@ async def test_load_noise_frame_helper_uses_executor_when_cold(monkeypatch) -> N
     )
 
 
-async def test_concurrent_cold_loads_import_once(monkeypatch) -> None:
+async def test_concurrent_cold_loads_import_once() -> None:
     """Concurrent cold loads import the noise stack once, not once per task."""
-    noise_module = sys.modules[connection_module._NOISE_FRAME_HELPER_MODULE]
-    monkeypatch.delitem(
-        sys.modules, connection_module._NOISE_FRAME_HELPER_MODULE, raising=False
-    )
     loop = asyncio.get_running_loop()
     import_started = asyncio.Event()
     release = asyncio.Event()
@@ -86,7 +94,7 @@ async def test_concurrent_cold_loads_import_once(monkeypatch) -> None:
     async def _slow_import() -> type[APINoiseFrameHelper]:
         import_started.set()
         await release.wait()
-        sys.modules[connection_module._NOISE_FRAME_HELPER_MODULE] = noise_module
+        connection_module._noise_frame_helper_cls = APINoiseFrameHelper
         return APINoiseFrameHelper
 
     def _fake_executor(_executor, func) -> asyncio.Future:

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -25,14 +25,14 @@ DEFERRED_MODULES = (
 
 @pytest.fixture(autouse=True)
 def _reset_noise_loader():
-    """Start each test cold with a lock bound to its own event loop."""
-    orig_cls = connection_module._noise_frame_helper_cls
-    orig_lock = connection_module._noise_import_lock
-    connection_module._noise_frame_helper_cls = None
-    connection_module._noise_import_lock = asyncio.Lock()
+    """Start each test cold; the loader creates a lock for the test loop."""
+    orig_cache = connection_module._noise_frame_helper_cache
+    orig_locks = connection_module._noise_import_locks
+    connection_module._noise_frame_helper_cache = []
+    connection_module._noise_import_locks = {}
     yield
-    connection_module._noise_frame_helper_cls = orig_cls
-    connection_module._noise_import_lock = orig_lock
+    connection_module._noise_frame_helper_cache = orig_cache
+    connection_module._noise_import_locks = orig_locks
 
 
 def test_import_does_not_load_noise_stack() -> None:
@@ -53,15 +53,15 @@ def test_import_does_not_load_noise_stack() -> None:
 
 def test_import_noise_frame_helper_caches_class() -> None:
     """The import helper resolves and caches the class only on completion."""
-    assert connection_module._noise_frame_helper_cls is None
+    assert connection_module._noise_frame_helper_cache == []
     cls = connection_module._import_noise_frame_helper()
     assert cls is APINoiseFrameHelper
-    assert connection_module._noise_frame_helper_cls is APINoiseFrameHelper
+    assert connection_module._noise_frame_helper_cache == [APINoiseFrameHelper]
 
 
 async def test_load_noise_frame_helper_returns_cached_without_import() -> None:
     """A warm load returns the cached class without touching the executor."""
-    connection_module._noise_frame_helper_cls = APINoiseFrameHelper
+    connection_module._noise_frame_helper_cache.append(APINoiseFrameHelper)
     loop = asyncio.get_running_loop()
     with patch.object(loop, "run_in_executor") as mock_executor:
         cls = await connection_module._async_load_noise_frame_helper(loop)
@@ -94,7 +94,7 @@ async def test_concurrent_cold_loads_import_once() -> None:
     async def _slow_import() -> type[APINoiseFrameHelper]:
         import_started.set()
         await release.wait()
-        connection_module._noise_frame_helper_cls = APINoiseFrameHelper
+        connection_module._noise_frame_helper_cache.append(APINoiseFrameHelper)
         return APINoiseFrameHelper
 
     def _fake_executor(_executor, func) -> asyncio.Future:


### PR DESCRIPTION
# What does this implement/fix?

The noise frame helper pulls in `cryptography`, the `noise` protocol stack, and `chacha20poly1305_reuseable`, which are only needed for encrypted connections; they were being imported eagerly when the package was imported, and even a plaintext connection dragged them in because `packets.py` imported `make_noise_packets` from `noise_encryption`.

This moves `make_noise_packets` into `noise.py` so the plaintext packet builder no longer depends on the noise stack, and loads the noise frame helper lazily on the first encrypted connection. The cold import is run in an executor so it never blocks the event loop; once the module is cached it binds inline.

For a use case like `esphome logs` against a plaintext device, the whole noise and cryptography stack is now skipped; warm import of `aioesphomeapi` drops by about 12 ms locally and the stack is no longer resident. For encrypted devices the cost simply moves to connect time, which is already waiting on the network.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
