### PR TITLE
Add public noise module with sync handshake primitives

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.pxd
+++ b/aioesphomeapi/_frame_helper/noise.pxd
@@ -10,6 +10,9 @@ from .base cimport (
 )
 from .noise_encryption cimport EncryptCipher, DecryptCipher
 
+cdef object decode_noise_psk
+cdef bytes NOISE_PROTOCOL_NAME
+
 cdef bint TYPE_CHECKING
 
 
@@ -81,7 +84,6 @@ cdef class APINoiseFrameHelper(APIFrameHelper):
 
     cdef void _setup_proto(self) except *
 
-    @cython.locals(psk_bytes=bytes)
     cdef _decode_noise_psk(self)
 
     cpdef void write_packets(self, list packets, bint debug_enabled) except *

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import binascii
 import logging
 from typing import TYPE_CHECKING
 
@@ -20,7 +19,13 @@ from ..core import (
     ProtocolAPIError,
 )
 from .base import _LOGGER, APIFrameHelper
-from .noise_encryption import ESPHOME_NOISE_BACKEND, DecryptCipher, EncryptCipher
+from .noise_encryption import (
+    ESPHOME_NOISE_BACKEND,
+    NOISE_PROTOCOL_NAME,
+    DecryptCipher,
+    EncryptCipher,
+    decode_noise_psk,
+)
 
 if TYPE_CHECKING:
     import asyncio
@@ -270,37 +275,20 @@ class APINoiseFrameHelper(APIFrameHelper):
 
     def _decode_noise_psk(self) -> bytes:
         """Decode the given noise psk from base64 format to raw bytes."""
-        psk = self._noise_psk
-        server_name = self._server_name
-        server_mac = self._server_mac
         try:
-            psk_bytes = binascii.a2b_base64(psk)
+            return decode_noise_psk(self._noise_psk)
         except ValueError as err:
-            msg = (
-                f"{self._log_name}: Malformed PSK (length={len(psk)}), "
-                "expected base64-encoded 32-byte value"
-            )
+            msg = f"{self._log_name}: {err}"
             raise InvalidEncryptionKeyAPIError(
                 msg,
-                server_name,
-                server_mac,
+                self._server_name,
+                self._server_mac,
             ) from err
-        if len(psk_bytes) != 32:
-            msg = (
-                f"{self._log_name}: Malformed PSK (length={len(psk)}), "
-                "expected base64-encoded 32-byte value"
-            )
-            raise InvalidEncryptionKeyAPIError(
-                msg,
-                server_name,
-                server_mac,
-            )
-        return psk_bytes
 
     def _setup_proto(self) -> None:
         """Set up the noise protocol."""
         proto = NoiseConnection.from_name(
-            b"Noise_NNpsk0_25519_ChaChaPoly_SHA256", backend=ESPHOME_NOISE_BACKEND
+            NOISE_PROTOCOL_NAME, backend=ESPHOME_NOISE_BACKEND
         )
         proto.set_as_initiator()
         proto.set_psks(self._decode_noise_psk())

--- a/aioesphomeapi/_frame_helper/noise_encryption.pxd
+++ b/aioesphomeapi/_frame_helper/noise_encryption.pxd
@@ -16,4 +16,4 @@ cdef class DecryptCipher:
     cdef uint64_t _nonce
     cdef object _decrypt
 
-    cdef bytes decrypt(self, object frame)
+    cpdef bytes decrypt(self, object frame)

--- a/aioesphomeapi/_frame_helper/noise_encryption.py
+++ b/aioesphomeapi/_frame_helper/noise_encryption.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import binascii
 from functools import partial
 from struct import Struct
 from typing import TYPE_CHECKING, Any
@@ -39,6 +40,24 @@ class ESPHomeNoiseBackend(DefaultNoiseBackend):  # type: ignore[misc]
 
 
 ESPHOME_NOISE_BACKEND = ESPHomeNoiseBackend()
+
+NOISE_PROTOCOL_NAME = b"Noise_NNpsk0_25519_ChaChaPoly_SHA256"
+
+
+def decode_noise_psk(psk: str) -> bytes:
+    """Decode a base64 noise PSK to its raw 32 bytes.
+
+    Raises ValueError when the input is not valid base64 or does not decode
+    to exactly 32 bytes.
+    """
+    msg = f"Malformed PSK (length={len(psk)}), expected base64-encoded 32-byte value"
+    try:
+        psk_bytes = binascii.a2b_base64(psk)
+    except ValueError as err:
+        raise ValueError(msg) from err
+    if len(psk_bytes) != 32:
+        raise ValueError(msg)
+    return psk_bytes
 
 
 class EncryptCipher:

