### PR TITLE
Avoid loading uuid and timezone modules at import time

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -1536,8 +1536,13 @@ def _join_split_uuid(value: list[int]) -> str:
 
 @lru_cache(maxsize=256)
 def _join_split_uuid_high_low(high: int, low: int) -> str:
-    # Same output as str(UUID(int=...)) without importing the uuid module
-    h = f"{(high << 64) | low:032x}"
+    # Same output and range check as str(UUID(int=...)) without
+    # importing the uuid module
+    value = (high << 64) | low
+    if not 0 <= value < 1 << 128:
+        msg = "int is out of range (need a 128-bit value)"
+        raise ValueError(msg)
+    h = f"{value:032x}"
     return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:]}"
 
 

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -5,7 +5,6 @@ from dataclasses import asdict, dataclass, field, fields
 import enum
 from functools import cache, lru_cache, partial
 from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
-from uuid import UUID
 
 from .util import fix_float_single_double_conversion
 
@@ -1537,7 +1536,9 @@ def _join_split_uuid(value: list[int]) -> str:
 
 @lru_cache(maxsize=256)
 def _join_split_uuid_high_low(high: int, low: int) -> str:
-    return str(UUID(int=(high << 64) | low))
+    # Same output as str(UUID(int=...)) without importing the uuid module
+    h = f"{(high << 64) | low:032x}"
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:]}"
 
 
 @lru_cache(maxsize=256)

--- a/aioesphomeapi/timezone.py
+++ b/aioesphomeapi/timezone.py
@@ -23,28 +23,37 @@ _LOGGER = logging.getLogger(__name__)
 # Guards the lazy imports below; a module-level lock is per-interpreter,
 # matching the per-interpreter sys.modules the imports populate.
 _import_lock = threading.Lock()
-_tz_modules_loaded = False
+_resources_loaded = False
+_tzlocal_loaded = False
 
 
-def _load_tz_modules() -> None:
-    """Import tzlocal/importlib.resources; blocking, so run off the event loop."""
-    global resources, tzlocal, _tz_modules_loaded  # noqa: PLW0603
+def _load_resources() -> None:
+    """Import importlib.resources; blocking, so run off the event loop."""
+    global resources, _resources_loaded  # noqa: PLW0603
     # Callers are behind lru_cache so this is cold; always taking the lock
     # keeps the flag and module stores ordered on free-threaded builds.
     with _import_lock:
-        if not _tz_modules_loaded:
+        if not _resources_loaded:
             from importlib import resources  # noqa: PLC0415
 
+            _resources_loaded = True
+
+
+def _load_tzlocal() -> None:
+    """Import tzlocal; blocking, so run off the event loop."""
+    global tzlocal, _tzlocal_loaded  # noqa: PLW0603
+    with _import_lock:
+        if not _tzlocal_loaded:
             import tzlocal  # noqa: PLC0415
 
-            _tz_modules_loaded = True
+            _tzlocal_loaded = True
 
 
 def _load_tzdata(iana_key: str) -> bytes | None:
     """Load timezone data from tzdata package."""
     if not iana_key:
         return None
-    _load_tz_modules()
+    _load_resources()
     try:
         package_loc, resource = iana_key.rsplit("/", 1)
     except ValueError:
