### PR TITLE
Cap cryptography below 49 on Intel macOS

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,5 @@ tzlocal>=5.3.1,<6
 zeroconf>=0.150.0,<2.0
 chacha20poly1305-reuseable>=0.13.2
 cryptography>=48.0.0
+cryptography<49.0.0; platform_system == "Darwin" and platform_machine == "x86_64"
 noiseprotocol>=0.3.1,<1.0


### PR DESCRIPTION
# What does this implement/fix?

TLDR: this is out of our control; the Python ecosystem we rely on is dropping support for Intel Macs, specifically [cryptography as of 49.0.0](https://cryptography.io/en/stable/changelog/#v49-0-0). We can work around it for now by holding Intel Macs on cryptography 48.0.1, but as soon as something breaking lands or a critical security issue hits cryptography we will be forced to drop macOS Intel support.

cryptography 49.0.0 [dropped Intel macOS](https://cryptography.io/en/stable/changelog/#v49-0-0); its macOS wheels are arm64 only and the changelog marks the x86_64 macOS drop as backwards incompatible. With only `cryptography>=48.0.0` as the floor, an Intel Mac install resolves to 49.0.0 and fails with no matching distribution; a source build needs Rust 1.83, which users do not have.

This adds an esptool style cap, `cryptography<49.0.0` on Darwin x86_64 only, so Intel Macs stay on 48.0.1, the last release with universal2 wheels; every other platform is unaffected. It also means #1806, which raises the floor to `>=49.0.0`, must not merge as is; it would make aioesphomeapi uninstallable on Intel macOS.

Verified with uv cross resolution on Python 3.13: `x86_64-apple-darwin` picks 48.0.1; `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu` still pick 49.0.0. setup.py passes the marker line through to install_requires verbatim.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome-desktop/issues/327

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#17658

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
