### PR TITLE
Run esphome bump after PyPI publish in the release workflow

### DIFF
--- a/.github/workflows/bump-esphome.yml
+++ b/.github/workflows/bump-esphome.yml
@@ -145,5 +145,5 @@ jobs:
             gh pr edit "$existing" --repo esphome/esphome --title "$title" --body-file pr_body.md
           else
             gh pr create --repo esphome/esphome --base dev --head bump-aioesphomeapi \
-              --draft --title "$title" --body-file pr_body.md
+              --title "$title" --body-file pr_body.md
           fi

--- a/.github/workflows/bump-esphome.yml
+++ b/.github/workflows/bump-esphome.yml
@@ -1,8 +1,7 @@
 name: Bump aioesphomeapi in esphome
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
     inputs:
       version:
@@ -19,7 +18,7 @@ jobs:
   bump-esphome:
     if: github.repository == 'esphome/aioesphomeapi' && (github.event_name == 'workflow_dispatch' || !github.event.release.prerelease)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - name: Determine version
         id: version
@@ -38,11 +37,11 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          for _ in $(seq 1 90); do
+          for _ in $(seq 1 20); do
             if curl -sfo /dev/null --connect-timeout 10 --max-time 30 "https://pypi.org/pypi/aioesphomeapi/$VERSION/json"; then
               exit 0
             fi
-            sleep 30
+            sleep 15
           done
           echo "aioesphomeapi $VERSION never appeared on PyPI" >&2
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,12 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+
+  bump_esphome:
+    name: Bump aioesphomeapi in esphome
+    needs: [upload_pypi]
+    concurrency:
+      group: bump-esphome
+    permissions: {}
+    secrets: inherit
+    uses: ./.github/workflows/bump-esphome.yml


### PR DESCRIPTION
# What does this implement/fix?

Runs the esphome bump as a job in the release workflow after the PyPI publish instead of a standalone release triggered workflow; the old setup started polling PyPI as soon as the release was published and could sit on a runner for up to 45 minutes while wheels built. Now the job only starts once the upload succeeded, so the poll just covers indexing lag and a failed wheel build never produces a dangling bump run. The bump workflow keeps workflow_dispatch for manual runs; the poll budget drops to 5 minutes and the job timeout to 15; the bump PR is now opened ready for review instead of draft.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
