### PR TITLE
Add support for feeding newly discovered addresses into a running client

### DIFF
--- a/aioesphomeapi/client_base.pxd
+++ b/aioesphomeapi/client_base.pxd
@@ -24,6 +24,7 @@ cdef str _stringify_or_none(object value)
 
 cdef class APIClientBase:
 
+    cdef public list _addresses_changed_callbacks
     cdef public set _background_tasks
     cdef public object _cached_device_info
     cdef public object _call_id_counter

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -425,15 +425,18 @@ class APIClientBase:
         params_addresses = self._params.addresses
         added = False
         for addr in addresses:
-            addr_str = str(addr)
+            # str() only normalizes str subclasses (e.g. Estr); anything
+            # else (a JSON null, an int) is bad discovery data
+            addr_str = str(addr).strip() if isinstance(addr, str) else ""
             if (
-                not addr_str.strip()
+                not addr_str
+                or " " in addr_str
                 or len(addr_str) > MAX_ADDRESS_LEN
                 or safe_label_str(addr_str, MAX_ADDRESS_LEN) != addr_str
             ):
                 # repr-escaped and truncated: the garbage must not forge log lines
                 _LOGGER.warning(
-                    "Ignoring invalid discovered address: %s", repr(addr_str)[:100]
+                    "Ignoring invalid discovered address: %s", repr(addr)[:100]
                 )
                 continue
             if addr_str not in params_addresses:

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -69,6 +69,10 @@ _LOGGER = logging.getLogger(__name__)
 # connection is poor.
 KEEP_ALIVE_FREQUENCY = 20.0
 
+# RFC 1035 caps a full domain name at 253 characters; anything longer in an
+# out-of-band discovered address is garbage and gets truncated for safety.
+MAX_ADDRESS_LEN = 253
+
 # Caps on the per-subscription camera reassembly buffer. The peer fully
 # controls cam_msg.key and cam_msg.done, so without these limits a single
 # device can stream chunks indefinitely (memory exhaustion DoS) or rotate
@@ -409,6 +413,11 @@ class APIClientBase:
         address is new, the addresses-changed callbacks are fired so
         consumers (e.g. ReconnectLogic) can act on them right away.
 
+        Addresses are expected to come from out-of-band discovery (e.g. an
+        MQTT broker lookup), so they are sanitized before they can reach
+        log output via ``log_name``; a legitimate IP or hostname passes
+        through unchanged.
+
         Must be called from the event loop. Returns True if at least one
         address was new.
         """
@@ -418,7 +427,8 @@ class APIClientBase:
         params_addresses = self._params.addresses
         added = False
         for addr in addresses:
-            if (addr_str := str(addr)) not in params_addresses:
+            addr_str = safe_label_str(str(addr), MAX_ADDRESS_LEN)
+            if addr_str not in params_addresses:
                 params_addresses.append(addr_str)
                 added = True
         if added:
@@ -433,10 +443,15 @@ class APIClientBase:
         """Register a callback fired when add_addresses adds a new address.
 
         Must be called from the event loop. Returns a callable that
-        unregisters the callback.
+        unregisters the callback; calling it more than once is a no-op.
         """
         self._addresses_changed_callbacks.append(callback)
-        return partial(self._addresses_changed_callbacks.remove, callback)
+        return partial(self._remove_addresses_changed_callback, callback)
+
+    def _remove_addresses_changed_callback(self, callback: Callable[[], None]) -> None:
+        """Remove an addresses-changed callback, tolerating a double call."""
+        if callback in self._addresses_changed_callbacks:
+            self._addresses_changed_callbacks.remove(callback)
 
     @property
     def connected_address(self) -> str | None:

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import itertools
 import logging
 from typing import TYPE_CHECKING, Any
@@ -274,6 +275,7 @@ class APIClientBase:
     """Base client for ESPHome API clients."""
 
     __slots__ = (
+        "_addresses_changed_callbacks",
         "_background_tasks",
         "_cached_device_info",
         "_call_id_counter",
@@ -350,6 +352,7 @@ class APIClientBase:
         self._cached_device_info: DeviceInfo | None = None
         self.cached_name: str | None = None
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._addresses_changed_callbacks: list[Callable[[], None]] = []
         self._notify_callbacks: dict[tuple[int, int], Callable[[], None]] = {}
         self._loop = asyncio.get_running_loop()
         self._call_id_counter = itertools.count(1)
@@ -398,6 +401,39 @@ class APIClientBase:
         plane clients such as Home Assistant.
         """
         self._params.noise_psk = None
