### PR TITLE
Add public bluetooth_device_disconnect_no_wait

### DIFF
--- a/aioesphomeapi/client.py
+++ b/aioesphomeapi/client.py
@@ -1155,6 +1155,20 @@ class APIClient(APIClientBase):
         )
         raise BluetoothConnectionDroppedError(msg)
 
+    def bluetooth_device_disconnect_no_wait(self, address: int) -> None:
+        """Disconnect from a Bluetooth device without waiting for a response.
+
+        Sends the disconnect request and returns immediately instead of
+        awaiting the device's connection state change, so a cleanup or
+        cancellation path can release the connection slot without an
+        uncancellable wait. The device frees the slot when it processes
+        the request and reports the state change through the usual
+        subscriptions.
+
+        Raises APIConnectionError if the API connection is not open.
+        """
+        self._bluetooth_disconnect_no_wait(address)
+
     def _bluetooth_disconnect_no_wait(self, address: int) -> None:
         """Disconnect from a Bluetooth device without waiting for a response."""
         self._get_connection().send_message(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1809,6 +1809,29 @@ async def test_bluetooth_disconnect(
     await disconnect_task
 
 
+async def test_bluetooth_disconnect_no_wait(
+    api_client: tuple[
+        APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper
+    ],
+) -> None:
+    """Test bluetooth_device_disconnect_no_wait sends without waiting."""
+    client, connection, _transport, _protocol = api_client
+    with patch.object(connection, "send_message") as send:
+        client.bluetooth_device_disconnect_no_wait(1234)
+    send.assert_called_once_with(
+        BluetoothDeviceRequest(
+            address=1234, request_type=BluetoothDeviceRequestType.DISCONNECT
+        )
+    )
+
+
+async def test_bluetooth_disconnect_no_wait_requires_connection() -> None:
+    """Test bluetooth_device_disconnect_no_wait raises when not connected."""
+    client = APIClient(address="1.2.3.4", port=6052, password=None)
+    with pytest.raises(APIConnectionError):
+        client.bluetooth_device_disconnect_no_wait(1234)
+
+
 async def test_bluetooth_pair(
     api_client: tuple[
         APIClient, APIConnection, asyncio.Transport, APIPlaintextFrameHelper


### PR DESCRIPTION
# What does this implement/fix?

Adds a public `bluetooth_device_disconnect_no_wait(address)` that sends the Bluetooth disconnect request and returns immediately instead of awaiting the connection state change. The private `_bluetooth_disconnect_no_wait` already exists and is used by `bluetooth_device_connect`'s own cancellation and error paths to recover the slot; exposing it lets clients such as bleak-esphome release a connection from their own cleanup and cancellation paths without an uncancellable await, the ESP frees the slot when it processes the request and reports the state change through the usual subscriptions. Needed to simplify the shielded release machinery in Bluetooth-Devices/bleak-esphome#422 (part of the slot leak work for home-assistant/core#176516).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to home-assistant/core#176516

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
