### PR TITLE
Filter unspecified addresses from getaddrinfo results

### DIFF
--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -146,6 +146,7 @@ async def _async_resolve_host_getaddrinfo(host: str, port: int) -> list[AddrInfo
     _LOGGER.debug("Successfully resolved %s via getaddrinfo", host)
 
     addrs: list[AddrInfo] = []
+    skipped_unspecified = False
     for family, type_, proto, _, raw in res:
         sockaddr: IPv4Sockaddr | IPv6Sockaddr
         if family == socket.AF_INET:
@@ -162,9 +163,24 @@ async def _async_resolve_host_getaddrinfo(host: str, port: int) -> list[AddrInfo
             # Unknown family
             continue
 
+        # DNS sinkholes answer with unspecified addresses (0.0.0.0 / ::);
+        # connecting to them is never useful, so treat them as a miss
+        if ip_address(address).is_unspecified:
+            _LOGGER.debug(
+                "Ignoring unspecified address %s for %s from getaddrinfo",
+                address,
+                host,
+            )
+            skipped_unspecified = True
+            continue
+
         addrs.append(
             AddrInfo(family=family, type=type_, proto=proto, sockaddr=sockaddr)
         )
+
+    if not addrs and skipped_unspecified:
+        msg = f"getaddrinfo for {host} returned only unspecified addresses"
+        raise ResolveAPIError(msg)
     return addrs
 
 

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -160,6 +160,69 @@ async def test_resolve_host_getaddrinfo(addr_infos):
         assert ret == addr_infos
 
 
+async def test_resolve_host_getaddrinfo_filters_unspecified(addr_infos):
+    """Unspecified addresses from sinkhole DNS answers are dropped."""
+    event_loop = asyncio.get_running_loop()
+    with patch.object(event_loop, "getaddrinfo") as mock:
+        mock.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon1",
+                ("0.0.0.0", 6052),  # noqa: S104
+            ),
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon1",
+                ("10.0.0.42", 6052),
+            ),
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon2",
+                ("::", 6052, 0, 0),
+            ),
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon2",
+                ("2001:db8:85a3::8a2e:370:7334", 6052, 0, 0),
+            ),
+        ]
+        ret = await hr._async_resolve_host_getaddrinfo("example.com", 6052)
+
+        assert ret == addr_infos
+
+
+async def test_resolve_host_getaddrinfo_all_unspecified():
+    """An all-unspecified getaddrinfo answer raises ResolveAPIError."""
+    event_loop = asyncio.get_running_loop()
+    with patch.object(event_loop, "getaddrinfo") as mock:
+        mock.return_value = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon1",
+                ("0.0.0.0", 6052),  # noqa: S104
+            ),
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "canon2",
+                ("::", 6052, 0, 0),
+            ),
+        ]
+        with pytest.raises(ResolveAPIError, match="only unspecified addresses"):
+            await hr._async_resolve_host_getaddrinfo("example.com", 6052)
+
+
 async def test_resolve_host_getaddrinfo_oserror():
     event_loop = asyncio.get_running_loop()
     with patch.object(event_loop, "getaddrinfo") as mock:


### PR DESCRIPTION
# What does this implement/fix?

On networks where a DNS sinkhole or interception layer answers queries with unspecified addresses, getaddrinfo returns 0.0.0.0 and ::, and the resolver passed them through as a successful resolve; the connect path then attempted them and always failed. Filter unspecified addresses out of getaddrinfo results, and raise ResolveAPIError when the answer contains nothing else, so the mDNS path or the caller's fallback decides instead.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/aioesphomeapi/issues/1833

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
