### PR TITLE
Defer zeroconf loading until the mDNS wake listener is needed

### DIFF
--- a/aioesphomeapi/_zc_listener.py
+++ b/aioesphomeapi/_zc_listener.py
@@ -7,21 +7,21 @@ from zeroconf import RecordUpdateListener
 if TYPE_CHECKING:
     from zeroconf import RecordUpdate, Zeroconf
 
-    from .reconnect_logic import ReconnectLogic
+    from .reconnect_logic import ZeroconfWake
 
 
 class ReconnectRecordUpdateListener(RecordUpdateListener):
-    """Forward zeroconf record updates to a ReconnectLogic.
+    """Forward zeroconf record updates to a ZeroconfWake.
 
     Lives in its own module so importing reconnect_logic does not import
     the zeroconf package; this module loads only when the mDNS-wake
     listener actually starts.
     """
 
-    def __init__(self, logic: ReconnectLogic) -> None:
-        self._logic = logic
+    def __init__(self, wake: ZeroconfWake) -> None:
+        self._wake = wake
 
     def async_update_records(
         self, zc: Zeroconf, now: float, records: list[RecordUpdate]
     ) -> None:
-        self._logic.async_update_records(zc, now, records)
+        self._wake.async_update_records(zc, now, records)

--- a/aioesphomeapi/_zc_listener.py
+++ b/aioesphomeapi/_zc_listener.py
@@ -13,9 +13,8 @@ if TYPE_CHECKING:
 class ReconnectRecordUpdateListener(RecordUpdateListener):
     """Forward zeroconf record updates to a ZeroconfWake.
 
-    Lives in its own module so importing reconnect_logic does not import
-    the zeroconf package; this module loads only when the mDNS-wake
-    listener actually starts.
+    Lazily imported so the zeroconf package loads only when the
+    mDNS-wake listener actually starts.
     """
 
     def __init__(self, wake: ZeroconfWake) -> None:

--- a/aioesphomeapi/_zc_listener.py
+++ b/aioesphomeapi/_zc_listener.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from zeroconf import RecordUpdateListener
+
+if TYPE_CHECKING:
+    from zeroconf import RecordUpdate, Zeroconf
+
+    from .reconnect_logic import ReconnectLogic
+
+
+class ReconnectRecordUpdateListener(RecordUpdateListener):
+    """Forward zeroconf record updates to a ReconnectLogic.
+
+    Lives in its own module so importing reconnect_logic does not import
+    the zeroconf package; this module loads only when the mDNS-wake
+    listener actually starts.
+    """
+
+    def __init__(self, logic: ReconnectLogic) -> None:
+        self._logic = logic
+
+    def async_update_records(
+        self, zc: Zeroconf, now: float, records: list[RecordUpdate]
+    ) -> None:
+        self._logic.async_update_records(zc, now, records)

--- a/aioesphomeapi/_zc_listener.py
+++ b/aioesphomeapi/_zc_listener.py
@@ -11,11 +11,7 @@ if TYPE_CHECKING:
 
 
 class ReconnectRecordUpdateListener(RecordUpdateListener):
-    """Forward zeroconf record updates to a ZeroconfWake.
-
-    Lazily imported so the zeroconf package loads only when the
-    mDNS-wake listener actually starts.
-    """
+    """Forward zeroconf record updates to a ZeroconfWake."""
 
     def __init__(self, wake: ZeroconfWake) -> None:
         self._wake = wake

--- a/aioesphomeapi/client_base.py
+++ b/aioesphomeapi/client_base.py
@@ -48,7 +48,7 @@ from .model import (
 )
 from .model_conversions import SUBSCRIBE_STATES_RESPONSE_TYPES
 from .util import build_log_name, create_eager_task
-from .zeroconf import ZeroconfInstanceType, ZeroconfManager
+from .zeroconf import ZeroconfManager
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from google.protobuf import message
 
     from .connection import APIConnection
+    from .zeroconf import ZeroconfInstanceType
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aioesphomeapi/host_resolver.py
+++ b/aioesphomeapi/host_resolver.py
@@ -9,9 +9,6 @@ import logging
 import socket
 from typing import TYPE_CHECKING, Any, cast
 
-from zeroconf import DNSQuestionType, IPVersion
-from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
-
 from .core import ResolveAPIError, ResolveTimeoutAPIError
 from .util import (
     address_is_local,
@@ -23,6 +20,8 @@ from .zeroconf import ZeroconfManager
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
+
+    from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,6 +64,8 @@ async def _async_zeroconf_get_service_info(
     short_host: str,
     timeout: float,
 ) -> AsyncServiceInfo:
+    from zeroconf import DNSQuestionType  # noqa: PLC0415
+
     info = _make_service_info_for_short_host(short_host)
     try:
         # Use QM (multicast) questions to ensure multicast responses that all
@@ -95,6 +96,8 @@ def _scope_id_to_int(value: str | None) -> int:
 
 def _make_service_info_for_short_host(host: str) -> AsyncServiceInfo:
     """Make service info for an ESPHome host."""
+    from zeroconf.asyncio import AsyncServiceInfo  # noqa: PLC0415
+
     service_name = f"{host}.{SERVICE_TYPE}"
     server = f"{host}.local."
     return AsyncServiceInfo(SERVICE_TYPE, service_name, server=server)
@@ -113,6 +116,8 @@ async def _async_resolve_short_host_zeroconf(
 
 
 def service_info_to_addr_info(info: AsyncServiceInfo, port: int) -> list[AddrInfo]:
+    from zeroconf import IPVersion  # noqa: PLC0415
+
     return [
         _async_ip_address_to_addrinfo(ip, port)
         for version in (IPVersion.V6Only, IPVersion.V4Only)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from enum import Enum
 import logging
 import time
 from typing import TYPE_CHECKING
-
-import zeroconf
-from zeroconf.const import (
-    _TYPE_A as TYPE_A,
-    _TYPE_AAAA as TYPE_AAAA,
-    _TYPE_PTR as TYPE_PTR,
-)
 
 from .core import (
     APIConnectionCancelledError,
@@ -27,12 +21,64 @@ from .util import address_is_local, create_eager_task, host_is_name_part, is_ip_
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from zeroconf import RecordUpdate, Zeroconf
+
+    from ._zc_listener import ReconnectRecordUpdateListener
     from .client import APIClient
     from .zeroconf import ZeroconfInstanceType
 
 _LOGGER = logging.getLogger(__name__)
 
+# DNS record type codes (RFC 1035/3596), duplicated from zeroconf.const and
+# pinned against it in tests so this module does not import zeroconf at load
+# time.
+TYPE_A = 1
+TYPE_PTR = 12
+TYPE_AAAA = 28
+
 ADDRESS_RECORD_TYPES = {TYPE_A, TYPE_AAAA}
+
+# How long a connect attempt may stay in flight before the mDNS listener is
+# started anyway, so a device that comes online mid-attempt (our SYN lost
+# while it was still booting) is caught by its boot announcement instead of
+# waiting out a TCP timeout. Connects that land within this window never
+# load the zeroconf stack at all.
+ZC_LISTEN_DELAY = 2.0
+
+_zc_listener_cache: list[type[ReconnectRecordUpdateListener]] = []
+_zc_listener_import_locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+
+
+def _import_zc_listener() -> type[ReconnectRecordUpdateListener]:
+    from ._zc_listener import ReconnectRecordUpdateListener  # noqa: PLC0415
+
+    if not _zc_listener_cache:
+        _zc_listener_cache.append(ReconnectRecordUpdateListener)
+    return ReconnectRecordUpdateListener
+
+
+async def _async_load_zc_listener(
+    loop: asyncio.AbstractEventLoop,
+) -> type[ReconnectRecordUpdateListener]:
+    """Load the listener class, importing off the loop on the first cold import.
+
+    The import pulls in the zeroconf package, which does blocking file I/O;
+    running it in the executor keeps the event loop unblocked. The resolved
+    class is cached once the import fully completes, so later starts skip the
+    import entirely and a task racing the first cold import waits on the lock
+    instead of re-running the import on the loop thread.
+    """
+    if _zc_listener_cache:
+        return _zc_listener_cache[0]
+    lock = _zc_listener_import_locks.get(loop)
+    if lock is None:
+        lock = _zc_listener_import_locks[loop] = asyncio.Lock()
+    async with lock:
+        # Another task may have completed the import while we waited.
+        if _zc_listener_cache:
+            return _zc_listener_cache[0]
+        return await loop.run_in_executor(None, _import_zc_listener)
+
 
 EXPECTED_DISCONNECT_COOLDOWN = 5.0
 MAXIMUM_BACKOFF_TRIES = 100
@@ -64,7 +110,7 @@ AUTH_EXCEPTIONS = (
 )
 
 
-class ReconnectLogic(zeroconf.RecordUpdateListener):
+class ReconnectLogic:
     """Reconnectiong logic handler for ESPHome config entries.
 
     Contains two reconnect strategies:
@@ -135,6 +181,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         self._connected_lock = asyncio.Lock()
         self._is_stopped = True
         self._zc_listening = False
+        self._zc_listener: ReconnectRecordUpdateListener | None = None
+        self._zc_listen_timer: asyncio.TimerHandle | None = None
+        self._zc_listen_start_task: asyncio.Task[None] | None = None
         # How many connect attempts have there been already, used for exponential wait time
         self._tries = 0
         # Event for tracking when logic should stop
@@ -401,9 +450,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
                 or self._is_stopped
             ):
                 return
-            self._start_zc_listen()
+            self._schedule_zc_listen()
             if await self._try_connect():
                 return
