### PR TITLE
Revert "Update cryptography requirement from >=48.0.0 to >=49.0.0"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,5 @@ tzdata>=2026.2
 tzlocal>=5.4.3,<6
 zeroconf>=0.150.0,<2.0
 chacha20poly1305-reuseable>=0.13.2
-cryptography>=49.0.0
+cryptography>=48.0.0
 noiseprotocol>=0.3.1,<1.0


### PR DESCRIPTION
Reverts esphome/aioesphomeapi#1781

blocked upstream https://github.com/home-assistant/core/pull/174819