### PR TITLE
Ignore PLR0917 and align ruff pin with pre-commit hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = [
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
   "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR0917", # Too many positional arguments ({c_pos_args} > {max_pos_args})
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
   "TRY003", # Too many to fix - Avoid specifying long messages outside the exception class

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 pylint==4.0.6
-ruff==0.15.20
+ruff==0.16.0
 isort==8.0.1
 mypy==2.3.0
 types-protobuf==7.34.1.20260518


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `pre-commit.ci` failure on `main`.

The ruff pre-commit hook was bumped from `v0.15.22` to `v0.16.0` in 1848b0e ("[pre-commit.ci] pre-commit autoupdate", #1841). ruff 0.16.0 stabilized `PLR0917` (too many positional arguments), which was previously a preview rule and so never fired. It now reports 12 errors against pre-existing code: 8 in `aioesphomeapi/client.py`, plus one each in `aioesphomeapi/_frame_helper/noise.py`, `aioesphomeapi/host_resolver.py`, `aioesphomeapi/log_runner.py`, and `tests/test_reconnect_logic.py`. None of them are new code.

`PLR0917` is added to the existing `[tool.ruff.lint]` ignore list, which already suppresses the rest of that family: `PLR0911`, `PLR0912`, `PLR0913`, and `PLR0915`. `PLR0913` ("too many arguments") is already ignored, so ignoring the positional-only variant matches the existing policy rather than introducing a new one. The alternative would be churning public API signatures to keyword-only for a rule family the repo has already opted out of.

This also bumps `ruff` in `requirements/test.txt` from `0.15.20` to `0.16.0` to match the pre-commit hook. The repo was linting itself with two different ruff versions - `.pre-commit-config.yaml` runs 0.16.0 via pre-commit.ci while the `ruff check` / `ruff format --check` steps in `.github/workflows/ci.yml` use the pin from `requirements/test.txt`. That skew is why this landed green and only broke afterwards. `ruff format --check` was verified against 0.16.0 and reports no changes, so no reformatting is needed.

Since pre-commit.ci evaluates each PR merged with `main`, every open PR currently inherits this failure. #1845 is one of them and will need a rebase or merge once this lands.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