+
+    def add_addresses(self, addresses: list[str_]) -> bool:
+        """Append new addresses to try on future connection attempts.
+
+        Addresses already known are ignored; order is preserved. If any
+        address is new, the addresses-changed callbacks are fired so
+        consumers (e.g. ReconnectLogic) can act on them right away.
+
+        Must be called from the event loop. Returns True if at least one
+        address was new.
+        """
+        params_addresses = self._params.addresses
+        added = False
+        for addr in addresses:
+            if (addr_str := str(addr)) not in params_addresses:
+                params_addresses.append(addr_str)
+                added = True
+        if added:
+            self._set_log_name()
+            for callback in self._addresses_changed_callbacks.copy():
+                callback()
+        return added
+
+    def register_addresses_changed_callback(
+        self, callback: Callable[[], None]
+    ) -> Callable[[], None]:
+        """Register a callback fired when add_addresses adds a new address.
+
+        Must be called from the event loop. Returns a callable that
+        unregisters the callback.
+        """
+        self._addresses_changed_callbacks.append(callback)
+        return partial(self._addresses_changed_callbacks.remove, callback)
 
     @property
     def connected_address(self) -> str | None:

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -69,8 +69,7 @@ _LOGGER = logging.getLogger(__name__)
 # connection is poor.
 KEEP_ALIVE_FREQUENCY = 20.0
 
-# RFC 1035 caps a full domain name at 253 characters; anything longer in an
-# out-of-band discovered address is garbage and gets truncated for safety.
+# RFC 1035 maximum FQDN length; longer discovered addresses are rejected
 MAX_ADDRESS_LEN = 253
 
 # Caps on the per-subscription camera reassembly buffer. The peer fully
@@ -413,10 +412,9 @@ class APIClientBase:
         address is new, the addresses-changed callbacks are fired so
         consumers (e.g. ReconnectLogic) can act on them right away.
 
-        Addresses are expected to come from out-of-band discovery (e.g. an
-        MQTT broker lookup), so they are sanitized before they can reach
-        log output via ``log_name``; a legitimate IP or hostname passes
-        through unchanged.
+        Addresses come from out-of-band discovery (e.g. an MQTT broker
+        lookup); anything empty, over-long, or non-printable (a log
+        injection risk via ``log_name``) is skipped with a warning.
 
         Must be called from the event loop. Returns True if at least one
         address was new.
@@ -427,14 +425,28 @@ class APIClientBase:
         params_addresses = self._params.addresses
         added = False
         for addr in addresses:
-            addr_str = safe_label_str(str(addr), MAX_ADDRESS_LEN)
+            addr_str = str(addr)
+            if (
+                not addr_str.strip()
+                or len(addr_str) > MAX_ADDRESS_LEN
+                or safe_label_str(addr_str, MAX_ADDRESS_LEN) != addr_str
+            ):
+                # repr-escaped and truncated: the garbage must not forge log lines
+                _LOGGER.warning(
+                    "Ignoring invalid discovered address: %s", repr(addr_str)[:100]
+                )
+                continue
             if addr_str not in params_addresses:
                 params_addresses.append(addr_str)
                 added = True
         if added:
             self._set_log_name()
             for callback in self._addresses_changed_callbacks.copy():
