### PR TITLE
Add workflow to open esphome bump PR on release

### DIFF
--- a/.github/workflows/bump-esphome.yml
+++ b/.github/workflows/bump-esphome.yml
@@ -12,6 +12,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: bump-esphome
+
 jobs:
   bump-esphome:
     runs-on: ubuntu-latest
@@ -34,7 +37,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           for _ in $(seq 1 90); do
-            if curl -sfo /dev/null "https://pypi.org/pypi/aioesphomeapi/$VERSION/json"; then
+            if curl -sfo /dev/null --connect-timeout 10 --max-time 30 "https://pypi.org/pypi/aioesphomeapi/$VERSION/json"; then
               exit 0
             fi
             sleep 30
@@ -77,6 +80,11 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if [[ "$(printf '%s\n' "$old" "$VERSION" | sort -V | tail -n1)" != "$VERSION" ]]; then
+            echo "requirements.txt pins aioesphomeapi==$old which is newer than $VERSION, skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           sed -i "s/^aioesphomeapi==.*/aioesphomeapi==$VERSION/" requirements.txt
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "old=$old" >> "$GITHUB_OUTPUT"
@@ -94,14 +102,16 @@ jobs:
           old = os.environ["OLD"]
           new = os.environ["VERSION"]
           template = Path("esphome/.github/PULL_REQUEST_TEMPLATE.md").read_text()
+          placeholder = "<!-- Quick description and explanation of changes -->"
+          checkbox = "- [ ] Other"
+          if placeholder not in template or checkbox not in template:
+              raise SystemExit("PR template changed, expected placeholders not found")
           description = (
               f"Bump aioesphomeapi from {old} to {new}, release notes: "
               f"https://github.com/esphome/aioesphomeapi/releases/tag/v{new}"
           )
-          body = template.replace(
-              "<!-- Quick description and explanation of changes -->", description, 1
-          )
-          body = body.replace("- [ ] Other", "- [x] Other", 1)
+          body = template.replace(placeholder, description, 1)
+          body = body.replace(checkbox, "- [x] Other", 1)
           Path("pr_body.md").write_text(body)
           EOF
 
@@ -129,7 +139,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           title="Bump aioesphomeapi from $OLD to $VERSION"
-          existing=$(gh pr list --repo esphome/esphome --head bump-aioesphomeapi --state open --json number --jq '.[].number')
+          existing=$(gh pr list --repo esphome/esphome --base dev --head bump-aioesphomeapi --state open --json number --jq '.[0].number // empty')
           if [[ -n "$existing" ]]; then
             gh pr edit "$existing" --repo esphome/esphome --title "$title" --body-file pr_body.md
           else

--- a/.github/workflows/bump-esphome.yml
+++ b/.github/workflows/bump-esphome.yml
@@ -1,0 +1,138 @@
+name: Bump aioesphomeapi in esphome
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "aioesphomeapi version to bump to (without v prefix)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  bump-esphome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "$INPUT_VERSION" ]]; then
+            version="$INPUT_VERSION"
+          else
+            version="${TAG_NAME#v}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for PyPI to index the release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for _ in $(seq 1 90); do
+            if curl -sfo /dev/null "https://pypi.org/pypi/aioesphomeapi/$VERSION/json"; then
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "aioesphomeapi $VERSION never appeared on PyPI" >&2
+          exit 1
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: esphome
+          repositories: esphome
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout esphome/esphome
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: esphome/esphome
+          ref: dev
+          token: ${{ steps.app-token.outputs.token }}
+          path: esphome
+
+      - name: Update requirements.txt pin
+        id: bump
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        working-directory: esphome
+        run: |
+          old=$(sed -n 's/^aioesphomeapi==\([0-9a-zrcb.]*\).*/\1/p' requirements.txt)
+          if [[ -z "$old" ]]; then
+            echo "aioesphomeapi pin not found in requirements.txt" >&2
+            exit 1
+          fi
+          if [[ "$old" == "$VERSION" ]]; then
+            echo "requirements.txt already pins aioesphomeapi==$VERSION"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          sed -i "s/^aioesphomeapi==.*/aioesphomeapi==$VERSION/" requirements.txt
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "old=$old" >> "$GITHUB_OUTPUT"
+
+      - name: Build PR body from template
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          OLD: ${{ steps.bump.outputs.old }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 - <<'EOF'
+          import os
+          from pathlib import Path
+
+          old = os.environ["OLD"]
+          new = os.environ["VERSION"]
+          template = Path("esphome/.github/PULL_REQUEST_TEMPLATE.md").read_text()
+          description = (
+              f"Bump aioesphomeapi from {old} to {new}, release notes: "
+              f"https://github.com/esphome/aioesphomeapi/releases/tag/v{new}"
+          )
+          body = template.replace(
+              "<!-- Quick description and explanation of changes -->", description, 1
+          )
+          body = body.replace("- [ ] Other", "- [x] Other", 1)
+          Path("pr_body.md").write_text(body)
+          EOF
+
+      - name: Commit and push
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          OLD: ${{ steps.bump.outputs.old }}
+          VERSION: ${{ steps.version.outputs.version }}
+        working-directory: esphome
+        run: |
+          bot_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git checkout -b bump-aioesphomeapi
+          git commit -am "Bump aioesphomeapi from $OLD to $VERSION"
+          git push --force origin bump-aioesphomeapi
+
+      - name: Open draft PR
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD: ${{ steps.bump.outputs.old }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          title="Bump aioesphomeapi from $OLD to $VERSION"
+          existing=$(gh pr list --repo esphome/esphome --head bump-aioesphomeapi --state open --json number --jq '.[].number')
+          if [[ -n "$existing" ]]; then
+            gh pr edit "$existing" --repo esphome/esphome --title "$title" --body-file pr_body.md
+          else
+            gh pr create --repo esphome/esphome --base dev --head bump-aioesphomeapi \
+              --draft --title "$title" --body-file pr_body.md
+          fi

--- a/.github/workflows/bump-esphome.yml
+++ b/.github/workflows/bump-esphome.yml
@@ -17,7 +17,9 @@ concurrency:
 
 jobs:
   bump-esphome:
+    if: github.repository == 'esphome/aioesphomeapi' && (github.event_name == 'workflow_dispatch' || !github.event.release.prerelease)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Determine version
         id: version
@@ -85,7 +87,7 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          sed -i "s/^aioesphomeapi==.*/aioesphomeapi==$VERSION/" requirements.txt
+          sed -i -E "s/^aioesphomeapi==[^[:space:];#]+/aioesphomeapi==$VERSION/" requirements.txt
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "old=$old" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a workflow that runs when a release is published; it waits for PyPI to index the new version, then updates the aioesphomeapi pin in esphome/esphome requirements.txt and opens a draft PR there, so the bump lands right away instead of waiting for the next dependabot run. It authenticates with the ESPHome GitHub App, fills in the esphome PR template at runtime, and reuses a single branch so back to back releases update the existing PR instead of opening duplicates. Also supports workflow_dispatch with a version input for manual runs.

Uses the org level ESPHOME_GITHUB_APP_CLIENT_ID variable and ESPHOME_GITHUB_APP_PRIVATE_KEY secret, already available to all org repos, same setup as device-builder-frontend.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
