### PR TITLE
Avoid blocking connection setup on timezone resolution

### DIFF
--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -123,6 +123,7 @@ cdef class APIConnection:
     cdef public str connected_address
     cdef public object disconnect_reason
     cdef str _cached_timezone
+    cdef public object _timezone_task
     cdef list _addrs_info
     cdef bint _log_errors
 

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -57,7 +57,7 @@ from .core import (
 from .model import APIVersion, message_types_to_names
 from .posix_tz import DSTRule as DSTRuleParsed, DSTRuleType, parse_posix_tz
 from .timezone import get_timezone
-from .util import asyncio_timeout
+from .util import asyncio_timeout, create_eager_task
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -328,6 +328,7 @@ class APIConnection:
         "_send_pending_ping",
         "_socket",
         "_start_connect_future",
+        "_timezone_task",
         "api_version",
         "connected_address",
         "connection_state",
@@ -384,6 +385,7 @@ class APIConnection:
         self._debug_enabled = debug_enabled
         self.received_name: str = ""
         self._cached_timezone: str = ""
+        self._timezone_task: asyncio.Task[str] | None = None
         self.connected_address: str | None = None
         self._addrs_info: list[hr.AddrInfo] = []
         self._log_errors = log_errors
@@ -839,11 +841,17 @@ class APIConnection:
 
     async def _do_finish_connect(self, login: bool) -> None:
         """Finish the connection process."""
-        # Cache timezone before registering handlers to ensure it's available
-        # when GetTimeRequest is received
+        # Resolve the timezone in an executor without serializing it in
+        # front of the network round trips; _handle_get_time_request_internal
+        # defers its response while the task is still pending.
         # Use provided timezone from params (converted from IANA to POSIX if needed),
         # or fall back to local timezone detection
-        self._cached_timezone = await get_timezone(self._params.timezone)
+        timezone_task = create_eager_task(get_timezone(self._params.timezone))
+        if timezone_task.done():
+            self._cached_timezone = timezone_task.result()
+        else:
+            self._timezone_task = timezone_task
+            timezone_task.add_done_callback(self._set_cached_timezone)
         # Register internal handlers before
         # connecting the helper so we can ensure
         # we handle any messages that are received immediately
@@ -1254,6 +1262,21 @@ class APIConnection:
         self, _msg: GetTimeRequest
     ) -> None:
         """Handle a GetTimeRequest."""
+        if (timezone_task := self._timezone_task) is not None:
+            timezone_task.add_done_callback(self._send_get_time_response_when_ready)
+            return
+        self._send_get_time_response()
+
+    def _set_cached_timezone(self, task: asyncio.Task[str]) -> None:
+        self._timezone_task = None
+        if not task.cancelled():
+            self._cached_timezone = task.result()
+
+    def _send_get_time_response_when_ready(self, _task: asyncio.Task[str]) -> None:
+        if self._handshake_complete:
+            self._send_get_time_response()
+
+    def _send_get_time_response(self) -> None:
         resp = GetTimeResponse()
         resp.epoch_seconds = int(time.time())
         resp.timezone = self._cached_timezone

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -841,17 +841,15 @@ class APIConnection:
 
     async def _do_finish_connect(self, login: bool) -> None:
         """Finish the connection process."""
-        # Resolve the timezone in an executor without serializing it in
-        # front of the network round trips; _handle_get_time_request_internal
-        # defers its response while the task is still pending.
-        # Use provided timezone from params (converted from IANA to POSIX if needed),
-        # or fall back to local timezone detection
-        timezone_task = create_eager_task(get_timezone(self._params.timezone))
-        if timezone_task.done():
-            self._cached_timezone = timezone_task.result()
-        else:
-            self._timezone_task = timezone_task
-            timezone_task.add_done_callback(self._set_cached_timezone)
+        # Only needed to answer GetTimeRequest; runs as its own task so it
+        # never delays the handshake.
+        if self._params.provide_time:
+            timezone_task = create_eager_task(get_timezone(self._params.timezone))
+            if timezone_task.done():
+                self._set_cached_timezone(timezone_task)
+            else:
+                self._timezone_task = timezone_task
+                timezone_task.add_done_callback(self._set_cached_timezone)
         # Register internal handlers before
         # connecting the helper so we can ensure
         # we handle any messages that are received immediately