+            # Not connected; bring the listener up for the backoff wait
+            # instead of waiting out the remainder of the arm timer.
+            await self._async_start_zc_listen()
             tries = min(self._tries, 10)  # prevent OverflowError
             max_backoff = (
                 DEEP_SLEEP_MAXIMUM_BACKOFF if self.deep_sleep else MAXIMUM_BACKOFF
@@ -504,6 +556,55 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
         await self._zeroconf_manager.async_close()
 
+    def _schedule_zc_listen(self) -> None:
+        """Arm the delayed mDNS listener start for a connect attempt.
+
+        Deferring the start keeps the zeroconf stack (import, sockets)
+        entirely off the fast path: a connect that lands within
+        ZC_LISTEN_DELAY cancels the timer before it fires.
+        """
+        if (
+            not self._zc_listening
+            and self._zc_listen_timer is None
+            and self._zc_listen_start_task is None
+            and self.name
+            and not self._is_ip_address
+        ):
+            self._zc_listen_timer = self.loop.call_later(
+                ZC_LISTEN_DELAY, self._fire_zc_listen_timer
+            )
+
+    def _fire_zc_listen_timer(self) -> None:
+        """Start the listener from the arm timer via a task for the cold import."""
+        self._zc_listen_timer = None
+        self._zc_listen_start_task = create_eager_task(
+            self._async_start_zc_listen(),
+            name=f"{self._cli.log_name}: aioesphomeapi start zc listen",
+        )
+        self._zc_listen_start_task.add_done_callback(self._remove_zc_listen_start_task)
+
+    def _remove_zc_listen_start_task(self, _fut: asyncio.Future[None]) -> None:
+        self._zc_listen_start_task = None
+
+    async def _async_start_zc_listen(self) -> None:
+        """Import the listener off the event loop, then start listening."""
+        if not _zc_listener_cache:
+            # A failed import is retried inline by _start_zc_listen, which
+            # owns logging the degraded no-mDNS-wake path.
+            with contextlib.suppress(Exception):
+                await _async_load_zc_listener(self.loop)
+        if not self._is_stopped and self._connection_state in NOT_YET_CONNECTED_STATES:
+            self._start_zc_listen()
+
+    def _cancel_zc_listen_timer(self) -> None:
+        """Cancel the delayed mDNS listener start."""
+        if self._zc_listen_timer:
+            self._zc_listen_timer.cancel()
+            self._zc_listen_timer = None
+        if self._zc_listen_start_task:
+            self._zc_listen_start_task.cancel()
+            self._zc_listen_start_task = None
+
     def _start_zc_listen(self) -> None:
         """Listen for mDNS records.
 
@@ -514,6 +615,7 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
         connect attempt; the listener is a reconnect-speed
         optimisation, not a requirement for connecting.
         """
+        self._cancel_zc_listen_timer()
         if not self._zc_listening and self.name and not self._is_ip_address:
             _LOGGER.debug("Starting zeroconf listener for %s", self.name)
             # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
@@ -523,8 +625,12 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
             self._ptr_alias = f"{self.name}._esphomelib._tcp.local.".lower()
             self._a_name = f"{self.name}.local.".lower()
             try:
+                from ._zc_listener import ReconnectRecordUpdateListener  # noqa: PLC0415
+
+                if self._zc_listener is None:
+                    self._zc_listener = ReconnectRecordUpdateListener(self)
                 async_zc = self._zeroconf_manager.get_async_zeroconf()
-                async_zc.zeroconf.async_add_listener(self, None)
+                async_zc.zeroconf.async_add_listener(self._zc_listener, None)
             except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
                 _LOGGER.log(
                     self._first_try_log_level(),
@@ -539,10 +645,13 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     def _stop_zc_listen(self) -> None:
         """Stop listening for zeroconf updates."""
+        self._cancel_zc_listen_timer()
         if self._zc_listening:
             _LOGGER.debug("Removing zeroconf listener for %s", self.name)
+            if TYPE_CHECKING:
+                assert self._zc_listener is not None
             self._zeroconf_manager.get_async_zeroconf().zeroconf.async_remove_listener(
-                self
+                self._zc_listener
             )
             self._zc_listening = False
 
@@ -553,9 +662,9 @@ class ReconnectLogic(zeroconf.RecordUpdateListener):
 
     def async_update_records(
         self,
-        zc: zeroconf.Zeroconf,  # noqa: ARG002 # pylint: disable=unused-argument
+        zc: Zeroconf,  # noqa: ARG002 # pylint: disable=unused-argument
         now: float,  # noqa: ARG002 # pylint: disable=unused-argument
-        records: list[zeroconf.RecordUpdate],
+        records: list[RecordUpdate],
     ) -> None:
         """Listen to zeroconf updated mDNS records. This must be called from the eventloop.
 

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -46,7 +46,6 @@ ADDRESS_RECORD_TYPES = {TYPE_A, TYPE_AAAA}
 ZC_LISTEN_DELAY = 2.0
 
 _zc_listener_cache: list[type[ReconnectRecordUpdateListener]] = []
-_zc_listener_import_locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
 
 
 def _import_zc_listener() -> type[ReconnectRecordUpdateListener]:
@@ -55,29 +54,6 @@ def _import_zc_listener() -> type[ReconnectRecordUpdateListener]:
     if not _zc_listener_cache:
         _zc_listener_cache.append(ReconnectRecordUpdateListener)
     return ReconnectRecordUpdateListener
-
-
-async def _async_load_zc_listener(
-    loop: asyncio.AbstractEventLoop,
-) -> type[ReconnectRecordUpdateListener]:
-    """Load the listener class, importing off the loop on the first cold import.
-
-    The import pulls in the zeroconf package, which does blocking file I/O;
-    running it in the executor keeps the event loop unblocked. The resolved
-    class is cached once the import fully completes, so later starts skip the
-    import entirely and a task racing the first cold import waits on the lock
-    instead of re-running the import on the loop thread.
-    """
-    if _zc_listener_cache:
-        return _zc_listener_cache[0]
-    lock = _zc_listener_import_locks.get(loop)
-    if lock is None:
-        lock = _zc_listener_import_locks[loop] = asyncio.Lock()
-    async with lock:
-        # Another task may have completed the import while we waited.
-        if _zc_listener_cache:
-            return _zc_listener_cache[0]
-        return await loop.run_in_executor(None, _import_zc_listener)
 
 
 EXPECTED_DISCONNECT_COOLDOWN = 5.0
@@ -159,6 +135,7 @@ class ReconnectLogic:
             self.name = client.address.partition(".")[0]
         if self.name:
             self._cli.set_cached_name_if_unset(self.name)
+        self._zc_eligible = bool(self.name) and not self._is_ip_address
         # Caps the reconnect backoff so a short awake window is not missed. A
         # consumer may seed it before the first connect as a bootstrap hint
         # (e.g. from persisted DeviceInfo, so a restart caps from the first
@@ -455,7 +432,7 @@ class ReconnectLogic:
                 return
             # Not connected; bring the listener up for the backoff wait
             # instead of waiting out the remainder of the arm timer.
-            await self._async_start_zc_listen()
+            self._start_zc_listen_soon()
             tries = min(self._tries, 10)  # prevent OverflowError
             max_backoff = (
                 DEEP_SLEEP_MAXIMUM_BACKOFF if self.deep_sleep else MAXIMUM_BACKOFF
@@ -564,24 +541,30 @@ class ReconnectLogic:
         ZC_LISTEN_DELAY cancels the timer before it fires.
         """
         if (
-            not self._zc_listening
+            self._zc_eligible
+            and not self._zc_listening
             and self._zc_listen_timer is None
             and self._zc_listen_start_task is None
-            and self.name
-            and not self._is_ip_address
         ):
             self._zc_listen_timer = self.loop.call_later(
-                ZC_LISTEN_DELAY, self._fire_zc_listen_timer
+                ZC_LISTEN_DELAY, self._start_zc_listen_soon
             )
 
-    def _fire_zc_listen_timer(self) -> None:
-        """Start the listener from the arm timer via a task for the cold import."""
-        self._zc_listen_timer = None
-        self._zc_listen_start_task = create_eager_task(
-            self._async_start_zc_listen(),
-            name=f"{self._cli.log_name}: aioesphomeapi start zc listen",
-        )
-        self._zc_listen_start_task.add_done_callback(self._remove_zc_listen_start_task)
+    def _start_zc_listen_soon(self) -> None:
+        """Start the listener via a task so the cold import stays off the loop."""
+        self._cancel_zc_listen_timer()
+        if (
+            self._zc_eligible
+            and not self._zc_listening
+            and self._zc_listen_start_task is None
+        ):
+            self._zc_listen_start_task = create_eager_task(
+                self._async_start_zc_listen(),
+                name=f"{self._cli.log_name}: aioesphomeapi start zc listen",
+            )
+            self._zc_listen_start_task.add_done_callback(
+                self._remove_zc_listen_start_task
+            )
 
     def _remove_zc_listen_start_task(self, _fut: asyncio.Future[None]) -> None:
         self._zc_listen_start_task = None
@@ -592,18 +575,15 @@ class ReconnectLogic:
             # A failed import is retried inline by _start_zc_listen, which
             # owns logging the degraded no-mDNS-wake path.
             with contextlib.suppress(Exception):
-                await _async_load_zc_listener(self.loop)
+                await self.loop.run_in_executor(None, _import_zc_listener)
         if not self._is_stopped and self._connection_state in NOT_YET_CONNECTED_STATES:
             self._start_zc_listen()
 
     def _cancel_zc_listen_timer(self) -> None:
-        """Cancel the delayed mDNS listener start."""
+        """Cancel the delayed mDNS listener start timer."""
         if self._zc_listen_timer:
             self._zc_listen_timer.cancel()
             self._zc_listen_timer = None
-        if self._zc_listen_start_task:
-            self._zc_listen_start_task.cancel()
-            self._zc_listen_start_task = None
 
     def _start_zc_listen(self) -> None:
         """Listen for mDNS records.
@@ -615,8 +595,7 @@ class ReconnectLogic:
         connect attempt; the listener is a reconnect-speed
         optimisation, not a requirement for connecting.
         """
-        self._cancel_zc_listen_timer()
-        if not self._zc_listening and self.name and not self._is_ip_address:
+        if not self._zc_listening and self._zc_eligible:
             _LOGGER.debug("Starting zeroconf listener for %s", self.name)
             # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
             # Lowercase the match keys here and the incoming records below
@@ -625,10 +604,8 @@ class ReconnectLogic:
             self._ptr_alias = f"{self.name}._esphomelib._tcp.local.".lower()
             self._a_name = f"{self.name}.local.".lower()
             try:
-                from ._zc_listener import ReconnectRecordUpdateListener  # noqa: PLC0415
-
                 if self._zc_listener is None:
-                    self._zc_listener = ReconnectRecordUpdateListener(self)
+                    self._zc_listener = _import_zc_listener()(self)
                 async_zc = self._zeroconf_manager.get_async_zeroconf()
                 async_zc.zeroconf.async_add_listener(self._zc_listener, None)
             except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
@@ -646,6 +623,9 @@ class ReconnectLogic:
     def _stop_zc_listen(self) -> None:
         """Stop listening for zeroconf updates."""
         self._cancel_zc_listen_timer()
+        if self._zc_listen_start_task:
+            self._zc_listen_start_task.cancel()
+            self._zc_listen_start_task = None
         if self._zc_listening:
             _LOGGER.debug("Removing zeroconf listener for %s", self.name)
             if TYPE_CHECKING:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -111,7 +111,7 @@ class ZeroconfWake:
         # exponential backoff.
         self._ptr_alias: str | None = None
         self._a_name: str | None = None
-        if name:
+        if self._eligible:
             self._ptr_alias = f"{name}._esphomelib._tcp.local.".lower()
             self._a_name = f"{name}.local.".lower()
         self._listening = False
@@ -265,10 +265,6 @@ class ZeroconfWake:
     def _remove_start_task(self, fut: asyncio.Future[None]) -> None:
         if self._start_task is fut:
             self._start_task = None
-        if not fut.cancelled() and (exc := fut.exception()) is not None:
-            _LOGGER.debug(
-                "%s: zc listen start task failed: %s", self._client.log_name, exc
-            )
 
 
 class ReconnectLogic:

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -710,15 +710,3 @@ class ReconnectLogic:
     def _connect_from_zeroconf(self) -> None:
         """Connect from zeroconf."""
         self._schedule_connect(0.0)
-
-    def async_update_records(
-        self,
-        zc: Zeroconf,
-        now: float,
-        records: list[RecordUpdate],
-    ) -> None:
-        """Listen to zeroconf updated mDNS records. This must be called from the eventloop.
-
-        This is a mDNS record from the device and could mean it just woke up.
-        """
-        self._zc_wake.async_update_records(zc, now, records)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -574,8 +574,9 @@ class ReconnectLogic:
                 self._remove_zc_listen_start_task
             )
 
-    def _remove_zc_listen_start_task(self, _fut: asyncio.Future[None]) -> None:
-        self._zc_listen_start_task = None
+    def _remove_zc_listen_start_task(self, fut: asyncio.Future[None]) -> None:
+        if self._zc_listen_start_task is fut:
+            self._zc_listen_start_task = None
 
     async def _async_start_zc_listen(self) -> None:
         """Import the listener off the event loop, then start listening."""

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from enum import Enum
 import logging
 import time
@@ -46,6 +45,10 @@ _zc_listener_cache: list[type[ReconnectRecordUpdateListener]] = []
 
 
 def _import_zc_listener() -> type[ReconnectRecordUpdateListener]:
+    # Preload zeroconf.asyncio too; start() needs it via get_async_zeroconf
+    # and it is not pulled in by the top-level zeroconf import.
+    import zeroconf.asyncio  # noqa: F401, PLC0415
+
     from ._zc_listener import ReconnectRecordUpdateListener  # noqa: PLC0415
 
     if not _zc_listener_cache:
@@ -91,7 +94,6 @@ class ZeroconfWake:
         client: APIClient,
         name: str | None,
         can_kick: Callable[[], bool],
-        log_level: Callable[[], int],
         on_wake: Callable[[], None],
     ) -> None:
         """Initialize the wake listener; can_kick gates records, on_wake kicks a connect."""
