### PR TITLE
Remove obsolete cibuildwheel free-threading enable group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
         env:
           CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
           CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
-          CIBW_ENABLE: cpython-freethreading
           REQUIRE_CYTHON: 1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
# What does this implement/fix?

The release wheel builds fail at the cibuildwheel step with `Unknown enable group: cpython-freethreading`, so no wheels are produced and the PyPI upload is skipped. The cibuildwheel action was bumped to the 3.x line (v4.1.0), where free threaded CPython is built by default and the `cpython-freethreading` enable group was removed; the leftover `CIBW_ENABLE` then hard errors on every platform.

This drops the obsolete `CIBW_ENABLE` line. Free threaded wheels still build by default; with the pinned cibuildwheel the default set includes `cp314t`, confirmed locally with `cibuildwheel --print-build-identifiers` (the flag reproduces the error, removing it lists `cp314t`). `cp313t` stays out via the existing skips, which is intended.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