@@ -79,7 +88,7 @@ def _get_local_timezone() -> str:
     This function is cached since the timezone doesn't change during runtime.
     This matches the implementation in ESPHome's time component.
     """
-    _load_tz_modules()
+    _load_tzlocal()
     try:
         # Use tzlocal to get the IANA timezone key, same as ESPHome
         iana_key: str | None = tzlocal.get_localzone_name()

--- a/aioesphomeapi/timezone.py
+++ b/aioesphomeapi/timezone.py
@@ -27,7 +27,7 @@ _tz_modules_loaded = False
 
 
 def _load_tz_modules() -> None:
-    """Import tzlocal/importlib.resources; call only from executor threads."""
+    """Import tzlocal/importlib.resources; blocking, so run off the event loop."""
     global resources, tzlocal, _tz_modules_loaded  # noqa: PLW0603
     if _tz_modules_loaded:
         return

--- a/aioesphomeapi/timezone.py
+++ b/aioesphomeapi/timezone.py
@@ -29,8 +29,8 @@ _tz_modules_loaded = False
 def _load_tz_modules() -> None:
     """Import tzlocal/importlib.resources; blocking, so run off the event loop."""
     global resources, tzlocal, _tz_modules_loaded  # noqa: PLW0603
-    if _tz_modules_loaded:
-        return
+    # Callers are behind lru_cache so this is cold; always taking the lock
+    # keeps the flag and module stores ordered on free-threaded builds.
     with _import_lock:
         if not _tz_modules_loaded:
             from importlib import resources  # noqa: PLC0415

--- a/aioesphomeapi/timezone.py
+++ b/aioesphomeapi/timezone.py
@@ -4,20 +4,47 @@ from __future__ import annotations
 
 import asyncio
 from functools import cache, lru_cache
-from importlib import resources
 import logging
-
-import tzlocal
+import threading
+from typing import TYPE_CHECKING
 
 from .singleton import singleton
 
+if TYPE_CHECKING:
+    from importlib import resources
+
+    import tzlocal
+else:
+    resources = None
+    tzlocal = None
+
 _LOGGER = logging.getLogger(__name__)
+
+# Guards the lazy imports below; a module-level lock is per-interpreter,
+# matching the per-interpreter sys.modules the imports populate.
+_import_lock = threading.Lock()
+_tz_modules_loaded = False
+
+
+def _load_tz_modules() -> None:
+    """Import tzlocal/importlib.resources; call only from executor threads."""
+    global resources, tzlocal, _tz_modules_loaded  # noqa: PLW0603
+    if _tz_modules_loaded:
+        return
+    with _import_lock:
+        if not _tz_modules_loaded:
+            from importlib import resources  # noqa: PLC0415
+
+            import tzlocal  # noqa: PLC0415
+
+            _tz_modules_loaded = True
 
 
 def _load_tzdata(iana_key: str) -> bytes | None:
     """Load timezone data from tzdata package."""
     if not iana_key:
         return None
+    _load_tz_modules()
     try:
         package_loc, resource = iana_key.rsplit("/", 1)
     except ValueError:
@@ -52,6 +79,7 @@ def _get_local_timezone() -> str:
     This function is cached since the timezone doesn't change during runtime.
     This matches the implementation in ESPHome's time component.
     """
+    _load_tz_modules()
     try:
         # Use tzlocal to get the IANA timezone key, same as ESPHome
         iana_key: str | None = tzlocal.get_localzone_name()

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -35,7 +35,8 @@ def _reset_noise_loader():
     connection_module._noise_import_locks = orig_locks
 
 