--- a/aioesphomeapi/_frame_helper/noise_encryption.py
+++ b/aioesphomeapi/_frame_helper/noise_encryption.py
@@ -44,19 +44,22 @@ ESPHOME_NOISE_BACKEND = ESPHomeNoiseBackend()
 NOISE_PROTOCOL_NAME = b"Noise_NNpsk0_25519_ChaChaPoly_SHA256"
 
 
+def _malformed_psk_msg(psk: str) -> str:
+    return f"Malformed PSK (length={len(psk)}), expected base64-encoded 32-byte value"
+
+
 def decode_noise_psk(psk: str) -> bytes:
     """Decode a base64 noise PSK to its raw 32 bytes.
 
     Raises ValueError when the input is not valid base64 or does not decode
     to exactly 32 bytes.
     """
-    msg = f"Malformed PSK (length={len(psk)}), expected base64-encoded 32-byte value"
     try:
         psk_bytes = binascii.a2b_base64(psk)
     except ValueError as err:
-        raise ValueError(msg) from err
+        raise ValueError(_malformed_psk_msg(psk)) from err
     if len(psk_bytes) != 32:
-        raise ValueError(msg)
+        raise ValueError(_malformed_psk_msg(psk))
     return psk_bytes
 
 

--- a/aioesphomeapi/_frame_helper/noise_encryption.py
+++ b/aioesphomeapi/_frame_helper/noise_encryption.py
@@ -51,8 +51,10 @@ def _malformed_psk_msg(psk: str) -> str:
 def decode_noise_psk(psk: str) -> bytes:
     """Decode a base64 noise PSK to its raw 32 bytes.
 
-    Raises ValueError when the input is not valid base64 or does not decode
-    to exactly 32 bytes.
+    Decoding is lenient, matching what the API connection path has always
+    accepted: whitespace and other non alphabet characters are ignored.
+    Raises ValueError when the input cannot be decoded or the result is not
+    exactly 32 bytes.
     """
     try:
         psk_bytes = binascii.a2b_base64(psk)

