### PR TITLE
Clarify deep_sleep is a bootstrap hint superseded by device_info

### DIFF
--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -113,9 +113,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self.name = client.address.partition(".")[0]
         if self.name:
             self._cli.set_cached_name_if_unset(self.name)
-        # Populated from DeviceInfo.has_deep_sleep after each successful connect
-        # (see _try_connect); caps the reconnect backoff so a short awake window
-        # is not missed. A consumer may also set it directly.
+        # Caps the reconnect backoff so a short awake window is not missed. A
+        # consumer may seed it before the first connect as a bootstrap hint
+        # (e.g. from persisted DeviceInfo, so a restart caps from the first
+        # attempt); each successful connect then refreshes it from the fetched
+        # DeviceInfo.has_deep_sleep (see _try_connect), so device_info wins and
+        # it self-heals.
         self.deep_sleep: bool = False
         self._on_connect_cb = on_connect
         self._on_disconnect_cb = on_disconnect


### PR DESCRIPTION
# What does this implement/fix?

Small follow-up to #1826. The `deep_sleep` attribute comment described the consumer-set value as if it were a co-equal, persistent override, but each successful connect refreshes `deep_sleep` from the fetched `DeviceInfo.has_deep_sleep`, so device_info wins after the first connect. The consumer-set value is really a pre-connect bootstrap hint (e.g. from persisted DeviceInfo so a restart caps the backoff from the first attempt). This clarifies the comment; no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
