### PR TITLE
Add deep_sleep param to async_run

### DIFF
--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -33,6 +33,7 @@ async def async_run(
     name: str | None = None,
     subscribe_states: bool = True,
     allow_plaintext_fallback: bool = False,
+    deep_sleep: bool = False,
 ) -> Callable[[], Coroutine[Any, Any, None]]:
     """Run logs until canceled.
 
@@ -42,6 +43,10 @@ async def async_run(
     plaintext (and log a warning) when connecting with a PSK to a device
     running plaintext firmware, instead of failing repeatedly. Defaults
     to False so callers must opt in.
+
+    Set ``deep_sleep`` when the device is known to deep sleep (e.g. from
+    the caller's YAML config) so the reconnect backoff is capped and a
+    short awake window is not missed while waiting to reconnect.
 
     The logger stream is one-way (device → client), so enabling the
     fallback here only exposes log output to an on-path attacker — no
@@ -79,6 +84,7 @@ async def async_run(
         name=name,
         allow_plaintext_fallback=allow_plaintext_fallback,
     )
+    logic.deep_sleep = deep_sleep
     await logic.start()
 
     async def _stop() -> None:

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -6,6 +6,8 @@ from functools import partial
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from aioesphomeapi.api_pb2 import (
     DisconnectRequest,
     DisconnectResponse,
@@ -17,7 +19,6 @@ from aioesphomeapi.log_runner import async_run
 
 if TYPE_CHECKING:
     from google.protobuf import message
-    import pytest
 
     from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
     from aioesphomeapi.connection import APIConnection
@@ -116,6 +117,35 @@ async def test_log_runner(
     disconnect_response = DisconnectResponse()
     mock_data_received(protocol, generate_plaintext_packet(disconnect_response))
     await stop_task
+
+
+@pytest.mark.parametrize("deep_sleep", [True, False])
+async def test_async_run_seeds_deep_sleep(deep_sleep: bool) -> None:
+    """async_run seeds ReconnectLogic.deep_sleep so the caller can cap the backoff."""
+    async_zeroconf = get_mock_async_zeroconf()
+    cli = APIClient(
+        address=Estr("127.0.0.1"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=Estr("fake"),
+        zeroconf_instance=async_zeroconf.zeroconf,
+    )
+    seen: list[bool] = []
+
+    async def _start(self: ReconnectLogic) -> None:
+        seen.append(self.deep_sleep)
+
+    with patch.object(ReconnectLogic, "start", _start):
+        stop = await async_run(
+            cli,
+            lambda msg: None,
+            aio_zeroconf_instance=async_zeroconf,
+            subscribe_states=False,
+            deep_sleep=deep_sleep,
+        )
+    await stop()
+    assert seen == [deep_sleep]
 
 
 async def test_log_runner_reconnects_on_disconnect(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the deep sleep reconnect backoff cap. `async_run` constructs the `ReconnectLogic` internally and did not expose a way to set the deep sleep flag, so callers that already know a device deep sleeps (from its YAML config) could not cap the log-stream reconnect backoff, and the self populate only kicks in after the first successful connect (and never when `subscribe_states` is off, since device_info is not fetched then).

This adds a `deep_sleep` param to `async_run` that seeds `ReconnectLogic.deep_sleep` before the first connect, so `esphome logs` on a deep sleep device caps the backoff from the first attempt and does not miss a short awake window. Defaults to False; behavior is unchanged when unset.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- The esphome logs command will pass this from the YAML config in a follow-up PR.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