--- a/aioesphomeapi/noise.py
+++ b/aioesphomeapi/noise.py
@@ -43,7 +43,7 @@ class NoiseHandshake:
     ``cryptography.exceptions.InvalidTag`` from ``read_message``.
     """
 
-    __slots__ = ("_proto",)
+    __slots__ = ("_ciphers", "_proto")
 
     def __init__(self, psk: str, prologue: bytes) -> None:
         """Initialize the handshake with a base64 PSK and a prologue."""
@@ -55,6 +55,7 @@ class NoiseHandshake:
         proto.set_prologue(prologue)
         proto.start_handshake()
         self._proto = proto
+        self._ciphers: tuple[EncryptCipher, DecryptCipher] | None = None
 
     def write_message(self) -> bytes:
         """Return the next handshake message to send to the responder."""
@@ -70,9 +71,19 @@ class NoiseHandshake:
         return bool(self._proto.handshake_finished)
 
     def get_ciphers(self) -> tuple[EncryptCipher, DecryptCipher]:
-        """Return the (encrypt, decrypt) transport ciphers after the handshake."""
-        noise_protocol = self._proto.noise_protocol
-        return (
-            EncryptCipher(noise_protocol.cipher_state_encrypt),
-            DecryptCipher(noise_protocol.cipher_state_decrypt),
-        )
+        """Return the (encrypt, decrypt) transport ciphers after the handshake.
+
+        The pair is created once and returned again on later calls; each
+        wrapper keeps its own nonce counter, so handing out fresh wrappers
+        twice would silently reuse nonces under the same key.
+        """
+        if self._ciphers is None:
+            if not self._proto.handshake_finished:
+                msg = "Handshake is not finished"
+                raise RuntimeError(msg)
+            noise_protocol = self._proto.noise_protocol
+            self._ciphers = (
+                EncryptCipher(noise_protocol.cipher_state_encrypt),
+                DecryptCipher(noise_protocol.cipher_state_decrypt),
+            )
+        return self._ciphers

--- a/aioesphomeapi/noise.py
+++ b/aioesphomeapi/noise.py
@@ -1,0 +1,78 @@
+"""Synchronous Noise protocol primitives for ESPHome connections.
+
+This module is deliberately standalone: it is not re-exported from
+``aioesphomeapi.__init__`` and must not be imported at module level anywhere
+else in this package. Importing it pulls in the noiseprotocol and
+cryptography stacks, a cost that plaintext consumers (such as ``esphome
+logs`` without an encryption key) must not pay. Import it lazily, only when
+an encrypted session is actually needed.
+"""
+
+from __future__ import annotations
+
+from noise.connection import NoiseConnection
+
+from ._frame_helper.noise_encryption import (
+    ESPHOME_NOISE_BACKEND,
+    NOISE_PROTOCOL_NAME,
+    DecryptCipher,
+    EncryptCipher,
+    decode_noise_psk,
+)
+
+__all__ = [
+    "DecryptCipher",
+    "EncryptCipher",
+    "NoiseHandshake",
+    "decode_noise_psk",
+]
+
+
+class NoiseHandshake:
+    """Sans-IO initiator for Noise_NNpsk0_25519_ChaChaPoly_SHA256.
+
+    Drives the two-message NNpsk0 handshake without any I/O; the caller moves
+    the messages over its own transport, then takes the transport ciphers:
+
+        handshake = NoiseHandshake(psk, prologue)
+        send(handshake.write_message())
+        handshake.read_message(receive())
+        encrypt_cipher, decrypt_cipher = handshake.get_ciphers()
+
+    A wrong PSK or mismatched prologue surfaces as
+    ``cryptography.exceptions.InvalidTag`` from ``read_message``.
+    """
+
+    __slots__ = ("_proto",)
+
+    def __init__(self, psk: str, prologue: bytes) -> None:
+        """Initialize the handshake with a base64 PSK and a prologue."""
+        proto = NoiseConnection.from_name(
+            NOISE_PROTOCOL_NAME, backend=ESPHOME_NOISE_BACKEND
+        )
+        proto.set_as_initiator()
+        proto.set_psks(decode_noise_psk(psk))
+        proto.set_prologue(prologue)
+        proto.start_handshake()
+        self._proto = proto
+
+    def write_message(self) -> bytes:
+        """Return the next handshake message to send to the responder."""
+        return bytes(self._proto.write_message())
+
+    def read_message(self, data: bytes) -> None:
+        """Process a handshake message received from the responder."""
+        self._proto.read_message(data)
+
+    @property
+    def handshake_finished(self) -> bool:
+        """Return True once both handshake messages have been processed."""
+        return bool(self._proto.handshake_finished)
+
+    def get_ciphers(self) -> tuple[EncryptCipher, DecryptCipher]:
+        """Return the (encrypt, decrypt) transport ciphers after the handshake."""
+        noise_protocol = self._proto.noise_protocol
+        return (
+            EncryptCipher(noise_protocol.cipher_state_encrypt),
+            DecryptCipher(noise_protocol.cipher_state_decrypt),
+        )

--- a/tests/common.py
+++ b/tests/common.py
@@ -20,6 +20,7 @@ from aioesphomeapi import APIClient, APIConnection
 from aioesphomeapi._frame_helper.noise import APINoiseFrameHelper
 from aioesphomeapi._frame_helper.noise_encryption import (
     ESPHOME_NOISE_BACKEND,
+    NOISE_PROTOCOL_NAME,
     EncryptCipher,
 )
 from aioesphomeapi._frame_helper.packets import _cached_varuint_to_bytes
@@ -282,13 +283,15 @@ def _make_encrypted_packet_from_encrypted_payload(encrypted_payload: bytes) -> b
     return encrypted_header + encrypted_payload
 
 
-def _mock_responder_proto(psk_bytes: bytes) -> NoiseConnection:
+def _mock_responder_proto(
+    psk_bytes: bytes, prologue: bytes = b"NoiseAPIInit\x00\x00"
+) -> NoiseConnection:
     proto = NoiseConnection.from_name(
-        b"Noise_NNpsk0_25519_ChaChaPoly_SHA256", backend=ESPHOME_NOISE_BACKEND
+        NOISE_PROTOCOL_NAME, backend=ESPHOME_NOISE_BACKEND
     )
     proto.set_as_responder()
     proto.set_psks(psk_bytes)
-    proto.set_prologue(b"NoiseAPIInit\x00\x00")
+    proto.set_prologue(prologue)
     proto.start_handshake()
     return proto
 

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -20,6 +20,7 @@ DEFERRED_MODULES = (
     "cryptography.hazmat.primitives.ciphers.aead",
     "aioesphomeapi._frame_helper.noise",
     "aioesphomeapi._frame_helper.noise_encryption",
+    "aioesphomeapi.noise",
 )
 
 

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -86,3 +86,22 @@ def test_decode_noise_psk_roundtrip() -> None:
 def test_decode_noise_psk_rejects_bad_input(bad_psk: str) -> None:
     with pytest.raises(ValueError, match="expected base64-encoded 32-byte value"):
         decode_noise_psk(bad_psk)
+
+
+def test_get_ciphers_before_handshake_raises() -> None:
+    """Taking the ciphers before the handshake completes is a caller bug."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    with pytest.raises(RuntimeError, match="Handshake is not finished"):
+        handshake.get_ciphers()
+
+
+def test_get_ciphers_returns_same_pair() -> None:
+    """Repeat calls return the identical wrappers so nonces are never reused."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    responder = _make_responder(PSK, PROLOGUE)
+    responder.read_message(handshake.write_message())
+    handshake.read_message(bytes(responder.write_message()))
+    first = handshake.get_ciphers()
+    assert handshake.get_ciphers() == first
+    assert handshake.get_ciphers()[0] is first[0]
+    assert handshake.get_ciphers()[1] is first[1]

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,88 @@
+"""Tests for the public aioesphomeapi.noise module."""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING
+
+from cryptography.exceptions import InvalidTag
+import pytest
+
+from aioesphomeapi._frame_helper.noise_encryption import DecryptCipher, EncryptCipher
+from aioesphomeapi.noise import NoiseHandshake, decode_noise_psk
+
+from .common import _mock_responder_proto
+
+if TYPE_CHECKING:
+    from noise.connection import NoiseConnection
+
+PSK = base64.b64encode(bytes(range(32))).decode()
+OTHER_PSK = base64.b64encode(bytes(range(1, 33))).decode()
+PROLOGUE = b"NoiseOTAInit-test-prologue"
+
+
+def _make_responder(psk: str, prologue: bytes) -> NoiseConnection:
+    return _mock_responder_proto(decode_noise_psk(psk), prologue)
+
+
+def test_handshake_and_cipher_roundtrip() -> None:
+    """Both handshake messages complete and the split ciphers interoperate."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    responder = _make_responder(PSK, PROLOGUE)
+
+    assert not handshake.handshake_finished
+    responder.read_message(handshake.write_message())
+    handshake.read_message(bytes(responder.write_message()))
+    assert handshake.handshake_finished
+
+    encrypt_cipher, decrypt_cipher = handshake.get_ciphers()
+    responder_decrypt = DecryptCipher(responder.noise_protocol.cipher_state_decrypt)
+    responder_encrypt = EncryptCipher(responder.noise_protocol.cipher_state_encrypt)
+
+    for i in range(5):
+        plaintext = b"frame %d " % i + bytes(200)
+        assert responder_decrypt.decrypt(encrypt_cipher.encrypt(plaintext)) == plaintext
+        assert decrypt_cipher.decrypt(responder_encrypt.encrypt(plaintext)) == plaintext
+
+
+def test_wrong_psk_fails_first_message() -> None:
+    """A responder with a different PSK rejects the first handshake message."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    responder = _make_responder(OTHER_PSK, PROLOGUE)
+    with pytest.raises(InvalidTag):
+        responder.read_message(handshake.write_message())
+
+
+def test_prologue_mismatch_fails_first_message() -> None:
+    """A tampered prologue breaks the handshake even with the right PSK."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    responder = _make_responder(PSK, PROLOGUE + b"tampered")
+    with pytest.raises(InvalidTag):
+        responder.read_message(handshake.write_message())
+
+
+def test_decrypt_rejects_tampered_frame() -> None:
+    """A flipped ciphertext bit fails the AEAD check."""
+    handshake = NoiseHandshake(PSK, PROLOGUE)
+    responder = _make_responder(PSK, PROLOGUE)
+    responder.read_message(handshake.write_message())
+    handshake.read_message(bytes(responder.write_message()))
+    encrypt_cipher, _ = handshake.get_ciphers()
+    responder_decrypt = DecryptCipher(responder.noise_protocol.cipher_state_decrypt)
+
+    ciphertext = bytearray(encrypt_cipher.encrypt(b"payload"))
+    ciphertext[0] ^= 0x01
+    with pytest.raises(InvalidTag):
+        responder_decrypt.decrypt(bytes(ciphertext))
+
+
+def test_decode_noise_psk_roundtrip() -> None:
+    assert decode_noise_psk(PSK) == bytes(range(32))
+
+
+@pytest.mark.parametrize(
+    "bad_psk", ["not-valid-base64!!!", base64.b64encode(b"short").decode()]
+)
+def test_decode_noise_psk_rejects_bad_input(bad_psk: str) -> None:
+    with pytest.raises(ValueError, match="expected base64-encoded 32-byte value"):
+        decode_noise_psk(bad_psk)


### PR DESCRIPTION
# What does this implement/fix?

Exposes the Noise primitives so the ESPHome CLI can encrypt OTA uploads with the same protocol the API uses. Adds a small public `aioesphomeapi.noise` module with a sans IO `NoiseHandshake` initiator, `decode_noise_psk`, and the existing `EncryptCipher`/`DecryptCipher`; the module is standalone and is not imported from the package root, so plaintext consumers like `esphome logs` never pull in the noise or cryptography stacks. Also makes `DecryptCipher.decrypt` callable from Python (it was `cdef` only, so it was unusable from pure Python on compiled wheels).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- enables encrypted OTA in the main ESPHome repo

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#18489

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