-                callback()
+                try:
+                    callback()
+                except Exception:
+                    # One buggy subscriber must not starve the rest
+                    _LOGGER.exception("Error in addresses-changed callback")
         return added
 
     def register_addresses_changed_callback(

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -51,7 +51,7 @@ from .util import build_log_name, create_eager_task
 from .zeroconf import ZeroconfInstanceType, ZeroconfManager
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Iterable
 
     from google.protobuf import message
 
@@ -402,7 +402,7 @@ class APIClientBase:
         """
         self._params.noise_psk = None
 
-    def add_addresses(self, addresses: list[str_]) -> bool:
+    def add_addresses(self, addresses: Iterable[str_]) -> bool:
         """Append new addresses to try on future connection attempts.
 
         Addresses already known are ignored; order is preserved. If any
@@ -412,6 +412,9 @@ class APIClientBase:
         Must be called from the event loop. Returns True if at least one
         address was new.
         """
+        if isinstance(addresses, str):
+            msg = "addresses must be an iterable of strings, not a string"
+            raise TypeError(msg)
         params_addresses = self._params.addresses
         added = False
         for addr in addresses:

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -81,7 +81,6 @@ async def async_run(
                     on_connect()
                 except Exception:
                     # A caller bug must not cost the state subscription
-                    # or escape the connect task unretrieved
                     _LOGGER.exception("Error in on_connect callback")
             if log_callback:
                 await _subscribe_entity_states(cli, on_log, log_callback)

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -34,6 +34,7 @@ async def async_run(
     subscribe_states: bool = True,
     allow_plaintext_fallback: bool = False,
     deep_sleep: bool = False,
+    on_connect: Callable[[], None] | None = None,
 ) -> Callable[[], Coroutine[Any, Any, None]]:
     """Run logs until canceled.
 
@@ -48,14 +49,20 @@ async def async_run(
     the caller's YAML config) so the reconnect backoff is capped and a
     short awake window is not missed while waiting to reconnect.
 
+    ``on_connect`` is called after each successful connection, once the
+    log subscription is in place. Callers can use it to stop side channels
+    that only matter while disconnected (e.g. an out-of-band address
+    discovery feeding ``cli.add_addresses``).
+
     The logger stream is one-way (device → client), so enabling the
     fallback here only exposes log output to an on-path attacker — no
     commands or secrets are sent. Do not enable the equivalent flag on
     control-plane connections (e.g. Home Assistant).
     """
     dumped_config = not dump_config
+    on_connect_callback = on_connect
 
-    async def on_connect() -> None:
+    async def on_connect_() -> None:
         """Handle a connection."""
         nonlocal dumped_config
         try:
@@ -66,6 +73,8 @@ async def async_run(
                 dump_config=not dumped_config,
             )
             dumped_config = True
+            if on_connect_callback is not None:
+                on_connect_callback()
             if log_callback:
                 await _subscribe_entity_states(cli, on_log, log_callback)
         except APIConnectionError:
@@ -78,7 +87,7 @@ async def async_run(
 
     logic = ReconnectLogic(
         client=cli,
-        on_connect=on_connect,
+        on_connect=on_connect_,
         on_disconnect=on_disconnect,
         zeroconf_instance=aio_zeroconf_instance,
         name=name,

--- a/aioesphomeapi/log_runner.py
+++ b/aioesphomeapi/log_runner.py
@@ -52,7 +52,11 @@ async def async_run(
     ``on_connect`` is called after each successful connection, once the
     log subscription is in place. Callers can use it to stop side channels
     that only matter while disconnected (e.g. an out-of-band address
-    discovery feeding ``cli.add_addresses``).
+    discovery feeding ``cli.add_addresses``). It deliberately fires before
+    the entity-state subscription, which costs a device round-trip that
+    the caller's cleanup should not have to wait on. An exception it
+    raises is logged and contained so it cannot cost the state
+    subscription or the connect flow.
 
     The logger stream is one-way (device → client), so enabling the
     fallback here only exposes log output to an on-path attacker — no
@@ -60,7 +64,6 @@ async def async_run(
     control-plane connections (e.g. Home Assistant).
     """
     dumped_config = not dump_config
-    on_connect_callback = on_connect
 
     async def on_connect_() -> None:
         """Handle a connection."""
@@ -73,8 +76,13 @@ async def async_run(
                 dump_config=not dumped_config,
             )
             dumped_config = True
-            if on_connect_callback is not None:
-                on_connect_callback()
+            if on_connect is not None:
+                try:
+                    on_connect()
+                except Exception:
+                    # A caller bug must not cost the state subscription
+                    # or escape the connect task unretrieved
+                    _LOGGER.exception("Error in on_connect callback")
             if log_callback:
                 await _subscribe_entity_states(cli, on_log, log_callback)
         except APIConnectionError:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -141,6 +141,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._connect_task: asyncio.Task[None] | None = None
         self._connect_timer: asyncio.TimerHandle | None = None
         self._stop_task: asyncio.Task[None] | None = None
+        self._unsub_addresses_changed: Callable[[], None] | None = None
 
     async def _on_disconnect(self, expected_disconnect: bool) -> None:
         """Log and issue callbacks when disconnecting."""
@@ -191,7 +192,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         """Set the connection state without holding the lock.
 
         This should only be used for setting the state to DISCONNECTED
-        when the state is CONNECTING.
+        after cancelling an attempt that has not yet established a
+        socket (RESOLVING, or CONNECTING before the socket connected).
         """
         self._connection_state = state
 
@@ -431,6 +433,33 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         )
         self._stop_task.add_done_callback(self._remove_stop_task)
 
+    def _on_addresses_changed(self) -> None:
+        """Handle new candidate addresses appearing on the client.
+
+        Try to connect with them right away instead of waiting out the
+        backoff timer. _call_connect_once owns the restart policy for an
+        in-flight attempt; only the RESOLVING case is handled here.
+        """
+        if self._is_stopped or self._connection_state not in NOT_YET_CONNECTED_STATES:
+            # HANDSHAKING / READY: too far along to benefit; a later
+            # attempt re-reads the address list anyway.
+            return
+        if self._connection_state is ReconnectLogicState.RESOLVING:
+            # _call_connect_once won't restart a RESOLVING attempt (correct
+            # for the mDNS kick, whose records are what the resolver is
+            # waiting for); here the resolver may be pinned on a dead
+            # hostname for its full timeout while the new addresses are
+            # typically IP literals that resolve instantly, so cancel it.
+            _LOGGER.debug(
+                "%s: Cancelling resolve to try newly added addresses",
+                self._cli.log_name,
+            )
+            self._cancel_connect_task("New addresses available")
+            self._async_set_connection_state_without_lock(
+                ReconnectLogicState.DISCONNECTED
+            )
+        self._schedule_connect(0.0)
+
     async def start(self) -> None:
         """Start the connecting logic background task."""
         async with self._connected_lock:
@@ -441,10 +470,19 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             # Clear any stale gate from a prior run that was stopped mid
             # attempt after an mDNS triggered restart.
             self._accept_zeroconf_records = True
+            if self._unsub_addresses_changed is None:
+                self._unsub_addresses_changed = (
+                    self._cli.register_addresses_changed_callback(
+                        self._on_addresses_changed
+                    )
+                )
             self._schedule_connect(0.0)
 
     async def stop(self) -> None:
         """Stop the connecting logic background task. Does not disconnect the client."""
+        if self._unsub_addresses_changed is not None:
+            self._unsub_addresses_changed()
+            self._unsub_addresses_changed = None
         if self._connection_state in NOT_YET_CONNECTED_STATES:
             # If we are still establishing a connection, we can safely
             # cancel the connect task here, otherwise we need to wait

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -458,6 +458,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._async_set_connection_state_without_lock(
                 ReconnectLogicState.DISCONNECTED
             )
+        # The gate is one mDNS kick per attempt; this starts a new attempt,
+        # so don't leave it spent from the previous one.
+        self._accept_zeroconf_records = True
         self._schedule_connect(0.0)
 
     async def start(self) -> None:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -458,8 +458,8 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._async_set_connection_state_without_lock(
                 ReconnectLogicState.DISCONNECTED
             )
-        # The gate is one mDNS kick per attempt; this starts a new attempt,
-        # so don't leave it spent from the previous one.
+        # Re-arm the one-kick-per-attempt mDNS gate for the attempt this
+        # schedules; harmless if _call_connect_once declines.
         self._accept_zeroconf_records = True
         self._schedule_connect(0.0)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5621,19 +5621,47 @@ async def test_add_addresses_unsubscribe_is_idempotent() -> None:
     assert cli._addresses_changed_callbacks == []
 
 
-async def test_add_addresses_sanitizes_discovered_strings() -> None:
-    """Out-of-band discovered addresses are sanitized before reaching log_name."""
+async def test_add_addresses_rejects_invalid_discovered_strings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Garbage from out-of-band discovery is skipped, not rewritten and dialed."""
     cli = APIClient(
         address="192.168.1.100",
         port=6052,
         password=None,
     )
-    assert cli.add_addresses(["10.0.0.1\n2026-08-12 ERROR forged line"]) is True
-    assert cli._params.addresses == [
-        "192.168.1.100",
-        "10.0.0.12026-08-12 ERROR forged line",
-    ]
+    assert (
+        cli.add_addresses(
+            [
+                "10.0.0.1\n2026-08-12 ERROR forged line",  # log injection
+                "",  # empty
+                "   ",  # whitespace only
+                "a" * 300,  # over the maximum legal FQDN length
+            ]
+        )
+        is False
+    )
+    assert cli._params.addresses == ["192.168.1.100"]
     assert "\n" not in cli.log_name
-    # Over-long garbage is truncated to the maximum legal FQDN length
-    assert cli.add_addresses(["a" * 300]) is True
-    assert cli._params.addresses[-1] == "a" * 253
+    assert caplog.text.count("Ignoring invalid discovered address") == 4
+
+    # A valid address mixed in with garbage still lands
+    assert cli.add_addresses(["\x1b[31mforged\x1b[0m", "10.0.0.2"]) is True
+    assert cli._params.addresses == ["192.168.1.100", "10.0.0.2"]
+
+
+async def test_add_addresses_raising_callback_does_not_starve_others() -> None:
+    """One buggy subscriber cannot skip later callbacks or the return value."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    first = MagicMock(side_effect=RuntimeError("consumer bug"))
+    second = MagicMock()
+    cli.register_addresses_changed_callback(first)
+    cli.register_addresses_changed_callback(second)
+
+    assert cli.add_addresses(["10.0.0.2"]) is True
+    first.assert_called_once_with()
+    second.assert_called_once_with()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5605,3 +5605,35 @@ async def test_add_addresses_rejects_bare_string() -> None:
     with pytest.raises(TypeError, match="not a string"):
         cli.add_addresses("10.0.0.1")  # type: ignore[arg-type]
     assert cli._params.addresses == ["192.168.1.100"]
+
+
+async def test_add_addresses_unsubscribe_is_idempotent() -> None:
+    """Calling the returned unsubscribe callable twice is a no-op."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    callback = MagicMock()
+    unsub = cli.register_addresses_changed_callback(callback)
+    unsub()
+    unsub()
+    assert cli._addresses_changed_callbacks == []
+
+
+async def test_add_addresses_sanitizes_discovered_strings() -> None:
+    """Out-of-band discovered addresses are sanitized before reaching log_name."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    assert cli.add_addresses(["10.0.0.1\n2026-08-12 ERROR forged line"]) is True
+    assert cli._params.addresses == [
+        "192.168.1.100",
+        "10.0.0.12026-08-12 ERROR forged line",
+    ]
+    assert "\n" not in cli.log_name
+    # Over-long garbage is truncated to the maximum legal FQDN length
+    assert cli.add_addresses(["a" * 300]) is True
+    assert cli._params.addresses[-1] == "a" * 253

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5593,3 +5593,15 @@ async def test_device_id_in_commands(
     # Verify key and device_id match
     assert actual_request.key == expected_request.key
     assert actual_request.device_id == expected_request.device_id
+
+
+async def test_add_addresses_rejects_bare_string() -> None:
+    """A bare string must not be iterated into single characters."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    with pytest.raises(TypeError, match="not a string"):
+        cli.add_addresses("10.0.0.1")  # type: ignore[arg-type]
+    assert cli._params.addresses == ["192.168.1.100"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1736,6 +1736,47 @@ async def test_addresses_parameter_handles_subclassed_string() -> None:
     assert cli._params.addresses[2] == "10.0.0.1"
 
 
+async def test_add_addresses() -> None:
+    """Test appending addresses after construction."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    assert cli.add_addresses(["192.168.1.100"]) is False
+    assert cli._params.addresses == ["192.168.1.100"]
+
+    assert cli.add_addresses(["192.168.1.101", "192.168.1.100"]) is True
+    assert cli._params.addresses == ["192.168.1.100", "192.168.1.101"]
+    assert cli.log_name == "192.168.1.100"
+
+    # Subclassed strings are converted, duplicates ignored
+    assert cli.add_addresses([Estr("192.168.1.101"), Estr("10.0.0.1")]) is True
+    assert cli._params.addresses == ["192.168.1.100", "192.168.1.101", "10.0.0.1"]
+    assert all(type(addr) is str for addr in cli._params.addresses)
+
+
+async def test_add_addresses_fires_callbacks() -> None:
+    """Test the addresses-changed callbacks fire only on real additions."""
+    cli = APIClient(
+        address="192.168.1.100",
+        port=6052,
+        password=None,
+    )
+    callback = MagicMock()
+    unsub = cli.register_addresses_changed_callback(callback)
+
+    assert cli.add_addresses(["192.168.1.100"]) is False
+    callback.assert_not_called()
+
+    assert cli.add_addresses(["192.168.1.101"]) is True
+    callback.assert_called_once_with()
+
+    unsub()
+    assert cli.add_addresses(["10.0.0.1"]) is True
+    callback.assert_called_once_with()
+
+
 async def test_client_properties(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5637,17 +5637,22 @@ async def test_add_addresses_rejects_invalid_discovered_strings(
                 "",  # empty
                 "   ",  # whitespace only
                 "a" * 300,  # over the maximum legal FQDN length
+                "10.0.0.5 extra",  # interior whitespace
+                None,  # JSON null from a broken broker payload
+                49,  # non-string element
             ]
         )
         is False
     )
     assert cli._params.addresses == ["192.168.1.100"]
     assert "\n" not in cli.log_name
-    assert caplog.text.count("Ignoring invalid discovered address") == 4
+    assert caplog.text.count("Ignoring invalid discovered address") == 7
 
-    # A valid address mixed in with garbage still lands
-    assert cli.add_addresses(["\x1b[31mforged\x1b[0m", "10.0.0.2"]) is True
+    # A valid address mixed in with garbage still lands, and padding is
+    # normalized so it dedups against the canonical form
+    assert cli.add_addresses(["\x1b[31mforged\x1b[0m", "  10.0.0.2  "]) is True
     assert cli._params.addresses == ["192.168.1.100", "10.0.0.2"]
+    assert cli.add_addresses(["10.0.0.2"]) is False
 
 
 async def test_add_addresses_raising_callback_does_not_starve_others() -> None:

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -785,4 +785,7 @@ async def test_log_runner_on_connect_callback(
 
     on_connect.assert_called_once_with()
 
-    await stop()
+    stop_task = asyncio.create_task(stop())
+    await asyncio.sleep(0)
+    mock_data_received(protocol, generate_plaintext_packet(DisconnectResponse()))
+    await stop_task

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -793,3 +793,45 @@ async def test_log_runner_on_connect_callback(
     await asyncio.sleep(0)
     mock_data_received(protocol, generate_plaintext_packet(DisconnectResponse()))
     await stop_task
+
+
+@pytest.mark.parametrize("callback_raises", [False, True])
+async def test_log_runner_on_connect_callback_keeps_state_subscription(
+    caplog: pytest.LogCaptureFixture,
+    callback_raises: bool,
+) -> None:
+    """The state subscription runs after the on_connect callback either way."""
+    cli = MagicMock(spec=APIClient)
+    cli.device_info_and_list_entities = AsyncMock(return_value=(MagicMock(), [], []))
+
+    on_connect_callback = None
+
+    class MockReconnectLogic(ReconnectLogic):
+        def __init__(self, *, on_connect, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal on_connect_callback
+            on_connect_callback = on_connect
+
+        async def start(self) -> None:
+            await on_connect_callback()
+
+        async def stop(self) -> None:
+            pass
+
+    on_connect = MagicMock(
+        side_effect=RuntimeError("callback blew up") if callback_raises else None
+    )
+
+    with patch("aioesphomeapi.log_runner.ReconnectLogic", MockReconnectLogic):
+        stop = await async_run(
+            cli,
+            lambda msg: None,
+            subscribe_states=True,
+            on_connect=on_connect,
+        )
+
+    on_connect.assert_called_once_with()
+    # The entity-state subscription must run even when the callback raised
+    cli.device_info_and_list_entities.assert_awaited_once()
+    assert ("Error in on_connect callback" in caplog.text) is callback_raises
+
+    await stop()

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -679,11 +679,7 @@ async def test_async_run_on_disconnect_logs_warning(
 
 
 async def test_log_runner_add_addresses_triggers_immediate_attempt() -> None:
-    """add_addresses on the client kicks the runner's internal ReconnectLogic.
-
-    This is the flow the esphome CLI uses to feed MQTT-discovered addresses
-    in while the runner is already retrying the directly-known addresses.
-    """
+    """add_addresses on the client kicks the runner's internal ReconnectLogic."""
     async_zeroconf = get_mock_async_zeroconf()
 
     class PatchableAPIClient(APIClient):

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -721,3 +721,68 @@ async def test_log_runner_add_addresses_triggers_immediate_attempt() -> None:
         assert cli._params.addresses == ["10.0.0.1", "127.0.0.1"]
 
     await stop()
+
+
+async def test_log_runner_on_connect_callback(
+    conn: APIConnection,
+    aiohappyeyeballs_start_connection,
+) -> None:
+    """The optional on_connect callback fires once the log subscription is up."""
+    loop = asyncio.get_running_loop()
+    protocol: APIPlaintextFrameHelper | None = None
+    transport = MagicMock()
+    connected = asyncio.Event()
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    async_zeroconf = get_mock_async_zeroconf()
+
+    cli = PatchableAPIClient(
+        address=Estr("127.0.0.1"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=Estr("fake"),
+        zeroconf_instance=async_zeroconf.zeroconf,
+    )
+
+    def _create_mock_transport_protocol(create_func, **kwargs):
+        nonlocal protocol
+        protocol = create_func()
+        protocol.connection_made(transport)
+        connected.set()
+        return transport, protocol
+
+    subscribed = asyncio.Event()
+    original_subscribe_logs = cli.subscribe_logs
+
+    def _wait_subscribe_cli(*args, **kwargs):
+        original_subscribe_logs(*args, **kwargs)
+        subscribed.set()
+
+    on_connect = MagicMock()
+
+    with (
+        patch.object(
+            loop, "create_connection", side_effect=_create_mock_transport_protocol
+        ),
+        patch.object(cli, "subscribe_logs", _wait_subscribe_cli),
+    ):
+        stop = await async_run(
+            cli,
+            lambda msg: None,
+            aio_zeroconf_instance=async_zeroconf,
+            subscribe_states=False,
+            on_connect=on_connect,
+        )
+        on_connect.assert_not_called()
+        await connected.wait()
+        protocol = cli._connection._frame_helper
+        send_plaintext_hello(protocol)
+        send_plaintext_auth_response(protocol, False)
+        await subscribed.wait()
+
+    on_connect.assert_called_once_with()
+
+    await stop()

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -725,6 +725,7 @@ async def test_log_runner_add_addresses_triggers_immediate_attempt() -> None:
 
 async def test_log_runner_on_connect_callback(
     conn: APIConnection,
+    caplog: pytest.LogCaptureFixture,
     aiohappyeyeballs_start_connection,
 ) -> None:
     """The optional on_connect callback fires once the log subscription is up."""
@@ -761,7 +762,9 @@ async def test_log_runner_on_connect_callback(
         original_subscribe_logs(*args, **kwargs)
         subscribed.set()
 
-    on_connect = MagicMock()
+    # A raising callback must be contained: the connection must still come
+    # up and the error must be logged rather than escaping the connect task
+    on_connect = MagicMock(side_effect=RuntimeError("callback blew up"))
 
     with (
         patch.object(
@@ -784,6 +787,7 @@ async def test_log_runner_on_connect_callback(
         await subscribed.wait()
 
     on_connect.assert_called_once_with()
+    assert "Error in on_connect callback" in caplog.text
 
     stop_task = asyncio.create_task(stop())
     await asyncio.sleep(0)

--- a/tests/test_log_runner.py
+++ b/tests/test_log_runner.py
@@ -676,3 +676,52 @@ async def test_async_run_on_disconnect_logs_warning(
     assert "Disconnected from API" in caplog.text
 
     await stop()
+
+
+async def test_log_runner_add_addresses_triggers_immediate_attempt() -> None:
+    """add_addresses on the client kicks the runner's internal ReconnectLogic.
+
+    This is the flow the esphome CLI uses to feed MQTT-discovered addresses
+    in while the runner is already retrying the directly-known addresses.
+    """
+    async_zeroconf = get_mock_async_zeroconf()
+
+    class PatchableAPIClient(APIClient):
+        pass
+
+    cli = PatchableAPIClient(
+        address=Estr("10.0.0.1"),
+        port=6052,
+        password=None,
+        noise_psk=None,
+        expected_name=Estr("fake"),
+        zeroconf_instance=async_zeroconf.zeroconf,
+    )
+
+    with patch.object(
+        cli, "start_resolve_host", side_effect=APIConnectionError
+    ) as mock_resolve:
+        stop = await async_run(
+            cli,
+            lambda msg: None,
+            aio_zeroconf_instance=async_zeroconf,
+            subscribe_states=False,
+        )
+        await asyncio.sleep(0)
+        assert mock_resolve.call_count == 1
+
+    # First attempt failed; the runner is waiting out its backoff timer.
+    # Feeding a new address must trigger an attempt right away that sees
+    # the full address list.
+    with (
+        patch.object(cli, "start_resolve_host") as mock_resolve_2,
+        patch.object(cli, "start_connection"),
+        patch.object(cli, "finish_connection"),
+    ):
+        assert cli.add_addresses(["127.0.0.1"]) is True
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert mock_resolve_2.call_count == 1
+        assert cli._params.addresses == ["10.0.0.1", "127.0.0.1"]
+
+    await stop()

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1703,3 +1703,175 @@ async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
     assert log_record.levelno == logging.DEBUG
 
     await logic.stop()
+
+
+async def test_addresses_changed_callback_lifecycle(
+    patchable_api_client: APIClient,
+) -> None:
+    """The addresses-changed callback registers on start and unregisters on stop."""
+    cli = patchable_api_client
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+    assert cli._addresses_changed_callbacks == []
+
+    with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+        await rl.start()
+        await asyncio.sleep(0)
+
+    assert cli._addresses_changed_callbacks == [rl._on_addresses_changed]
+
+    await rl.stop()
+    assert cli._addresses_changed_callbacks == []
+
+    # add_addresses after stop must not schedule anything
+    assert rl._connect_timer is None
+    cli.add_addresses(["10.0.0.2"])
+    assert rl._connect_timer is None
+    assert rl._connect_task is None
+
+
+async def test_add_addresses_kicks_backoff_timer(
+    patchable_api_client: APIClient,
+) -> None:
+    """New addresses trigger an immediate attempt instead of waiting out backoff."""
+    cli = patchable_api_client
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+
+    with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+        await rl.start()
+        await asyncio.sleep(0)
+
+    # First attempt failed; we are DISCONNECTED waiting on the backoff timer
+    assert rl._connection_state is ReconnectLogicState.DISCONNECTED
+    assert rl._connect_timer is not None
+
+    with (
+        patch.object(cli, "start_resolve_host") as mock_resolve,
+        patch.object(cli, "start_connection", side_effect=slow_connect_fail),
+    ):
+        assert cli.add_addresses(["10.0.0.2"]) is True
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert mock_resolve.call_count == 1
+        assert cli._params.addresses == ["127.0.0.1", "10.0.0.2"]
+
+    rl._cancel_connect("forced cancel in test")
+    await rl.stop()
+
+
+@pytest.mark.parametrize(
+    ("stall_in_resolve", "expected_log"),
+    [
+        (False, "Cancelling existing connect task"),
+        (True, "Cancelling resolve to try newly added addresses"),
+    ],
+)
+async def test_add_addresses_cancels_stalled_attempt(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+    stall_in_resolve: bool,
+    expected_log: str,
+) -> None:
+    """New addresses cancel an attempt stuck before a socket is established.
+
+    The CONNECTING-without-socket restart is _call_connect_once's existing
+    policy; the RESOLVING cancel is specific to the address kick. Unlike the
+    mDNS kick, which leaves a RESOLVING attempt alone because the resolver
+    is waiting for the very records zeroconf is delivering, new addresses
+    must interrupt a resolve that may be pinned on a dead hostname for its
+    full timeout.
+    """
+    cli = patchable_api_client
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+
+    if stall_in_resolve:
+        with patch.object(cli, "start_resolve_host", side_effect=slow_connect_fail):
+            await rl.start()
+            await asyncio.sleep(0)
+        assert rl._connection_state is ReconnectLogicState.RESOLVING
+    else:
+        with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
+            await rl.start()
+            await asyncio.sleep(0)
+        with (
+            patch.object(cli, "start_resolve_host"),
+            patch.object(cli, "start_connection", side_effect=slow_connect_fail),
+        ):
+            assert rl._connect_timer is not None
+            rl._connect_timer._run()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+        assert rl._connection_state is ReconnectLogicState.CONNECTING
+
+    assert cli.connected_address is None
+    caplog.clear()
+
+    with (
+        patch.object(cli, "start_resolve_host") as mock_resolve_2,
+        patch.object(
+            cli, "start_connection", side_effect=slow_connect_fail
+        ) as mock_connect_2,
+    ):
+        assert cli.add_addresses(["10.0.0.2"]) is True
+        assert expected_log in caplog.text
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert mock_resolve_2.call_count == 1
+        assert mock_connect_2.call_count == 1
+        assert rl._connection_state is ReconnectLogicState.CONNECTING
+
+    rl._cancel_connect("forced cancel in test")
+    await rl.stop()
+
+
+async def test_add_addresses_ignored_when_ready(
+    patchable_api_client: APIClient,
+) -> None:
+    """New addresses while READY must not disturb the live connection."""
+    cli = patchable_api_client
+
+    rl = ReconnectLogic(
+        client=cli,
+        on_disconnect=AsyncMock(),
+        on_connect=AsyncMock(),
+        zeroconf_instance=get_mock_zeroconf(),
+        name="mydevice",
+    )
+
+    with (
+        patch.object(cli, "start_resolve_host"),
+        patch.object(cli, "start_connection"),
+        patch.object(cli, "finish_connection"),
+    ):
+        await rl.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert rl._connection_state is ReconnectLogicState.READY
+
+    assert cli.add_addresses(["10.0.0.2"]) is True
+    assert rl._connect_timer is None
+    assert rl._connection_state is ReconnectLogicState.READY
+
+    await rl.stop()

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1785,15 +1785,7 @@ async def test_add_addresses_cancels_stalled_attempt(
     stall_in_resolve: bool,
     expected_log: str,
 ) -> None:
-    """New addresses cancel an attempt stuck before a socket is established.
-
-    The CONNECTING-without-socket restart is _call_connect_once's existing
-    policy; the RESOLVING cancel is specific to the address kick. Unlike the
-    mDNS kick, which leaves a RESOLVING attempt alone because the resolver
-    is waiting for the very records zeroconf is delivering, new addresses
-    must interrupt a resolve that may be pinned on a dead hostname for its
-    full timeout.
-    """
+    """New addresses cancel an attempt stuck before a socket is established."""
     cli = patchable_api_client
 
     rl = ReconnectLogic(


### PR DESCRIPTION
# What does this implement/fix?

Connection attempts can only try the addresses the client was constructed with, so a caller that learns about an address late, for example from an MQTT broker lookup, has no way to feed it into a client that is already retrying. This adds APIClient.add_addresses to append newly discovered addresses to a live client, plus a callback registry that ReconnectLogic subscribes to so new addresses trigger an immediate connect attempt instead of waiting out the backoff timer. An attempt that is still resolving, or connecting without an established socket, is cancelled and restarted so the new addresses are tried right away.

The esphome CLI will use this to start log streaming immediately with the addresses it already knows while the MQTT IP discovery runs in the background, see esphome/esphome#18311. log_runner.async_run also gains an optional on_connect callback that fires once the log subscription is up, so the CLI can cancel the broker lookup as soon as a connection succeeds; discovered addresses are only useful while still disconnected.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#18311

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#18313

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