@@ -100,8 +102,8 @@ class ZeroconfWake:
         self._name = name
         self._eligible = bool(name) and not is_ip_address(name)
         self._can_kick = can_kick
-        self._log_level = log_level
         self._on_wake = on_wake
+        self._warned = False
         # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
         # Lowercase the match keys here and the incoming records in
         # async_update_records so a device advertising mixed-case labels
@@ -156,14 +158,17 @@ class ZeroconfWake:
                 async_zc = self._client.zeroconf_manager.get_async_zeroconf()
                 async_zc.zeroconf.async_add_listener(self._listener, None)
             except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+                # WARNING once per instance, DEBUG after, so a broken
+                # zeroconf stack is visible without spamming every retry.
                 _LOGGER.log(
-                    self._log_level(),
+                    logging.DEBUG if self._warned else logging.WARNING,
                     "Could not start zeroconf listener for %s: %s (%s); "
                     "continuing without mDNS-triggered reconnects",
                     self._client.log_name,
                     err,
                     type(err).__name__,
                 )
+                self._warned = True
                 return
             self._listening = True
 
@@ -231,10 +236,15 @@ class ZeroconfWake:
     async def _async_start(self) -> None:
         """Import the listener off the event loop, then start listening."""
         if not _zc_listener_cache:
-            # A failed import is retried inline by start(), which owns
-            # logging the degraded no-mDNS-wake path.
-            with contextlib.suppress(Exception):
+            try:
                 await self._loop.run_in_executor(None, _import_zc_listener)
+            except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+                # start() retries the import inline and logs if still failing.
+                _LOGGER.debug(
+                    "%s: off-loop zc listener import failed: %s",
+                    self._client.log_name,
+                    err,
+                )
         if self._can_kick():
             self.start()
 
@@ -255,6 +265,10 @@ class ZeroconfWake:
     def _remove_start_task(self, fut: asyncio.Future[None]) -> None:
         if self._start_task is fut:
             self._start_task = None
+        if not fut.cancelled() and (exc := fut.exception()) is not None:
+            _LOGGER.debug(
+                "%s: zc listen start task failed: %s", self._client.log_name, exc
+            )
 
 
 class ReconnectLogic:
@@ -327,7 +341,6 @@ class ReconnectLogic:
             client,
             self.name,
             self._zc_can_kick,
-            self._first_try_log_level,
             self._connect_from_zeroconf,
         )
         # How many connect attempts have there been already, used for exponential wait time

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -150,8 +150,16 @@ class ReconnectLogic:
         self._zeroconf_manager = client.zeroconf_manager
         if zeroconf_instance is not None:
             self._zeroconf_manager.set_instance(zeroconf_instance)
+        # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
+        # Lowercase the match keys here and the incoming records in
+        # async_update_records so a device advertising mixed-case labels
+        # still triggers the fast reconnect instead of falling back to
+        # exponential backoff.
         self._ptr_alias: str | None = None
         self._a_name: str | None = None
+        if self.name:
+            self._ptr_alias = f"{self.name}._esphomelib._tcp.local.".lower()
+            self._a_name = f"{self.name}.local.".lower()
         # Flag to check if the device is connected
         self._connection_state = ReconnectLogicState.DISCONNECTED
         self._accept_zeroconf_records: bool = True