@@ -1269,10 +1267,16 @@ class APIConnection:
 
     def _set_cached_timezone(self, task: asyncio.Task[str]) -> None:
         self._timezone_task = None
-        if not task.cancelled():
-            self._cached_timezone = task.result()
+        if task.cancelled():
+            return
+        if (exc := task.exception()) is not None:
+            _LOGGER.warning("%s: Timezone resolution failed: %s", self.log_name, exc)
+            return
+        self._cached_timezone = task.result()
 
     def _send_get_time_response_when_ready(self, _task: asyncio.Task[str]) -> None:
+        # _cleanup clears _handshake_complete, so this also drops the
+        # response when the connection closed while the timezone resolved.
         if self._handshake_complete:
             self._send_get_time_response()
 

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from functools import partial
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioesphomeapi.api_pb2 import (  # type: ignore[attr-defined]
     GetTimeRequest,
@@ -28,6 +28,8 @@ from .common import (
 from .conftest import PatchableAPIClient, PatchableAPIConnection, mock_on_stop
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aioesphomeapi._frame_helper.plain_text import APIPlaintextFrameHelper
     from aioesphomeapi.connection import APIConnection
 
@@ -46,10 +48,19 @@ async def test_api_client_provide_time_false() -> None:
     assert cli._params.provide_time is False
 
 
+async def _drain_loop_until(condition: Callable[[], bool], max_ticks: int = 25) -> None:
+    """Spin the event loop until condition() holds, bounded by max_ticks."""
+    for _ in range(max_ticks):
+        if condition():
+            return
+        await asyncio.sleep(0)
+
+
 async def _make_connected_conn(
     provide_time: bool,
     resolve_host,
     aiohappyeyeballs_start_connection,
+    get_timezone_patch: Any = None,
 ) -> tuple[APIConnection, asyncio.Transport, APIPlaintextFrameHelper]:
     """Set up a plaintext-connected PatchableAPIConnection with provide_time set."""
     loop = asyncio.get_running_loop()
@@ -58,9 +69,11 @@ async def _make_connected_conn(
     params = replace(get_mock_connection_params(), provide_time=provide_time)
     conn = PatchableAPIConnection(params, mock_on_stop, True, None)
 
+    if get_timezone_patch is None:
+        get_timezone_patch = AsyncMock(return_value="UTC0")
     with (
         patch_create_connection(loop, transport, connected),
-        patch("aioesphomeapi.connection.get_timezone", return_value="UTC0"),
+        patch("aioesphomeapi.connection.get_timezone", get_timezone_patch),
     ):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await connected.wait()
@@ -135,28 +148,18 @@ async def test_get_time_response_deferred_until_timezone_resolved(
     aiohappyeyeballs_start_connection,
 ) -> None:
     """A GetTimeRequest received before the timezone resolves is answered after."""
-    loop = asyncio.get_running_loop()
-    transport = MagicMock()
-    connected = asyncio.Event()
     release = asyncio.Event()
 
     async def slow_get_timezone(_tz: str | None) -> str:
         await release.wait()
         return "UTC0"
 
-    params = replace(get_mock_connection_params(), provide_time=True)
-    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
-
-    with (
-        patch_create_connection(loop, transport, connected),
-        patch("aioesphomeapi.connection.get_timezone", slow_get_timezone),
-    ):
-        connect_task = asyncio.create_task(connect(conn, login=False))
-        await connected.wait()
-        send_plaintext_hello(conn._frame_helper)
-        await connect_task
-
-    protocol = conn._frame_helper
+    conn, transport, protocol = await _make_connected_conn(
+        provide_time=True,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
+        get_timezone_patch=slow_get_timezone,
+    )
     try:
         transport.reset_mock()
         mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
@@ -164,8 +167,7 @@ async def test_get_time_response_deferred_until_timezone_resolved(
         transport.writelines.assert_not_called()
 
         release.set()
-        for _ in range(5):
-            await asyncio.sleep(0)
+        await _drain_loop_until(lambda: transport.writelines.call_count == 1)
 
         assert transport.writelines.call_count == 1
         raw = b"".join(transport.writelines.call_args[0][0])
@@ -181,28 +183,18 @@ async def test_get_time_request_between_timezone_task_done_and_callback(
     aiohappyeyeballs_start_connection,
 ) -> None:
     """A GetTimeRequest still gets a timezone when the task is done but its callback has not run."""
-    loop = asyncio.get_running_loop()
-    transport = MagicMock()
-    connected = asyncio.Event()
     release = asyncio.Event()
 
     async def slow_get_timezone(_tz: str | None) -> str:
         await release.wait()
         return "UTC0"
 
-    params = replace(get_mock_connection_params(), provide_time=True)
-    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
-
-    with (
-        patch_create_connection(loop, transport, connected),
-        patch("aioesphomeapi.connection.get_timezone", slow_get_timezone),
-    ):
-        connect_task = asyncio.create_task(connect(conn, login=False))
-        await connected.wait()
-        send_plaintext_hello(conn._frame_helper)
-        await connect_task
-
-    protocol = conn._frame_helper
+    conn, transport, protocol = await _make_connected_conn(
+        provide_time=True,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
+        get_timezone_patch=slow_get_timezone,
+    )
     try:
         transport.reset_mock()
         release.set()
@@ -215,14 +207,72 @@ async def test_get_time_request_between_timezone_task_done_and_callback(
         mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
         transport.writelines.assert_not_called()
 
-        for _ in range(3):
-            await asyncio.sleep(0)
+        await _drain_loop_until(lambda: transport.writelines.call_count == 1)
 
         assert transport.writelines.call_count == 1
         raw = b"".join(transport.writelines.call_args[0][0])
         resp = GetTimeResponse()
         resp.ParseFromString(raw[3:])  # strip 3-byte plaintext frame header
         assert resp.timezone == "UTC0"
+        assert conn._timezone_task is None
+    finally:
+        conn.force_disconnect()
+
+
+async def test_get_time_response_empty_timezone_when_resolution_fails(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+    caplog,
+) -> None:
+    """A failing timezone task logs a warning and the response carries no timezone."""
+    release = asyncio.Event()
+
+    async def failing_get_timezone(_tz: str | None) -> str:
+        await release.wait()
+        err = "tz boom"
+        raise ValueError(err)
+
+    conn, transport, protocol = await _make_connected_conn(
+        provide_time=True,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
+        get_timezone_patch=failing_get_timezone,
+    )
+    try:
+        transport.reset_mock()
+        mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
+        await asyncio.sleep(0)
+        transport.writelines.assert_not_called()
+
+        release.set()
+        await _drain_loop_until(lambda: transport.writelines.call_count == 1)
+
+        assert transport.writelines.call_count == 1
+        raw = b"".join(transport.writelines.call_args[0][0])
+        resp = GetTimeResponse()
+        resp.ParseFromString(raw[3:])  # strip 3-byte plaintext frame header
+        assert resp.timezone == ""
+        assert resp.epoch_seconds > 0
+        assert "Timezone resolution failed" in caplog.text
+        assert conn._timezone_task is None
+    finally:
+        conn.force_disconnect()
+
+
+async def test_timezone_not_resolved_when_provide_time_false(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """No timezone task is created when provide_time=False."""
+    tz_mock = AsyncMock(return_value="UTC0")
+    conn, _transport, _protocol = await _make_connected_conn(
+        provide_time=False,
+        resolve_host=resolve_host,
+        aiohappyeyeballs_start_connection=aiohappyeyeballs_start_connection,
+        get_timezone_patch=tz_mock,
+    )
+    try:
+        assert tz_mock.call_count == 0
         assert conn._timezone_task is None
     finally:
         conn.force_disconnect()

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -58,7 +58,10 @@ async def _make_connected_conn(
     params = replace(get_mock_connection_params(), provide_time=provide_time)
     conn = PatchableAPIConnection(params, mock_on_stop, True, None)
 
-    with patch_create_connection(loop, transport, connected):
+    with (
+        patch_create_connection(loop, transport, connected),
+        patch("aioesphomeapi.connection.get_timezone", return_value="UTC0"),
+    ):
         connect_task = asyncio.create_task(connect(conn, login=False))
         await connected.wait()
         send_plaintext_hello(conn._frame_helper)
@@ -123,5 +126,103 @@ async def test_get_time_response_not_sent_when_provide_time_false(
 
         transport.write.assert_not_called()
         transport.writelines.assert_not_called()
+    finally:
+        conn.force_disconnect()
+
+
+async def test_get_time_response_deferred_until_timezone_resolved(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """A GetTimeRequest received before the timezone resolves is answered after."""
+    loop = asyncio.get_running_loop()
+    transport = MagicMock()
+    connected = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_get_timezone(_tz: str | None) -> str:
+        await release.wait()
+        return "UTC0"
+
+    params = replace(get_mock_connection_params(), provide_time=True)
+    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
+
+    with (
+        patch_create_connection(loop, transport, connected),
+        patch("aioesphomeapi.connection.get_timezone", slow_get_timezone),
+    ):
+        connect_task = asyncio.create_task(connect(conn, login=False))
+        await connected.wait()
+        send_plaintext_hello(conn._frame_helper)
+        await connect_task
+
+    protocol = conn._frame_helper
+    try:
+        transport.reset_mock()
+        mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
+        await asyncio.sleep(0)
+        transport.writelines.assert_not_called()
+
+        release.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert transport.writelines.call_count == 1
+        raw = b"".join(transport.writelines.call_args[0][0])
+        resp = GetTimeResponse()
+        resp.ParseFromString(raw[3:])  # strip 3-byte plaintext frame header
+        assert resp.timezone == "UTC0"
+    finally:
+        conn.force_disconnect()
+
+
+async def test_get_time_request_between_timezone_task_done_and_callback(
+    resolve_host,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """A GetTimeRequest still gets a timezone when the task is done but its callback has not run."""
+    loop = asyncio.get_running_loop()
+    transport = MagicMock()
+    connected = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_get_timezone(_tz: str | None) -> str:
+        await release.wait()
+        return "UTC0"
+
+    params = replace(get_mock_connection_params(), provide_time=True)
+    conn = PatchableAPIConnection(params, mock_on_stop, True, None)
+
+    with (
+        patch_create_connection(loop, transport, connected),
+        patch("aioesphomeapi.connection.get_timezone", slow_get_timezone),
+    ):
+        connect_task = asyncio.create_task(connect(conn, login=False))
+        await connected.wait()
+        send_plaintext_hello(conn._frame_helper)
+        await connect_task
+
+    protocol = conn._frame_helper
+    try:
+        transport.reset_mock()
+        release.set()
+        # One tick: the timezone task completes, but _set_cached_timezone is
+        # still queued for the next callback batch.
+        await asyncio.sleep(0)
+        assert conn._timezone_task is not None
+        assert conn._timezone_task.done()
+
+        mock_data_received(protocol, generate_plaintext_packet(GetTimeRequest()))
+        transport.writelines.assert_not_called()
+
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        assert transport.writelines.call_count == 1
+        raw = b"".join(transport.writelines.call_args[0][0])
+        resp = GetTimeResponse()
+        resp.ParseFromString(raw[3:])  # strip 3-byte plaintext frame header
+        assert resp.timezone == "UTC0"
+        assert conn._timezone_task is None
     finally:
         conn.force_disconnect()


### PR DESCRIPTION
# What does this implement/fix?

Connection setup awaited get_timezone before starting the frame helper handshake, so the first connection paid for local timezone detection in front of the network round trips. The call is only async to keep the blocking tzlocal work off the event loop, it does not need to hold up the connect path. The timezone is now resolved in a background task; if a GetTimeRequest arrives before the task finishes, the GetTimeResponse is deferred until the timezone is ready.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
