### PR TITLE
Cap reconnect backoff for deep-sleep devices

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -381,6 +381,11 @@ class APIClient(APIClientBase):
         else:
             await self._connection.disconnect()
 
+    @property
+    def cached_device_info(self) -> DeviceInfo | None:
+        """DeviceInfo from this session's last fetch, or None before one / after disconnect."""
+        return self._cached_device_info
+
     async def device_info(self) -> DeviceInfo:
         resp = await self._get_connection().send_message_await_response(
             DeviceInfoRequest(), DeviceInfoResponse

--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -382,9 +382,11 @@ class APIClient(APIClientBase):
             await self._connection.disconnect()
 
     @property
-    def cached_device_info(self) -> DeviceInfo | None:
-        """DeviceInfo from this session's last fetch, or None before one / after disconnect."""
-        return self._cached_device_info
+    def cached_device_has_deep_sleep(self) -> bool | None:
+        """has_deep_sleep from this session's cached device_info, or None if not fetched."""
+        if (info := self._cached_device_info) is None:
+            return None
+        return info.has_deep_sleep
 
     async def device_info(self) -> DeviceInfo:
         resp = await self._get_connection().send_message_await_response(

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -36,6 +36,10 @@ ADDRESS_RECORD_TYPES = {TYPE_A, TYPE_AAAA}
 
 EXPECTED_DISCONNECT_COOLDOWN = 5.0
 MAXIMUM_BACKOFF_TRIES = 100
+MAXIMUM_BACKOFF = 60.0
+# Deep-sleep devices are only awake for a short window; a lost boot-announce must
+# not leave a reconnect waiting out the full backoff past that window.
+DEEP_SLEEP_MAXIMUM_BACKOFF = 15.0
 
 
 class ReconnectLogicState(Enum):
@@ -109,6 +113,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self.name = client.address.partition(".")[0]
         if self.name:
             self._cli.set_cached_name_if_unset(self.name)
+        # Set by the consumer once known (from DeviceInfo.has_deep_sleep); caps the
+        # reconnect backoff so a short awake window is not missed.
+        self.deep_sleep: bool = False
         self._on_connect_cb = on_connect
         self._on_disconnect_cb = on_disconnect
         self._on_connect_error_cb = on_connect_error
@@ -385,7 +392,10 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             if await self._try_connect():
                 return
             tries = min(self._tries, 10)  # prevent OverflowError
-            wait_time = round(min(1.8**tries, 60.0))
+            max_backoff = (
+                DEEP_SLEEP_MAXIMUM_BACKOFF if self.deep_sleep else MAXIMUM_BACKOFF
+            )
+            wait_time = round(min(1.8**tries, max_backoff))
             if tries == 1:
                 _LOGGER.info(
                     "Trying to connect to %s in the background", self._cli.log_name

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -271,8 +271,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         # fetched; the client clears its cache on disconnect, so capture it now
         # while connected. Persists on this long-lived object to cap the next
         # reconnect's backoff, and self-heals if the device's config changes.
-        if (info := self._cli.cached_device_info) is not None:
-            self.deep_sleep = info.has_deep_sleep
+        # None means device_info was not fetched, so leave any override intact.
+        if (has_deep_sleep := self._cli.cached_device_has_deep_sleep) is not None:
+            self.deep_sleep = has_deep_sleep
         return True
 
     async def _handle_connection_failure(self, err: Exception) -> None:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -113,8 +113,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self.name = client.address.partition(".")[0]
         if self.name:
             self._cli.set_cached_name_if_unset(self.name)
-        # Set by the consumer once known (from DeviceInfo.has_deep_sleep); caps the
-        # reconnect backoff so a short awake window is not missed.
+        # Populated from DeviceInfo.has_deep_sleep after each successful connect
+        # (see _try_connect); caps the reconnect backoff so a short awake window
+        # is not missed. A consumer may also set it directly.
         self.deep_sleep: bool = False
         self._on_connect_cb = on_connect
         self._on_disconnect_cb = on_disconnect
@@ -266,6 +267,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         )
         self._async_set_connection_state_while_locked(ReconnectLogicState.READY)
         await self._on_connect_cb()
+        # Remember deep-sleep from the device_info the connect callback just
+        # fetched; the client clears its cache on disconnect, so capture it now
+        # while connected. Persists on this long-lived object to cap the next
+        # reconnect's backoff, and self-heals if the device's config changes.
+        if (info := self._cli.cached_device_info) is not None:
+            self.deep_sleep = info.has_deep_sleep
         return True
 
     async def _handle_connection_failure(self, err: Exception) -> None:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -30,6 +30,8 @@ from aioesphomeapi.core import APIConnectionCancelledError
 if TYPE_CHECKING:
     from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
 from aioesphomeapi.reconnect_logic import (
+    DEEP_SLEEP_MAXIMUM_BACKOFF,
+    MAXIMUM_BACKOFF,
     MAXIMUM_BACKOFF_TRIES,
     ReconnectLogic,
     ReconnectLogicState,
@@ -364,6 +366,46 @@ async def test_reconnect_retry(
 
     await rl.stop()
     assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+
+
+@pytest.mark.parametrize(
+    ("deep_sleep", "expected_wait"),
+    [(True, DEEP_SLEEP_MAXIMUM_BACKOFF), (False, MAXIMUM_BACKOFF)],
+)
+async def test_deep_sleep_caps_reconnect_backoff(
+    patchable_api_client: APIClient,
+    deep_sleep: bool,
+    expected_wait: float,
+) -> None:
+    """A deep-sleep device caps the backoff so a lost boot-announce still redials in time."""
+    cli = patchable_api_client
+
+    async def _noop(*args: object) -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_connect=_noop,
+        on_disconnect=_noop,
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+    rl.deep_sleep = deep_sleep
+    rl._is_stopped = False
+    # High enough that 1.8**tries would exceed MAXIMUM_BACKOFF without the cap.
+    rl._tries = 10
+
+    loop = asyncio.get_running_loop()
+    now = loop.time()
+    with (
+        patch.object(rl, "_start_zc_listen"),
+        patch.object(rl, "_try_connect", AsyncMock(return_value=False)),
+    ):
+        await rl._connect_once_or_reschedule()
+
+    assert rl._connect_timer is not None
+    assert rl._connect_timer.when() - now == pytest.approx(expected_wait, abs=1)
+    await rl.stop()
 
 
 DNS_POINTER = DNSPointer(

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -21,6 +21,7 @@ from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR
 
 from aioesphomeapi import (
     APIConnectionError,
+    DeviceInfo,
     EncryptionPlaintextAPIError,
     RequiresEncryptionAPIError,
 )
@@ -405,6 +406,44 @@ async def test_deep_sleep_caps_reconnect_backoff(
 
     assert rl._connect_timer is not None
     assert rl._connect_timer.when() - now == pytest.approx(expected_wait, abs=1)
+    await rl.stop()
+
+
+@pytest.mark.parametrize("has_deep_sleep", [True, False])
+async def test_deep_sleep_self_populates_from_device_info(
+    patchable_api_client: APIClient,
+    has_deep_sleep: bool,
+) -> None:
+    """The flag is read from the connect callback's device_info, so it self-heals on reconnect."""
+    cli = patchable_api_client
+
+    async def on_connect() -> None:
+        # Stand in for the consumer fetching device_info during on_connect,
+        # which is what populates the client's cache.
+        cli._cached_device_info = DeviceInfo(has_deep_sleep=has_deep_sleep)
+
+    async def on_disconnect(expected_disconnect: bool) -> None:
+        pass
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_connect=on_connect,
+        on_disconnect=on_disconnect,
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+    assert rl.deep_sleep is False
+
+    with (
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection"),
+        patch.object(cli, "finish_connection"),
+    ):
+        await rl.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert rl.deep_sleep is has_deep_sleep
     await rl.stop()
 
 


### PR DESCRIPTION
# What does this implement/fix?

Deep sleep devices are only awake for a short window. After an OTA reboot the reconnect backoff grows on every failed dial while the device is down (2, 3, 6, 11, 19, 34, 60s), so if the boot mDNS announce is lost the next dial can be scheduled well past the awake window and Home Assistant reconnects only after the device has gone back to sleep.

This caps the reconnect backoff at 15s for deep sleep devices, so a redial still lands inside a typical awake window even when the announce is lost. The zeroconf short circuit still wins when the announce arrives; the cap only matters on the lost announce path.

`ReconnectLogic` learns whether the device deep sleeps on its own: at the end of each successful connect it reads has_deep_sleep from the device_info the connect callback just fetched, and remembers it on the long lived object (the client clears its cache on disconnect, so it is captured while connected). No coordination from the consumer is needed, and it self heals if the device's deep sleep config changes. The `deep_sleep` attribute stays settable as an override for consumers that do not fetch device_info. Default behavior (no deep sleep) is byte for byte unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