@@ -597,12 +605,6 @@ class ReconnectLogic:
         """
         if not self._zc_listening and self._zc_eligible:
             _LOGGER.debug("Starting zeroconf listener for %s", self.name)
-            # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
-            # Lowercase the match keys here and the incoming records below
-            # so a device advertising mixed-case labels still triggers the
-            # fast reconnect instead of falling back to exponential backoff.
-            self._ptr_alias = f"{self.name}._esphomelib._tcp.local.".lower()
-            self._a_name = f"{self.name}.local.".lower()
             try:
                 if self._zc_listener is None:
                     self._zc_listener = _import_zc_listener()(self)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -86,6 +86,186 @@ AUTH_EXCEPTIONS = (
 )
 
 
+class ZeroconfWake:
+    """Deferred mDNS listener that wakes a reconnect attempt when its device announces."""
+
+    def __init__(
+        self,
+        client: APIClient,
+        name: str | None,
+        can_kick: Callable[[], bool],
+        log_level: Callable[[], int],
+        on_wake: Callable[[], None],
+    ) -> None:
+        """Initialize the wake listener; can_kick gates records, on_wake kicks a connect."""
+        self._loop = asyncio.get_running_loop()
+        self._client = client
+        self._name = name
+        self._eligible = bool(name) and not is_ip_address(name)
+        self._can_kick = can_kick
+        self._log_level = log_level
+        self._on_wake = on_wake
+        # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
+        # Lowercase the match keys here and the incoming records in
+        # async_update_records so a device advertising mixed-case labels
+        # still triggers the fast reconnect instead of falling back to
+        # exponential backoff.
+        self._ptr_alias: str | None = None
+        self._a_name: str | None = None
+        if name:
+            self._ptr_alias = f"{name}._esphomelib._tcp.local.".lower()
+            self._a_name = f"{name}.local.".lower()
+        self._listening = False
+        self._listener: ReconnectRecordUpdateListener | None = None
+        self._timer: asyncio.TimerHandle | None = None
+        self._start_task: asyncio.Task[None] | None = None
+        # One-shot gate so a single connect attempt is only kicked once
+        # per mDNS record burst.
+        self._accept_records = True
+
+    def reopen(self) -> None:
+        """Allow the next matching mDNS record to kick a connect again."""
+        self._accept_records = True
+
+    def arm(self) -> None:
+        """Arm the delayed listener start for a connect attempt.
+
+        Deferring the start keeps the zeroconf stack (import, sockets)
+        entirely off the fast path: a connect that lands within
+        ZC_LISTEN_DELAY cancels the timer before it fires.
+        """
+        if self._startable() and self._timer is None:
+            self._timer = self._loop.call_later(ZC_LISTEN_DELAY, self.start_soon)
+
+    def start_soon(self) -> None:
+        """Start the listener via a task so the cold import stays off the loop."""
+        self._cancel_timer()
+        if self._startable():
+            self._start_task = create_eager_task(
+                self._async_start(),
+                name=f"{self._client.log_name}: aioesphomeapi start zc listen",
+            )
+            self._start_task.add_done_callback(self._remove_start_task)
+
+    def start(self) -> None:
+        """Listen for mDNS records.
+
+        This listener allows us to schedule a connect as soon as a
+        received mDNS record indicates the node is up again. Failures
+        to start the zeroconf stack (e.g. port 5353 already bound on
+        BSD-derived systems running avahi) must not prevent the
+        connect attempt; the listener is a reconnect-speed
+        optimisation, not a requirement for connecting.
+        """
+        if not self._listening and self._eligible:
+            _LOGGER.debug("Starting zeroconf listener for %s", self._name)
+            try:
+                if self._listener is None:
+                    self._listener = _import_zc_listener()(self)
+                async_zc = self._client.zeroconf_manager.get_async_zeroconf()
+                async_zc.zeroconf.async_add_listener(self._listener, None)
+            except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+                _LOGGER.log(
+                    self._log_level(),
+                    "Could not start zeroconf listener for %s: %s (%s); "
+                    "continuing without mDNS-triggered reconnects",
+                    self._client.log_name,
+                    err,
+                    type(err).__name__,
+                )
+                return
+            self._listening = True
+
+    def stop(self) -> None:
+        """Stop listening for zeroconf updates."""
+        self._cancel_timer()
+        if self._start_task:
+            self._start_task.cancel()
+            self._start_task = None
+        if self._listening:
+            _LOGGER.debug("Removing zeroconf listener for %s", self._name)
+            if TYPE_CHECKING:
+                assert self._listener is not None
+            zc = self._client.zeroconf_manager.get_async_zeroconf().zeroconf
+            zc.async_remove_listener(self._listener)
+            self._listening = False
+
+    def async_update_records(
+        self,
+        zc: Zeroconf,  # noqa: ARG002 # pylint: disable=unused-argument
+        now: float,  # noqa: ARG002 # pylint: disable=unused-argument
+        records: list[RecordUpdate],
+    ) -> None:
+        """Handle updated mDNS records. This must be called from the eventloop.
+
+        This is a mDNS record from the device and could mean it just woke up.
+        """
+        # Bail if the current attempt has already been kicked by a previous
+        # mDNS record (one-shot gate) or if a kick could no longer help
+        # (stopped, or past the point where a restart matters).
+        if not self._accept_records or not self._can_kick():
+            return
+
+        for record_update in records:
+            # We only consider A, AAAA, and PTR records and match using the alias name
+            new_record = record_update.new
+            if not (
+                (
+                    new_record.type == TYPE_PTR
+                    and new_record.alias.lower() == self._ptr_alias  # type: ignore[attr-defined]
+                )
+                or (
+                    new_record.type in ADDRESS_RECORD_TYPES
+                    and new_record.name.lower() == self._a_name
+                )
+            ):
+                continue
+
+            # Tell connection logic to retry connection attempt now (even before connect timer finishes)
+            _LOGGER.debug(
+                "%s: Triggering connect because of received mDNS record %s",
+                self._client.log_name,
+                record_update.new,
+            )
+            #
+            # If we scheduled the connect attempt immediately, the listener could fire
+            # again before the connect attempt and we cancel and reschedule the connect
+            # attempt again.
+            #
+            self.stop()
+            self._on_wake()
+            self._accept_records = False
+            return
+
+    async def _async_start(self) -> None:
+        """Import the listener off the event loop, then start listening."""
+        if not _zc_listener_cache:
+            # A failed import is retried inline by start(), which owns
+            # logging the degraded no-mDNS-wake path.
+            with contextlib.suppress(Exception):
+                await self._loop.run_in_executor(None, _import_zc_listener)
+        if self._can_kick():
+            self.start()
+
+    def _startable(self) -> bool:
+        """Return True when the listener may be armed or started."""
+        return (
+            self._eligible
+            and not self._listening
+            and (self._start_task is None or self._start_task.done())
+        )
+
+    def _cancel_timer(self) -> None:
+        """Cancel the delayed listener start timer."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+
+    def _remove_start_task(self, fut: asyncio.Future[None]) -> None:
+        if self._start_task is fut:
+            self._start_task = None
+
+
 class ReconnectLogic:
     """Reconnectiong logic handler for ESPHome config entries.
 
@@ -128,14 +308,12 @@ class ReconnectLogic:
         self.loop = asyncio.get_running_loop()
         self._cli = client
         self.name: str | None = None
-        self._is_ip_address = is_ip_address(name)
         if name:
             self.name = name
         elif host_is_name_part(client.address) or address_is_local(client.address):
             self.name = client.address.partition(".")[0]
         if self.name:
             self._cli.set_cached_name_if_unset(self.name)
-        self._zc_eligible = bool(self.name) and not self._is_ip_address
         # Caps the reconnect backoff so a short awake window is not missed. A
         # consumer may seed it before the first connect as a bootstrap hint
         # (e.g. from persisted DeviceInfo, so a restart caps from the first
@@ -150,25 +328,17 @@ class ReconnectLogic:
         self._zeroconf_manager = client.zeroconf_manager
         if zeroconf_instance is not None:
             self._zeroconf_manager.set_instance(zeroconf_instance)
-        # RFC 6762 §16 / RFC 4343: mDNS labels are case-insensitive.
-        # Lowercase the match keys here and the incoming records in
-        # async_update_records so a device advertising mixed-case labels
-        # still triggers the fast reconnect instead of falling back to
-        # exponential backoff.
-        self._ptr_alias: str | None = None
-        self._a_name: str | None = None
-        if self.name:
-            self._ptr_alias = f"{self.name}._esphomelib._tcp.local.".lower()
-            self._a_name = f"{self.name}.local.".lower()
         # Flag to check if the device is connected
         self._connection_state = ReconnectLogicState.DISCONNECTED
-        self._accept_zeroconf_records: bool = True
         self._connected_lock = asyncio.Lock()
         self._is_stopped = True
-        self._zc_listening = False
-        self._zc_listener: ReconnectRecordUpdateListener | None = None
-        self._zc_listen_timer: asyncio.TimerHandle | None = None
-        self._zc_listen_start_task: asyncio.Task[None] | None = None
+        self._zc_wake = ZeroconfWake(
+            client,
+            self.name,
+            self._zc_can_kick,
+            self._first_try_log_level,
+            self._connect_from_zeroconf,
+        )
         # How many connect attempts have there been already, used for exponential wait time
         self._tries = 0
         # Event for tracking when logic should stop
@@ -207,7 +377,7 @@ class ReconnectLogic:
             )
             # The previous session ended — allow the next mDNS record to
             # kick a fresh connect attempt early.
-            self._accept_zeroconf_records = True
+            self._zc_wake.reopen()
             await self._on_disconnect_cb(expected_disconnect)
 
         if not self._is_stopped:
@@ -291,7 +461,7 @@ class ReconnectLogic:
         _LOGGER.info(
             "Successfully connected to %s in %0.3fs", self._cli.log_name, connect_time
         )
-        self._stop_zc_listen()
+        self._zc_wake.stop()
         self._async_set_connection_state_while_locked(ReconnectLogicState.HANDSHAKING)
         try:
             await self._cli.finish_connection(login=True)
@@ -320,7 +490,7 @@ class ReconnectLogic:
         self._async_set_connection_state_while_locked(ReconnectLogicState.DISCONNECTED)
         # The attempt has truly ended — allow the next mDNS record to
         # kick a fresh connect attempt early.
-        self._accept_zeroconf_records = True
+        self._zc_wake.reopen()
         if self._on_connect_error_cb is not None:
             await self._on_connect_error_cb(err)
         self._async_log_connection_error(err)
@@ -435,12 +605,12 @@ class ReconnectLogic:
                 or self._is_stopped
             ):
                 return
-            self._schedule_zc_listen()
+            self._zc_wake.arm()
             if await self._try_connect():
                 return
             # Not connected; bring the listener up for the backoff wait
             # instead of waiting out the remainder of the arm timer.
-            self._start_zc_listen_soon()
+            self._zc_wake.start_soon()
             tries = min(self._tries, 10)  # prevent OverflowError
             max_backoff = (
                 DEEP_SLEEP_MAXIMUM_BACKOFF if self.deep_sleep else MAXIMUM_BACKOFF
@@ -497,7 +667,7 @@ class ReconnectLogic:
             )
         # Re-arm the one-kick-per-attempt mDNS gate for the attempt this
         # schedules; harmless if _call_connect_once declines.
-        self._accept_zeroconf_records = True
+        self._zc_wake.reopen()
         self._schedule_connect(0.0)
 
     async def start(self) -> None:
@@ -509,7 +679,7 @@ class ReconnectLogic:
             self._tries = 0
             # Clear any stale gate from a prior run that was stopped mid
             # attempt after an mDNS triggered restart.
-            self._accept_zeroconf_records = True
+            self._zc_wake.reopen()
             if self._unsub_addresses_changed is None:
                 self._unsub_addresses_changed = (
                     self._cli.register_addresses_changed_callback(
@@ -534,161 +704,31 @@ class ReconnectLogic:
             self._is_stopped = True
             # Cancel again while holding the lock
             self._cancel_connect("Stopping")
-            self._stop_zc_listen()
+            self._zc_wake.stop()
             self._async_set_connection_state_while_locked(
                 ReconnectLogicState.DISCONNECTED
             )
 
         await self._zeroconf_manager.async_close()
 
-    def _schedule_zc_listen(self) -> None:
-        """Arm the delayed mDNS listener start for a connect attempt.
-
-        Deferring the start keeps the zeroconf stack (import, sockets)
-        entirely off the fast path: a connect that lands within
-        ZC_LISTEN_DELAY cancels the timer before it fires.
-        """
-        if (
-            self._zc_eligible
-            and not self._zc_listening
-            and self._zc_listen_timer is None
-            and self._zc_listen_start_task is None
-        ):
-            self._zc_listen_timer = self.loop.call_later(
-                ZC_LISTEN_DELAY, self._start_zc_listen_soon
-            )
-
-    def _start_zc_listen_soon(self) -> None:
-        """Start the listener via a task so the cold import stays off the loop."""
-        self._cancel_zc_listen_timer()
-        if (
-            self._zc_eligible
-            and not self._zc_listening
-            and self._zc_listen_start_task is None
-        ):
-            self._zc_listen_start_task = create_eager_task(
-                self._async_start_zc_listen(),
-                name=f"{self._cli.log_name}: aioesphomeapi start zc listen",
-            )
-            self._zc_listen_start_task.add_done_callback(
-                self._remove_zc_listen_start_task
-            )
-
-    def _remove_zc_listen_start_task(self, fut: asyncio.Future[None]) -> None:
-        if self._zc_listen_start_task is fut:
-            self._zc_listen_start_task = None
-
-    async def _async_start_zc_listen(self) -> None:
-        """Import the listener off the event loop, then start listening."""
-        if not _zc_listener_cache:
-            # A failed import is retried inline by _start_zc_listen, which
-            # owns logging the degraded no-mDNS-wake path.
-            with contextlib.suppress(Exception):
-                await self.loop.run_in_executor(None, _import_zc_listener)
-        if not self._is_stopped and self._connection_state in NOT_YET_CONNECTED_STATES:
-            self._start_zc_listen()
-
-    def _cancel_zc_listen_timer(self) -> None:
-        """Cancel the delayed mDNS listener start timer."""
-        if self._zc_listen_timer:
-            self._zc_listen_timer.cancel()
-            self._zc_listen_timer = None
-
-    def _start_zc_listen(self) -> None:
-        """Listen for mDNS records.
-
-        This listener allows us to schedule a connect as soon as a
-        received mDNS record indicates the node is up again. Failures
-        to start the zeroconf stack (e.g. port 5353 already bound on
-        BSD-derived systems running avahi) must not prevent the
-        connect attempt; the listener is a reconnect-speed
-        optimisation, not a requirement for connecting.
-        """
-        if not self._zc_listening and self._zc_eligible:
-            _LOGGER.debug("Starting zeroconf listener for %s", self.name)
-            try:
-                if self._zc_listener is None:
-                    self._zc_listener = _import_zc_listener()(self)
-                async_zc = self._zeroconf_manager.get_async_zeroconf()
-                async_zc.zeroconf.async_add_listener(self._zc_listener, None)
-            except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
-                _LOGGER.log(
-                    self._first_try_log_level(),
-                    "Could not start zeroconf listener for %s: %s (%s); "
-                    "continuing without mDNS-triggered reconnects",
-                    self._cli.log_name,
-                    err,
-                    type(err).__name__,
-                )
-                return
-            self._zc_listening = True
-
-    def _stop_zc_listen(self) -> None:
-        """Stop listening for zeroconf updates."""
-        self._cancel_zc_listen_timer()
-        if self._zc_listen_start_task:
-            self._zc_listen_start_task.cancel()
-            self._zc_listen_start_task = None
-        if self._zc_listening:
-            _LOGGER.debug("Removing zeroconf listener for %s", self.name)
-            if TYPE_CHECKING:
-                assert self._zc_listener is not None
-            self._zeroconf_manager.get_async_zeroconf().zeroconf.async_remove_listener(
-                self._zc_listener
-            )
-            self._zc_listening = False
+    def _zc_can_kick(self) -> bool:
+        """Return True while an mDNS record could still usefully kick a connect."""
+        return (
+            not self._is_stopped and self._connection_state in NOT_YET_CONNECTED_STATES
+        )
 
     def _connect_from_zeroconf(self) -> None:
         """Connect from zeroconf."""
-        self._stop_zc_listen()
         self._schedule_connect(0.0)
 
     def async_update_records(
         self,
-        zc: Zeroconf,  # noqa: ARG002 # pylint: disable=unused-argument
-        now: float,  # noqa: ARG002 # pylint: disable=unused-argument
+        zc: Zeroconf,
+        now: float,
         records: list[RecordUpdate],
     ) -> None:
         """Listen to zeroconf updated mDNS records. This must be called from the eventloop.
 
         This is a mDNS record from the device and could mean it just woke up.
         """
-        # Bail if we've been stopped, if the current attempt has already been
-        # kicked by a previous mDNS record (one-shot gate), or if we're past
-        # the point where a restart could still help (HANDSHAKING / READY).
-        if (
-            not self._accept_zeroconf_records
-            or self._is_stopped
-            or self._connection_state not in NOT_YET_CONNECTED_STATES
-        ):
-            return
-
-        for record_update in records:
-            # We only consider A, AAAA, and PTR records and match using the alias name
-            new_record = record_update.new
-            if not (
-                (
-                    new_record.type == TYPE_PTR
-                    and new_record.alias.lower() == self._ptr_alias  # type: ignore[attr-defined]
-                )
-                or (
-                    new_record.type in ADDRESS_RECORD_TYPES
-                    and new_record.name.lower() == self._a_name
-                )
-            ):
-                continue
-
-            # Tell connection logic to retry connection attempt now (even before connect timer finishes)
-            _LOGGER.debug(
-                "%s: Triggering connect because of received mDNS record %s",
-                self._cli.log_name,
-                record_update.new,
-            )
-            #
-            # If we scheduled the connect attempt immediately, the listener could fire
-            # again before the connect attempt and we cancel and reschedule the connect
-            # attempt again.
-            #
-            self._connect_from_zeroconf()
-            self._accept_zeroconf_records = False
-            return
+        self._zc_wake.async_update_records(zc, now, records)

--- a/aioesphomeapi/reconnect_logic.py
+++ b/aioesphomeapi/reconnect_logic.py
@@ -29,20 +29,17 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# DNS record type codes (RFC 1035/3596), duplicated from zeroconf.const and
-# pinned against it in tests so this module does not import zeroconf at load
-# time.
+# DNS record type codes (RFC 1035/3596), duplicated from zeroconf.const
+# (pinned in tests) so this module does not import zeroconf at load time.
 TYPE_A = 1
 TYPE_PTR = 12
 TYPE_AAAA = 28
 
 ADDRESS_RECORD_TYPES = {TYPE_A, TYPE_AAAA}
 
-# How long a connect attempt may stay in flight before the mDNS listener is
-# started anyway, so a device that comes online mid-attempt (our SYN lost
-# while it was still booting) is caught by its boot announcement instead of
-# waiting out a TCP timeout. Connects that land within this window never
-# load the zeroconf stack at all.
+# Connects that land within this window never load the zeroconf stack; an
+# attempt still in flight when it fires gets the listener so a device that
+# came online mid-attempt is woken by its boot announcement.
 ZC_LISTEN_DELAY = 2.0
 
 _zc_listener_cache: list[type[ReconnectRecordUpdateListener]] = []
@@ -119,8 +116,7 @@ class ZeroconfWake:
         self._listener: ReconnectRecordUpdateListener | None = None
         self._timer: asyncio.TimerHandle | None = None
         self._start_task: asyncio.Task[None] | None = None
-        # One-shot gate so a single connect attempt is only kicked once
-        # per mDNS record burst.
+        # One-shot gate: a connect attempt is only kicked once per record burst.
         self._accept_records = True
 
     def reopen(self) -> None:
@@ -128,12 +124,7 @@ class ZeroconfWake:
         self._accept_records = True
 
     def arm(self) -> None:
-        """Arm the delayed listener start for a connect attempt.
-
-        Deferring the start keeps the zeroconf stack (import, sockets)
-        entirely off the fast path: a connect that lands within
-        ZC_LISTEN_DELAY cancels the timer before it fires.
-        """
+        """Arm the delayed listener start for a connect attempt."""
         if self._startable() and self._timer is None:
             self._timer = self._loop.call_later(ZC_LISTEN_DELAY, self.start_soon)
 
@@ -608,8 +599,7 @@ class ReconnectLogic:
             self._zc_wake.arm()
             if await self._try_connect():
                 return
-            # Not connected; bring the listener up for the backoff wait
-            # instead of waiting out the remainder of the arm timer.
+            # Listen during the backoff wait without waiting out the arm timer.
             self._zc_wake.start_soon()
             tries = min(self._tries, 10)  # prevent OverflowError
             max_backoff = (

--- a/aioesphomeapi/zeroconf.py
+++ b/aioesphomeapi/zeroconf.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from zeroconf import Zeroconf
-from zeroconf.asyncio import AsyncZeroconf
+if TYPE_CHECKING:
+    from zeroconf import Zeroconf
+    from zeroconf.asyncio import AsyncZeroconf
 
-ZeroconfInstanceType = Zeroconf | AsyncZeroconf
+    ZeroconfInstanceType = Zeroconf | AsyncZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +34,9 @@ class ZeroconfManager:
 
     def set_instance(self, zc: AsyncZeroconf | Zeroconf) -> None:
         """Set the AsyncZeroconf instance."""
+        from zeroconf import Zeroconf  # noqa: PLC0415
+        from zeroconf.asyncio import AsyncZeroconf  # noqa: PLC0415
+
         if self._aiozc:
             if isinstance(zc, AsyncZeroconf) and self._aiozc.zeroconf is zc.zeroconf:
                 return
@@ -45,6 +49,8 @@ class ZeroconfManager:
 
     def _create_async_zeroconf(self) -> None:
         """Create an AsyncZeroconf instance."""
+        from zeroconf.asyncio import AsyncZeroconf  # noqa: PLC0415
+
         _LOGGER.debug("Creating new AsyncZeroconf instance")
         self._aiozc = AsyncZeroconf()
         self._created = True

--- a/tests/test_host_resolver.py
+++ b/tests/test_host_resolver.py
@@ -76,8 +76,8 @@ async def test_resolve_host_zeroconf(async_zeroconf: AsyncZeroconf, addr_infos):
     ]
     info.async_request = AsyncMock(return_value=True)
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
-        patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncZeroconf", return_value=async_zeroconf),
     ):
         ret = await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
@@ -93,7 +93,7 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
         [ipv6],
     ]
     info.async_request = AsyncMock(return_value=True)
-    with patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info):
+    with patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info):
         ret = await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
 
     info.async_request.assert_called_once()
@@ -102,9 +102,7 @@ async def test_resolve_host_passed_zeroconf(addr_infos, async_zeroconf):
 
 
 async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
-    with patch(
-        "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request"
-    ) as mock_async_request:
+    with patch("zeroconf.asyncio.AsyncServiceInfo.async_request") as mock_async_request:
         ret = await hr._async_resolve_short_host_zeroconf(
             async_zeroconf, "asdf.local", 6052
         )
@@ -115,7 +113,7 @@ async def test_resolve_host_zeroconf_empty(async_zeroconf: AsyncZeroconf):
 async def test_resolve_host_zeroconf_fails(async_zeroconf: AsyncZeroconf):
     with (
         patch(
-            "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
+            "zeroconf.asyncio.AsyncServiceInfo.async_request",
             side_effect=Exception("no buffers"),
         ),
         pytest.raises(ResolveAPIError, match="no buffers"),
@@ -270,7 +268,7 @@ async def test_resolve_host_mdns_and_dns_slow_mdns_wins(
         return []
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", slow_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -302,7 +300,7 @@ async def test_resolve_host_mdns_and_dns_exception_mdns_wins(
         raise OSError(None, "DNS exception")
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", slow_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -334,7 +332,7 @@ async def test_resolve_host_mdns_and_dns_fast_mdns_wins(
         return []
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", slow_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -377,7 +375,7 @@ async def test_resolve_host_mdns_and_dns_slow_dns_wins(
         return mock_getaddrinfo
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", slow_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -418,7 +416,7 @@ async def test_resolve_host_mdns_and_mdns_exception_dns_wins(
         return mock_getaddrinfo
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", fast_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -453,7 +451,7 @@ async def test_resolve_host_mdns_and_mdns_no_results_dns_wins(
         return mock_getaddrinfo
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", fast_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -493,7 +491,7 @@ async def test_resolve_host_mdns_and_dns_fast_dns_wins(
         raise OSError(msg)
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", fast_getaddrinfo),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -512,7 +510,7 @@ async def test_resolve_host_mdns_cache(addr_infos: list[AddrInfo]) -> None:
     ]
     info.async_request = AsyncMock(return_value=False)
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo") as mock_getaddrinfo,
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -539,7 +537,7 @@ async def test_resolve_host_mdns_and_mdns_both_fail(
         raise OSError(None, "DNS exception")
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", fast_fail_getaddrinfo),
         pytest.raises(ResolveAPIError, match="DNS exception"),
     ):
@@ -572,7 +570,7 @@ async def test_resolve_host_mdns_and_dns_slow_all_timeout(
         return mock_getaddrinfo
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", slow_getaddrinfo),
         pytest.raises(ResolveTimeoutAPIError, match="x"),
     ):
@@ -599,7 +597,7 @@ async def test_resolve_host_mdns_empty(resolve_addr, resolve_zc, addr_infos):
         assert addr in ret
 
 
-@patch("aioesphomeapi.host_resolver.AsyncServiceInfo.async_request", return_value=False)
+@patch("zeroconf.asyncio.AsyncServiceInfo.async_request", return_value=False)
 @patch("aioesphomeapi.host_resolver._async_resolve_host_getaddrinfo")
 async def test_resolve_host_mdns_no_results(resolve_addr, addr_infos):
     resolve_addr.return_value = addr_infos
@@ -778,7 +776,7 @@ async def test_resolve_host_local_suffix_fallback_wins(
         raise OSError(msg)
 
     with (
-        patch("aioesphomeapi.host_resolver.AsyncServiceInfo", return_value=info),
+        patch("zeroconf.asyncio.AsyncServiceInfo", return_value=info),
         patch.object(loop, "getaddrinfo", getaddrinfo_with_fallback),
     ):
         ret = await hr.async_resolve_host(["example.local"], 6052)
@@ -817,10 +815,10 @@ async def test_resolve_host_zeroconf_service_info_oserror(
     info.async_request = AsyncMock(return_value=True)
     with (
         patch(
-            "aioesphomeapi.host_resolver.AsyncServiceInfo.async_request",
+            "zeroconf.asyncio.AsyncServiceInfo.async_request",
             side_effect=OSError("out of buffers"),
         ),
-        patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf),
+        patch("zeroconf.asyncio.AsyncZeroconf", return_value=async_zeroconf),
         pytest.raises(ResolveAPIError, match="out of buffers"),
     ):
         await hr._async_resolve_short_host_zeroconf(async_zeroconf, "asdf", 6052)
@@ -838,7 +836,7 @@ async def test_resolve_host_create_zeroconf_oserror(
     info.async_request = AsyncMock(return_value=True)
     with (
         patch(
-            "aioesphomeapi.zeroconf.AsyncZeroconf",
+            "zeroconf.asyncio.AsyncZeroconf",
             side_effect=OSError("out of buffers"),
         ),
         pytest.raises(ResolveAPIError, match="out of buffers"),

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -45,6 +45,16 @@ TZ_DEFERRED_MODULES = (
 )
 
 
+# Modules that must only load when mDNS is actually used: resolution of a
+# .local name, or the mDNS-wake reconnect listener starting.
+ZEROCONF_DEFERRED_MODULES = (
+    "zeroconf",
+    "zeroconf.asyncio",
+    "ifaddr",
+    "aioesphomeapi._zc_listener",
+)
+
+
 def _assert_modules_not_loaded_on_import(modules: tuple[str, ...]) -> None:
     script = (
         "import sys, aioesphomeapi\n"
@@ -68,6 +78,11 @@ def test_import_does_not_load_noise_stack() -> None:
 def test_import_does_not_load_tz_or_uuid_modules() -> None:
     """Importing the package must not pull in uuid or the timezone stack."""
     _assert_modules_not_loaded_on_import(TZ_DEFERRED_MODULES)
+
+
+def test_import_does_not_load_zeroconf_stack() -> None:
+    """Importing the package must not pull in the zeroconf stack."""
+    _assert_modules_not_loaded_on_import(ZEROCONF_DEFERRED_MODULES)
 
 
 def test_explicit_timezone_does_not_load_tzlocal() -> None:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1736,6 +1736,44 @@ async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
     await logic.stop()
 
 
+async def test_zc_listen_import_failure_logged_and_retried_inline(
+    patchable_api_client: APIClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed off-loop import logs at DEBUG; start() retries inline and warns."""
+    cli = patchable_api_client
+    logic = ReconnectLogic(
+        client=cli,
+        on_connect=AsyncMock(),
+        on_disconnect=AsyncMock(),
+        on_connect_error=AsyncMock(),
+        name="mydevice",
+    )
+
+    with (
+        patch("aioesphomeapi.reconnect_logic._zc_listener_cache", []),
+        patch(
+            "aioesphomeapi.reconnect_logic._import_zc_listener",
+            side_effect=ImportError("boom"),
+        ),
+        patch.object(cli, "start_resolve_host", side_effect=APIConnectionError),
+    ):
+        await logic.start()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await drain_zc_start(logic)
+
+    assert (
+        find_log_with_message(caplog, "off-loop zc listener import failed") is not None
+    )
+    log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
+    assert log_record is not None
+    assert log_record.levelno == logging.WARNING
+    assert logic._zc_wake._listening is False
+
+    await logic.stop()
+
+
 async def test_addresses_changed_callback_lifecycle(
     patchable_api_client: APIClient,
 ) -> None:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1508,7 +1508,7 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         mock_get_zc.assert_not_called()
 
         # Firing the arm timer starts the listener for a device name
