### PR TITLE
Note the frame helper mirrors NoiseHandshake on purpose

### DIFF
--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -286,7 +286,12 @@ class APINoiseFrameHelper(APIFrameHelper):
             ) from err
 
     def _setup_proto(self) -> None:
-        """Set up the noise protocol."""
+        """Set up the noise protocol.
+
+        Mirrors aioesphomeapi.noise.NoiseHandshake rather than delegating to
+        it: this module is cythonized and its hot path and .pxd stay
+        untouched. Keep the two in sync.
+        """
         proto = NoiseConnection.from_name(
             NOISE_PROTOCOL_NAME, backend=ESPHOME_NOISE_BACKEND
         )

--- a/aioesphomeapi/noise.py
+++ b/aioesphomeapi/noise.py
@@ -78,7 +78,7 @@ class NoiseHandshake:
         twice would silently reuse nonces under the same key.
         """
         if self._ciphers is None:
-            if not self._proto.handshake_finished:
+            if not self.handshake_finished:
                 msg = "Handshake is not finished"
                 raise RuntimeError(msg)
             noise_protocol = self._proto.noise_protocol


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1874. Documents that the noise frame helper deliberately mirrors `NoiseHandshake` instead of delegating to it, so the cythonized hot path and its pxd stay untouched, and makes `NoiseHandshake.get_ciphers` use its own public `handshake_finished` property instead of reaching into the connection object.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow up to #1874

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#18489

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