-# Modules that must only load when timezone handling (provide_time) runs.
+# Modules that must not load on package import: the timezone stack loads
+# only when provide_time timezone handling runs; uuid is no longer used.
 TZ_DEFERRED_MODULES = (
     "uuid",
     "tzlocal",
@@ -67,6 +68,22 @@ def test_import_does_not_load_noise_stack() -> None:
 def test_import_does_not_load_tz_or_uuid_modules() -> None:
     """Importing the package must not pull in uuid or the timezone stack."""
     _assert_modules_not_loaded_on_import(TZ_DEFERRED_MODULES)
+
+
+def test_explicit_timezone_does_not_load_tzlocal() -> None:
+    """Resolving an explicit IANA key must not pull in tzlocal."""
+    script = (
+        "import sys\n"
+        "from aioesphomeapi.timezone import iana_to_posix_tz\n"
+        "assert iana_to_posix_tz('America/Chicago')\n"
+        "assert 'tzlocal' not in sys.modules\n"
+    )
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
 
 def test_import_noise_frame_helper_caches_class() -> None:

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -35,11 +35,19 @@ def _reset_noise_loader():
     connection_module._noise_import_locks = orig_locks
 
 
-def test_import_does_not_load_noise_stack() -> None:
-    """Importing the package must not pull in the noise/cryptography stack."""
+# Modules that must only load when timezone handling (provide_time) runs.
+TZ_DEFERRED_MODULES = (
+    "uuid",
+    "tzlocal",
+    "zoneinfo",
+    "importlib.resources",
+)
+
+
+def _assert_modules_not_loaded_on_import(modules: tuple[str, ...]) -> None:
     script = (
         "import sys, aioesphomeapi\n"
-        f"loaded = [m for m in {DEFERRED_MODULES!r} if m in sys.modules]\n"
+        f"loaded = [m for m in {modules!r} if m in sys.modules]\n"
         "print(','.join(loaded))\n"
     )
     result = subprocess.run(  # noqa: S603
@@ -49,6 +57,16 @@ def test_import_does_not_load_noise_stack() -> None:
         check=True,
     )
     assert result.stdout.strip() == "", f"unexpectedly loaded: {result.stdout.strip()}"
+
+
+def test_import_does_not_load_noise_stack() -> None:
+    """Importing the package must not pull in the noise/cryptography stack."""
+    _assert_modules_not_loaded_on_import(DEFERRED_MODULES)
+
+
+def test_import_does_not_load_tz_or_uuid_modules() -> None:
+    """Importing the package must not pull in uuid or the timezone stack."""
+    _assert_modules_not_loaded_on_import(TZ_DEFERRED_MODULES)
 
 
 def test_import_noise_frame_helper_caches_class() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1055,6 +1055,14 @@ def test_bluetooth_all_zero_uuid_from_dict() -> None:
     )
 
 
+def test_bluetooth_out_of_range_uuid_from_dict() -> None:
+    """from_dict rejects uuid words outside the 128-bit range."""
+    with pytest.raises(ValueError, match="128-bit"):
+        BluetoothGATTDescriptorModel.from_dict({"uuid": [2**100, 0], "handle": 7})
+    with pytest.raises(ValueError, match="128-bit"):
+        BluetoothGATTDescriptorModel.from_dict({"uuid": [-1, 0], "handle": 7})
+
+
 def test_bluetooth_characteristic_efficient_uuids() -> None:
     """Test characteristic with mixed UUID types in descriptors."""
     pb_char = BluetoothGATTCharacteristic()

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -11,8 +11,9 @@ from aioesphomeapi.singleton import _SINGLETON_CACHE
 from aioesphomeapi.timezone import (
     _extract_tz_string,
     _get_local_timezone,
-    _load_tz_modules,
+    _load_resources,
     _load_tzdata,
+    _load_tzlocal,
     get_local_timezone,
     get_timezone,
     iana_to_posix_tz,
@@ -20,7 +21,8 @@ from aioesphomeapi.timezone import (
 
 # Populate the lazily imported tzlocal/resources module globals so the
 # patch targets below resolve.
-_load_tz_modules()
+_load_resources()
+_load_tzlocal()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -11,11 +11,16 @@ from aioesphomeapi.singleton import _SINGLETON_CACHE
 from aioesphomeapi.timezone import (
     _extract_tz_string,
     _get_local_timezone,
+    _load_tz_modules,
     _load_tzdata,
     get_local_timezone,
     get_timezone,
     iana_to_posix_tz,
 )
+
+# Populate the lazily imported tzlocal/resources module globals so the
+# patch targets below resolve.
+_load_tz_modules()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# What does this implement/fix?

Importing the client currently pulls in uuid, importlib.resources, tzlocal, and zoneinfo even when they are never used, which slows down startup of CLI tools like esphome logs. The uuid module was only needed to format BLE UUID strings, plain hex formatting produces the same output without the import. The timezone stack is only needed when provide_time is set, so tzlocal and importlib.resources are now imported lazily; the import happens in the executor since the callers already run there, and it is guarded by a per interpreter lock so concurrent imports are serialized (python/cpython#83065).

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