-        logic_with_name._fire_zc_listen_timer()
+        logic_with_name._start_zc_listen_soon()
         assert logic_with_name._zc_listen_start_task is not None
         await logic_with_name._zc_listen_start_task
         mock_get_zc.assert_called()
@@ -1951,6 +1951,8 @@ async def test_zc_listener_delegate_registered_on_failed_attempt(
             await rl.start()
             await asyncio.sleep(0)
             await asyncio.sleep(0)
+            if rl._zc_listen_start_task is not None:
+                await rl._zc_listen_start_task
 
             add_listener.assert_called_once()
             listener, question = add_listener.call_args[0]
@@ -2000,8 +2002,7 @@ async def test_zc_listener_starts_when_timer_fires_mid_attempt(
             await resolve_started.wait()
 
             assert rl._zc_listen_timer is not None
-            rl._cancel_zc_listen_timer()
-            rl._fire_zc_listen_timer()
+            rl._start_zc_listen_soon()
             assert rl._zc_listen_start_task is not None
             await rl._zc_listen_start_task
 

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1507,10 +1507,8 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         assert logic_with_name._zc_listen_timer is not None
         mock_get_zc.assert_not_called()
 
-        # Firing the arm timer starts the listener for a device name
-        logic_with_name._start_zc_listen_soon()
-        assert logic_with_name._zc_listen_start_task is not None
-        await logic_with_name._zc_listen_start_task
+        # Starting the listener for a device name calls get_async_zeroconf
+        logic_with_name._start_zc_listen()
         mock_get_zc.assert_called()
 
         await logic_with_name.stop()

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -625,7 +625,7 @@ async def test_reconnect_zeroconf(  # noqa: C901  # parametrized over many recor
             # For matching records, signal the resolver to complete
             resolve_event.set()
 
-        rl.async_update_records(
+        rl._zc_wake.async_update_records(
             mock_zeroconf, current_time_millis(), [RecordUpdate(record, None)]
         )
 
@@ -715,7 +715,7 @@ async def test_reconnect_zeroconf_cancels_connecting_no_socket(
         patch.object(cli, "start_connection") as mock_start_connection_2,
         patch.object(cli, "finish_connection"),
     ):
-        rl.async_update_records(
+        rl._zc_wake.async_update_records(
             mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
         )
 
@@ -783,7 +783,7 @@ async def test_reconnect_zeroconf_only_cancels_connecting_once(
         patch.object(cli, "finish_connection"),
     ):
         caplog.clear()
-        rl.async_update_records(
+        rl._zc_wake.async_update_records(
             mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
         )
         assert (
@@ -801,7 +801,7 @@ async def test_reconnect_zeroconf_only_cancels_connecting_once(
         # Subsequent mDNS records during the same attempt must be ignored.
         caplog.clear()
         for _ in range(5):
-            rl.async_update_records(
+            rl._zc_wake.async_update_records(
                 mock_zeroconf,
                 current_time_millis(),
                 [RecordUpdate(DNS_POINTER, None)],
@@ -915,7 +915,7 @@ async def test_reconnect_zeroconf_does_not_cancel_connecting_with_socket(
         return_value="192.168.1.5",
     ):
         # Now trigger zeroconf while in CONNECTING state with socket connected
-        rl.async_update_records(
+        rl._zc_wake.async_update_records(
             mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
         )
 
@@ -962,7 +962,7 @@ async def test_reconnect_zeroconf_cancels_pending_timer(
         patch.object(cli, "start_connection"),
         patch.object(cli, "finish_connection"),
     ):
-        rl.async_update_records(
+        rl._zc_wake.async_update_records(
             mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
         )
 
@@ -1028,7 +1028,7 @@ async def test_reconnect_zeroconf_not_while_handshaking(
         assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
-    rl.async_update_records(
+    rl._zc_wake.async_update_records(
         mock_zeroconf, current_time_millis(), [RecordUpdate(DNS_POINTER, None)]
     )
     assert (

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -75,6 +75,16 @@ def find_log_with_message(
     return None
 
 
+async def drain_zc_start(rl: ReconnectLogic) -> None:
+    """Wait out a pending deferred listener start.
+
+    A warm _zc_listener_cache completes the eager task synchronously,
+    so the task slot may already be cleared.
+    """
+    if (task := rl._zc_wake._start_task) is not None:
+        await task
+
+
 async def slow_connect_fail(*args, **kwargs):
     await asyncio.sleep(10)
     raise APIConnectionError
@@ -1642,7 +1652,6 @@ async def test_zc_listen_failure_does_not_block_connect(
         name="mydevice",
     )
 
-    caplog.clear()
     with patch.object(
         cli.zeroconf_manager,
         "get_async_zeroconf",
@@ -1652,9 +1661,9 @@ async def test_zc_listen_failure_does_not_block_connect(
             await logic.start()
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-            if logic._zc_wake._start_task is not None:
-                await logic._zc_wake._start_task
+            await drain_zc_start(logic)
 
+        assert on_connect_fail.call_count == 1
         # The first failed listener start warns
         log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
         assert log_record is not None, (
@@ -1711,16 +1720,14 @@ async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert logic._tries == 1
-        if logic._zc_wake._start_task is not None:
-            await logic._zc_wake._start_task
+        await drain_zc_start(logic)
 
         caplog.clear()
         assert logic._connect_timer is not None
         logic._connect_timer._run()
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        if logic._zc_wake._start_task is not None:
-            await logic._zc_wake._start_task
+        await drain_zc_start(logic)
 
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
     assert log_record is not None, "Expected zeroconf failure log was not emitted"
@@ -1960,13 +1967,11 @@ async def test_zc_listener_delegate_registered_on_failed_attempt(
             await rl.start()
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-            if rl._zc_wake._start_task is not None:
-                await rl._zc_wake._start_task
+            await drain_zc_start(rl)
 
             add_listener.assert_called_once()
             listener, question = add_listener.call_args[0]
             assert question is None
-            assert listener is not rl
             assert isinstance(listener, RecordUpdateListener)
 
             with patch.object(rl._zc_wake, "async_update_records") as mock_update:

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1643,34 +1643,41 @@ async def test_zc_listen_failure_does_not_block_connect(
     )
 
     caplog.clear()
-    with (
-        patch.object(
-            cli.zeroconf_manager,
-            "get_async_zeroconf",
-            side_effect=OSError(48, "Address already in use"),
-        ),
-        patch.object(cli, "start_resolve_host"),
-        patch.object(cli, "start_connection"),
-        patch.object(cli, "finish_connection"),
+    with patch.object(
+        cli.zeroconf_manager,
+        "get_async_zeroconf",
+        side_effect=OSError(48, "Address already in use"),
     ):
-        await logic.start()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        with patch.object(cli, "start_resolve_host", side_effect=APIConnectionError):
+            await logic.start()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            if logic._zc_wake._start_task is not None:
+                await logic._zc_wake._start_task
 
-        # The connection should have succeeded despite the zeroconf failure.
+        # The first failed listener start warns
+        log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
+        assert log_record is not None, (
+            "Expected zeroconf failure warning was not logged"
+        )
+        assert log_record.levelno == logging.WARNING
+        # _listening must remain False so stop() doesn't try to remove a
+        # listener we never added.
+        assert logic._zc_wake._listening is False
+
+        # The broken zeroconf stack must not block the next attempt
+        with (
+            patch.object(cli, "start_resolve_host"),
+            patch.object(cli, "start_connection"),
+            patch.object(cli, "finish_connection"),
+        ):
+            assert logic._connect_timer is not None
+            logic._connect_timer._run()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
         assert on_connect.call_count == 1
-        assert on_connect_fail.call_count == 0
         assert logic._connection_state is ReconnectLogicState.READY
-
-        # A broken zeroconf stack logs a warning, connection untouched
-        logic._zc_wake.start()
-
-    log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
-    assert log_record is not None, "Expected zeroconf failure warning was not logged"
-    assert log_record.levelno == logging.WARNING
-    # _listening must remain False so stop() doesn't try to remove a listener
-    # we never added.
-    assert logic._zc_wake._listening is False
 
     await logic.stop()
 
@@ -1704,6 +1711,8 @@ async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert logic._tries == 1
+        if logic._zc_wake._start_task is not None:
+            await logic._zc_wake._start_task
 
         caplog.clear()
         assert logic._connect_timer is not None

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -13,6 +13,7 @@ from zeroconf import (
     DNSPointer,
     DNSRecord,
     RecordUpdate,
+    RecordUpdateListener,
     Zeroconf,
     current_time_millis,
 )
@@ -34,6 +35,9 @@ from aioesphomeapi.reconnect_logic import (
     DEEP_SLEEP_MAXIMUM_BACKOFF,
     MAXIMUM_BACKOFF,
     MAXIMUM_BACKOFF_TRIES,
+    TYPE_A,
+    TYPE_AAAA,
+    TYPE_PTR,
     ReconnectLogic,
     ReconnectLogicState,
 )
@@ -1499,7 +1503,14 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         await logic_with_name.start()
         await asyncio.sleep(0)
 
-        # Should have called get_async_zeroconf for device name
+        # The listener start is deferred; the arm timer must be scheduled
+        assert logic_with_name._zc_listen_timer is not None
+        mock_get_zc.assert_not_called()
+
+        # Firing the arm timer starts the listener for a device name
+        logic_with_name._fire_zc_listen_timer()
+        assert logic_with_name._zc_listen_start_task is not None
+        await logic_with_name._zc_listen_start_task
         mock_get_zc.assert_called()
 
         await logic_with_name.stop()
@@ -1647,11 +1658,15 @@ async def test_zc_listen_failure_does_not_block_connect(
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
-    # The connection should have succeeded despite the zeroconf failure.
-    assert on_connect.call_count == 1
-    assert on_connect_fail.call_count == 0
-    assert logic._connection_state is ReconnectLogicState.READY
-    # The zeroconf failure should have been logged as a warning on the first try.
+        # The connection should have succeeded despite the zeroconf failure.
+        assert on_connect.call_count == 1
+        assert on_connect_fail.call_count == 0
+        assert logic._connection_state is ReconnectLogicState.READY
+
+        # Starting the listener with a broken zeroconf stack must log a
+        # warning and leave the connection untouched.
+        logic._start_zc_listen()
+
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
     assert log_record is not None, "Expected zeroconf failure warning was not logged"
     assert log_record.levelno == logging.WARNING
@@ -1867,3 +1882,133 @@ async def test_add_addresses_ignored_when_ready(
     assert rl._connection_state is ReconnectLogicState.READY
 
     await rl.stop()
+
+
+def test_zc_record_type_constants_match_zeroconf() -> None:
+    """The hardcoded DNS record type codes must match zeroconf's."""
+    assert TYPE_A == _TYPE_A
+    assert TYPE_AAAA == _TYPE_AAAA
+    assert TYPE_PTR == _TYPE_PTR
+
+
+@pytest.mark.asyncio
+async def test_zc_listen_timer_cancelled_on_fast_connect(
+    patchable_api_client: APIClient,
+) -> None:
+    """A connect landing before ZC_LISTEN_DELAY never touches zeroconf."""
+    cli = patchable_api_client
+
+    with patch.object(cli.zeroconf_manager, "get_async_zeroconf") as mock_get_zc:
+        rl = ReconnectLogic(
+            client=cli,
+            on_connect=AsyncMock(),
+            on_disconnect=AsyncMock(),
+            name="mydevice",
+        )
+        with (
+            patch.object(cli, "start_resolve_host"),
+            patch.object(cli, "start_connection"),
+            patch.object(cli, "finish_connection"),
+        ):
+            await rl.start()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        assert rl._connection_state is ReconnectLogicState.READY
+        assert rl._zc_listen_timer is None
+        assert rl._zc_listen_start_task is None
+        mock_get_zc.assert_not_called()
+
+        await rl.stop()
+
+
+@pytest.mark.asyncio
+async def test_zc_listener_delegate_registered_on_failed_attempt(
+    patchable_api_client: APIClient,
+) -> None:
+    """A failed attempt registers a delegate listener that forwards to the logic."""
+    cli = patchable_api_client
+    async_zeroconf = get_mock_async_zeroconf()
+
+    with patch.object(
+        cli.zeroconf_manager, "get_async_zeroconf", return_value=async_zeroconf
+    ):
+        rl = ReconnectLogic(
+            client=cli,
+            on_connect=AsyncMock(),
+            on_disconnect=AsyncMock(),
+            name="mydevice",
+        )
+        with (
+            patch.object(
+                cli, "start_resolve_host", side_effect=APIConnectionError("no dice")
+            ),
+            patch.object(async_zeroconf.zeroconf, "async_add_listener") as add_listener,
+            patch.object(
+                async_zeroconf.zeroconf, "async_remove_listener"
+            ) as remove_listener,
+        ):
+            await rl.start()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            add_listener.assert_called_once()
+            listener, question = add_listener.call_args[0]
+            assert question is None
+            assert listener is not rl
+            assert isinstance(listener, RecordUpdateListener)
+
+            with patch.object(rl, "async_update_records") as mock_update:
+                listener.async_update_records(async_zeroconf.zeroconf, 0.0, [])
+            mock_update.assert_called_once_with(async_zeroconf.zeroconf, 0.0, [])
+
+            await rl.stop()
+            remove_listener.assert_called_once_with(listener)
+
+
+@pytest.mark.asyncio
+async def test_zc_listener_starts_when_timer_fires_mid_attempt(
+    patchable_api_client: APIClient,
+) -> None:
+    """An attempt still in flight when the arm timer fires gets the listener."""
+    cli = patchable_api_client
+    async_zeroconf = get_mock_async_zeroconf()
+    resolve_started = asyncio.Event()
+    release_resolve = asyncio.Event()
+
+    async def _hanging_resolve(*args, **kwargs) -> None:
+        resolve_started.set()
+        await release_resolve.wait()
+        msg = "cancelled"
+        raise APIConnectionError(msg)
+
+    with patch.object(
+        cli.zeroconf_manager, "get_async_zeroconf", return_value=async_zeroconf
+    ):
+        rl = ReconnectLogic(
+            client=cli,
+            on_connect=AsyncMock(),
+            on_disconnect=AsyncMock(),
+            name="mydevice",
+        )
+        with (
+            patch.object(cli, "start_resolve_host", side_effect=_hanging_resolve),
+            patch.object(async_zeroconf.zeroconf, "async_add_listener") as add_listener,
+            patch.object(async_zeroconf.zeroconf, "async_remove_listener"),
+        ):
+            await rl.start()
+            await resolve_started.wait()
+
+            assert rl._zc_listen_timer is not None
+            rl._cancel_zc_listen_timer()
+            rl._fire_zc_listen_timer()
+            assert rl._zc_listen_start_task is not None
+            await rl._zc_listen_start_task
+
+            add_listener.assert_called_once()
+            assert rl._zc_listening is True
+
+            release_resolve.set()
+            await asyncio.sleep(0)
+
+            await rl.stop()

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -38,6 +38,7 @@ from aioesphomeapi.reconnect_logic import (
     TYPE_A,
     TYPE_AAAA,
     TYPE_PTR,
+    ZC_LISTEN_DELAY,
     ReconnectLogic,
     ReconnectLogicState,
 )
@@ -2001,7 +2002,10 @@ async def test_zc_listener_starts_when_timer_fires_mid_attempt(
             await resolve_started.wait()
 
             assert rl._zc_wake._timer is not None
-            rl._zc_wake.start_soon()
+            assert rl._zc_wake._timer.when() == pytest.approx(
+                rl.loop.time() + ZC_LISTEN_DELAY, abs=0.1
+            )
+            rl._zc_wake._timer._run()
             assert rl._zc_wake._start_task is not None
             await rl._zc_wake._start_task
 

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -1503,7 +1503,7 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         await logic_with_name.start()
         await asyncio.sleep(0)
 
-        # The listener start is deferred; the arm timer must be scheduled
+        # Deferred start: only the arm timer is scheduled
         assert logic_with_name._zc_wake._timer is not None
         mock_get_zc.assert_not_called()
 
@@ -1661,8 +1661,7 @@ async def test_zc_listen_failure_does_not_block_connect(
         assert on_connect_fail.call_count == 0
         assert logic._connection_state is ReconnectLogicState.READY
 
-        # Starting the listener with a broken zeroconf stack must log a
-        # warning and leave the connection untouched.
+        # A broken zeroconf stack logs a warning, connection untouched
         logic._zc_wake.start()
 
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")

--- a/tests/test_reconnect_logic.py
+++ b/tests/test_reconnect_logic.py
@@ -403,7 +403,7 @@ async def test_deep_sleep_caps_reconnect_backoff(
     loop = asyncio.get_running_loop()
     now = loop.time()
     with (
-        patch.object(rl, "_start_zc_listen"),
+        patch.object(rl._zc_wake, "start"),
         patch.object(rl, "_try_connect", AsyncMock(return_value=False)),
     ):
         await rl._connect_once_or_reschedule()
@@ -691,7 +691,7 @@ async def test_reconnect_zeroconf_cancels_connecting_no_socket(
         ) as mock_start_connection,
     ):
         assert rl._connection_state is ReconnectLogicState.DISCONNECTED
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
         assert rl._connect_timer is not None
@@ -701,7 +701,7 @@ async def test_reconnect_zeroconf_cancels_connecting_no_socket(
         assert mock_start_resolve_host.call_count == 1
         assert mock_start_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.CONNECTING
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
     caplog.clear()
@@ -773,7 +773,7 @@ async def test_reconnect_zeroconf_only_cancels_connecting_once(
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert rl._connection_state is ReconnectLogicState.CONNECTING
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
 
     with (
         patch.object(cli, "start_resolve_host") as mock_resolve_2,
@@ -789,7 +789,7 @@ async def test_reconnect_zeroconf_only_cancels_connecting_once(
         assert (
             caplog.text.count("Triggering connect because of received mDNS record") == 1
         )
-        assert rl._accept_zeroconf_records is False
+        assert rl._zc_wake._accept_records is False
 
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -822,7 +822,7 @@ async def test_start_clears_stale_zeroconf_gate(
     """A stop() while the gate is closed must not leak into the next start().
 
     If the logic is stopped mid attempt after an mDNS triggered restart,
-    _accept_zeroconf_records is False. A subsequent start() on the same
+    the wake gate (accept_records) is False. A subsequent start() on the same
     instance must reopen the gate, otherwise the next run would ignore
     mDNS records until its first real failure.
     """
@@ -843,16 +843,16 @@ async def test_start_clears_stale_zeroconf_gate(
         await asyncio.sleep(0)
 
     # Simulate the stop-mid-attempt-with-closed-gate state directly.
-    rl._accept_zeroconf_records = False
+    rl._zc_wake._accept_records = False
     await rl.stop()
     assert rl._is_stopped is True
-    assert rl._accept_zeroconf_records is False
+    assert rl._zc_wake._accept_records is False
 
     with patch.object(cli, "start_resolve_host", side_effect=quick_connect_fail):
         await rl.start()
         await asyncio.sleep(0)
 
-    assert rl._accept_zeroconf_records is True
+    assert rl._zc_wake._accept_records is True
 
     await rl.stop()
 
@@ -892,7 +892,7 @@ async def test_reconnect_zeroconf_does_not_cancel_connecting_with_socket(
         ) as mock_start_connection,
     ):
         assert rl._connection_state is ReconnectLogicState.DISCONNECTED
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
         assert rl._connect_timer is not None
@@ -902,7 +902,7 @@ async def test_reconnect_zeroconf_does_not_cancel_connecting_with_socket(
         assert mock_start_resolve_host.call_count == 1
         assert mock_start_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.CONNECTING
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
     caplog.clear()
@@ -1015,7 +1015,7 @@ async def test_reconnect_zeroconf_not_while_handshaking(
         ) as mock_finish_connection,
     ):
         assert rl._connection_state is ReconnectLogicState.DISCONNECTED
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
         assert rl._connect_timer is not None
@@ -1025,7 +1025,7 @@ async def test_reconnect_zeroconf_not_while_handshaking(
         assert mock_start_connection.call_count == 1
         assert mock_finish_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.HANDSHAKING
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
     rl.async_update_records(
@@ -1073,7 +1073,7 @@ async def test_connect_task_not_cancelled_while_handshaking(
         ) as mock_finish_connection,
     ):
         assert rl._connection_state is ReconnectLogicState.DISCONNECTED
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
         assert rl._connect_timer is not None
@@ -1083,7 +1083,7 @@ async def test_connect_task_not_cancelled_while_handshaking(
         assert mock_start_connection.call_count == 1
         assert mock_finish_connection.call_count == 1
         assert rl._connection_state is ReconnectLogicState.HANDSHAKING
-        assert rl._accept_zeroconf_records is True
+        assert rl._zc_wake._accept_records is True
         assert not rl._is_stopped
 
     caplog.clear()
@@ -1504,11 +1504,11 @@ async def test_reconnect_logic_no_zeroconf_listener_for_ip_addresses(
         await asyncio.sleep(0)
 
         # The listener start is deferred; the arm timer must be scheduled
-        assert logic_with_name._zc_listen_timer is not None
+        assert logic_with_name._zc_wake._timer is not None
         mock_get_zc.assert_not_called()
 
         # Starting the listener for a device name calls get_async_zeroconf
-        logic_with_name._start_zc_listen()
+        logic_with_name._zc_wake.start()
         mock_get_zc.assert_called()
 
         await logic_with_name.stop()
@@ -1663,14 +1663,14 @@ async def test_zc_listen_failure_does_not_block_connect(
 
         # Starting the listener with a broken zeroconf stack must log a
         # warning and leave the connection untouched.
-        logic._start_zc_listen()
+        logic._zc_wake.start()
 
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
     assert log_record is not None, "Expected zeroconf failure warning was not logged"
     assert log_record.levelno == logging.WARNING
-    # _zc_listening must remain False so stop() doesn't try to remove a listener
+    # _listening must remain False so stop() doesn't try to remove a listener
     # we never added.
-    assert logic._zc_listening is False
+    assert logic._zc_wake._listening is False
 
     await logic.stop()
 
@@ -1710,6 +1710,8 @@ async def test_zc_listen_failure_downgrades_to_debug_after_first_try(
         logic._connect_timer._run()
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+        if logic._zc_wake._start_task is not None:
+            await logic._zc_wake._start_task
 
     log_record = find_log_with_message(caplog, "Could not start zeroconf listener")
     assert log_record is not None, "Expected zeroconf failure log was not emitted"
@@ -1913,8 +1915,8 @@ async def test_zc_listen_timer_cancelled_on_fast_connect(
             await asyncio.sleep(0)
 
         assert rl._connection_state is ReconnectLogicState.READY
-        assert rl._zc_listen_timer is None
-        assert rl._zc_listen_start_task is None
+        assert rl._zc_wake._timer is None
+        assert rl._zc_wake._start_task is None
         mock_get_zc.assert_not_called()
 
         await rl.stop()
@@ -1949,8 +1951,8 @@ async def test_zc_listener_delegate_registered_on_failed_attempt(
             await rl.start()
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-            if rl._zc_listen_start_task is not None:
-                await rl._zc_listen_start_task
+            if rl._zc_wake._start_task is not None:
+                await rl._zc_wake._start_task
 
             add_listener.assert_called_once()
             listener, question = add_listener.call_args[0]
@@ -1958,7 +1960,7 @@ async def test_zc_listener_delegate_registered_on_failed_attempt(
             assert listener is not rl
             assert isinstance(listener, RecordUpdateListener)
 
-            with patch.object(rl, "async_update_records") as mock_update:
+            with patch.object(rl._zc_wake, "async_update_records") as mock_update:
                 listener.async_update_records(async_zeroconf.zeroconf, 0.0, [])
             mock_update.assert_called_once_with(async_zeroconf.zeroconf, 0.0, [])
 
@@ -1999,13 +2001,13 @@ async def test_zc_listener_starts_when_timer_fires_mid_attempt(
             await rl.start()
             await resolve_started.wait()
 
-            assert rl._zc_listen_timer is not None
-            rl._start_zc_listen_soon()
-            assert rl._zc_listen_start_task is not None
-            await rl._zc_listen_start_task
+            assert rl._zc_wake._timer is not None
+            rl._zc_wake.start_soon()
+            assert rl._zc_wake._start_task is not None
+            await rl._zc_wake._start_task
 
             add_listener.assert_called_once()
-            assert rl._zc_listening is True
+            assert rl._zc_wake._listening is True
 
             release_resolve.set()
             await asyncio.sleep(0)

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -31,7 +31,7 @@ async def test_does_not_closed_passed_in_sync_instance(async_zeroconf: AsyncZero
 
 async def test_closes_created_instance(async_zeroconf: AsyncZeroconf):
     """Test that the created instance is closed."""
-    with patch("aioesphomeapi.zeroconf.AsyncZeroconf", return_value=async_zeroconf):
+    with patch("zeroconf.asyncio.AsyncZeroconf", return_value=async_zeroconf):
         manager = ZeroconfManager()
         assert manager.get_async_zeroconf() is async_zeroconf
         await manager.async_close()


### PR DESCRIPTION
# What does this implement/fix?

Importing aioesphomeapi always pulled in the zeroconf package, which is the biggest piece of the import cost, about 90ms cold. When the dashboard hands `esphome logs` a pre-resolved IP via `--mdns-address-cache`, the happy path imported zeroconf, registered the mDNS listener, then tore it down as soon as the connection succeeded without it ever doing anything.

zeroconf now loads lazily. `ReconnectLogic` arms a 2s timer when a connect cycle starts; if the connection lands inside that window the timer is cancelled and zeroconf is never imported. If the attempt is still in flight at 2s the listener comes up mid-attempt, so a device that boots right after our SYN got dropped is woken by its boot announcement instead of waiting out a TCP timeout; a failed attempt starts the listener immediately for the backoff wait. The cold import runs in the executor so the event loop never blocks, same pattern as the noise stack loader. Since zeroconf requires a `RecordUpdateListener` subclass at registration, the listener is now a small delegate in `_zc_listener.py`; `ReconnectLogic` keeps its public surface including `async_update_records`.

Measured with `esphome logs` against a live device with a cache hit: time to the first connect attempt drops from 194ms to 170ms median, and the zeroconf stack stays completely unloaded on the happy path. Verified against an unreachable address that the listener still starts 2s into the attempt. `test_lazy_imports.py` now pins zeroconf and ifaddr as deferred.

Note: `aioesphomeapi.zeroconf.ZeroconfInstanceType` is now a type checking only alias and can no longer be imported at runtime; it was never re-exported from the package and no known consumer imports it. `ReconnectLogic.async_update_records` is removed as well; it existed only as the zeroconf listener callback, which now lives on the internal wake handler.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
