### PR TITLE
Build with Cython 3.3.0 by reconciling annotations with the pxd declarations

### DIFF
--- a/aioesphomeapi/_frame_helper/base.py
+++ b/aioesphomeapi/_frame_helper/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
     from ..connection import APIConnection
+    from .packets import Packet
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,9 +145,7 @@ class APIFrameHelper:
         return cstr[original_pos:new_pos]
 
     @abstractmethod
-    def write_packets(
-        self, packets: list[tuple[int, bytes]], debug_enabled: bool
-    ) -> None:
+    def write_packets(self, packets: list[Packet], debug_enabled: bool) -> None:
         """Write a packets to the socket.
 
         Packets are in the format of tuple[protobuf_type, protobuf_data]

--- a/aioesphomeapi/_frame_helper/noise.py
+++ b/aioesphomeapi/_frame_helper/noise.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     import asyncio
 
     from ..connection import APIConnection
+    from .packets import Packet
 
 
 # This is effectively an enum but we don't want to use an enum
@@ -59,13 +60,13 @@ _MAX_EXPLANATION_LEN = MAX_EXPLANATION_LEN
 
 
 def make_noise_packets(
-    packets: list[tuple[int, bytes]], encrypt_cipher: EncryptCipher
+    packets: list[Packet], encrypt_cipher: EncryptCipher
 ) -> list[bytes]:
     """Make a list of noise packet."""
     out: list[bytes] = []
     for packet in packets:
-        type_: int = packet[0]
-        data: bytes = packet[1]
+        type_ = packet[0]
+        data = packet[1]
         data_len = len(data)
         data_header = bytes(
             (
@@ -360,9 +361,7 @@ class APINoiseFrameHelper(APIFrameHelper):
         self._encrypt_cipher = EncryptCipher(noise_protocol.cipher_state_encrypt)  # pylint: disable=no-member
         self.ready_future.set_result(None)
 
-    def write_packets(
-        self, packets: list[tuple[int, bytes]], debug_enabled: bool
-    ) -> None:
+    def write_packets(self, packets: list[Packet], debug_enabled: bool) -> None:
         """Write a packets to the socket.
 
         Packets are in the format of tuple[protobuf_type, protobuf_data]

--- a/aioesphomeapi/_frame_helper/packets.py
+++ b/aioesphomeapi/_frame_helper/packets.py
@@ -2,6 +2,11 @@ from functools import lru_cache
 
 _int = int
 
+# Cython 3.3 checks subscripted annotations against the .pxd signature and
+# has no spelling for the Python int in tuple[int, bytes]; an alias it cannot
+# resolve makes it read the argument as a plain list, as before.
+Packet = tuple[int, bytes]
+
 
 def _varuint_to_bytes(value: _int) -> bytes:
     """Convert a varuint to bytes."""
@@ -24,12 +29,12 @@ _cached_varuint_to_bytes = lru_cache(maxsize=1024)(_varuint_to_bytes)
 varuint_to_bytes = _cached_varuint_to_bytes
 
 
-def make_plain_text_packets(packets: list[tuple[int, bytes]]) -> list[bytes]:
+def make_plain_text_packets(packets: list[Packet]) -> list[bytes]:
     """Make a list of plain text packet."""
     out: list[bytes] = []
     for packet in packets:
-        type_: int = packet[0]
-        data: bytes = packet[1]
+        type_ = packet[0]
+        data = packet[1]
         out.append(b"\0")
         out.append(varuint_to_bytes(len(data)))
         out.append(varuint_to_bytes(type_))

--- a/aioesphomeapi/_frame_helper/plain_text.py
+++ b/aioesphomeapi/_frame_helper/plain_text.py
@@ -9,6 +9,8 @@ from .packets import make_plain_text_packets
 if TYPE_CHECKING:
     import asyncio
 
+    from .packets import Packet
+
 _int = int
 
 # Cap at 4 bytes so the decoded value (max 2**28 - 1) always fits in a signed
@@ -43,9 +45,7 @@ class APIPlaintextFrameHelper(APIFrameHelper):
         super().connection_made(transport)
         self.ready_future.set_result(None)
 
-    def write_packets(
-        self, packets: list[tuple[int, bytes]], debug_enabled: bool
-    ) -> None:
+    def write_packets(self, packets: list[Packet], debug_enabled: bool) -> None:
         """Write a packets to the socket.
 
         Packets are in the format of tuple[protobuf_type, protobuf_data]

--- a/aioesphomeapi/connection.pxd
+++ b/aioesphomeapi/connection.pxd
@@ -78,7 +78,6 @@ cdef tuple MESSAGE_NUMBER_TO_PROTO
 cdef Py_ssize_t _MESSAGE_NUMBER_TO_PROTO_LEN
 
 
-@cython.dataclasses.dataclass
 cdef class ConnectionParams:
 
     cdef public list addresses

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from asyncio import CancelledError
-from dataclasses import astuple, dataclass
+from dataclasses import astuple
 import enum
 from functools import lru_cache, partial
 import logging
@@ -183,7 +183,6 @@ class ConnectionInterruptedError(Exception):
     """An error that is raised when a connection is interrupted."""
 
 
-@dataclass
 class ConnectionParams:
     addresses: list[str]
     port: int
@@ -194,8 +193,34 @@ class ConnectionParams:
     noise_psk: str | None
     expected_name: str | None
     expected_mac: str | None
-    timezone: str | None = None
-    provide_time: bool = True
+    timezone: str | None
+    provide_time: bool
+
+    def __init__(
+        self,
+        addresses: list[str],
+        port: int,
+        password: str | None,
+        client_info: str,
+        keepalive: float,
+        zeroconf_manager: ZeroconfManager,
+        noise_psk: str | None,
+        expected_name: str | None,
+        expected_mac: str | None,
+        timezone: str | None = None,
+        provide_time: bool = True,
+    ) -> None:
+        self.addresses = addresses
+        self.port = port
+        self.password = password
+        self.client_info = client_info
+        self.keepalive = keepalive
+        self.zeroconf_manager = zeroconf_manager
+        self.noise_psk = noise_psk
+        self.expected_name = expected_name
+        self.expected_mac = expected_mac
+        self.timezone = timezone
+        self.provide_time = provide_time
 
 
 class ConnectionState(enum.Enum):

--- a/aioesphomeapi/connection.py
+++ b/aioesphomeapi/connection.py
@@ -183,6 +183,8 @@ class ConnectionInterruptedError(Exception):
     """An error that is raised when a connection is interrupted."""
 
 
+# Not a dataclass: Cython 3.3 rejects an annotated field with a default on a
+# cdef class declared in a .pxd, and the defaults here are public API.
 class ConnectionParams:
     addresses: list[str]
     port: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,24 +104,27 @@ async def conn(connection_params: ConnectionParams) -> APIConnection:
 
 
 @pytest.fixture
-async def conn_with_password(connection_params: ConnectionParams) -> APIConnection:
-    connection_params.password = "password"  # noqa: S105
-    return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
+async def conn_with_password() -> APIConnection:
+    params = get_mock_connection_params()
+    params.password = "password"  # noqa: S105
+    return PatchableAPIConnection(params, mock_on_stop, True, None)
 
 
 @pytest.fixture
-async def noise_conn(connection_params: ConnectionParams) -> APIConnection:
+async def noise_conn() -> APIConnection:
     # Pre-resolve the noise frame helper so connection setup takes the warm
     # inline path; the cold executor import is covered in test_lazy_imports.
     _import_noise_frame_helper()
-    connection_params.noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
-    return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
+    params = get_mock_connection_params()
+    params.noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
+    return PatchableAPIConnection(params, mock_on_stop, True, None)
 
 
 @pytest.fixture
-async def conn_with_expected_name(connection_params: ConnectionParams) -> APIConnection:
-    connection_params.expected_name = "test"
-    return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
+async def conn_with_expected_name() -> APIConnection:
+    params = get_mock_connection_params()
+    params.expected_name = "test"
+    return PatchableAPIConnection(params, mock_on_stop, True, None)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
-from dataclasses import replace
 from functools import partial
 import reprlib
 import socket
@@ -106,7 +105,7 @@ async def conn(connection_params: ConnectionParams) -> APIConnection:
 
 @pytest.fixture
 async def conn_with_password(connection_params: ConnectionParams) -> APIConnection:
-    connection_params = replace(connection_params, password="password")
+    connection_params.password = "password"  # noqa: S105
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 
@@ -115,15 +114,13 @@ async def noise_conn(connection_params: ConnectionParams) -> APIConnection:
     # Pre-resolve the noise frame helper so connection setup takes the warm
     # inline path; the cold executor import is covered in test_lazy_imports.
     _import_noise_frame_helper()
-    connection_params = replace(
-        connection_params, noise_psk="QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
-    )
+    connection_params.noise_psk = "QRTIErOb/fcE9Ukd/5qA3RGYMn0Y+p06U58SCtOXvPc="
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 
 @pytest.fixture
 async def conn_with_expected_name(connection_params: ConnectionParams) -> APIConnection:
-    connection_params = replace(connection_params, expected_name="test")
+    connection_params.expected_name = "test"
     return PatchableAPIConnection(connection_params, mock_on_stop, True, None)
 
 

--- a/tests/test_provide_time.py
+++ b/tests/test_provide_time.py
@@ -7,7 +7,6 @@ for GetTimeRequest and responds to it, otherwise ignores the request.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
 from functools import partial
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -66,7 +65,8 @@ async def _make_connected_conn(
     loop = asyncio.get_running_loop()
     transport = MagicMock()
     connected = asyncio.Event()
-    params = replace(get_mock_connection_params(), provide_time=provide_time)
+    params = get_mock_connection_params()
+    params.provide_time = provide_time
     conn = PatchableAPIConnection(params, mock_on_stop, True, None)
 
     if get_timezone_patch is None:


### PR DESCRIPTION
# What does this implement/fix?

Cython 3.3.0 (released yesterday, and unpinned by `Cython>=3.2.9`) now analyses the annotations in a `.py` file against its `.pxd`, so the `use_cython` jobs on every open PR fail at build time. Three things in our code trip it.

`write_packets`, `make_plain_text_packets` and `make_noise_packets` annotate `packets: list[tuple[int, bytes]]` while the pxd declares `list packets`; Cython compares subscripted types structurally and a pxd has no spelling for the Python `int` inside the tuple, so the signatures never match. The annotation now goes through a `Packet = tuple[int, bytes]` alias that Cython cannot resolve, which makes it read the argument as a plain `list` again; mypy still sees the full type. The `type_: int` and `data: bytes` locals in those loops lose their annotations since the pxd `@cython.locals` already owns them and 3.3.0 reports the pair as a redeclaration.

**Breaking:** `ConnectionParams` is no longer a dataclass. Cython 3.3.0 rejects an annotated field with a default (`timezone: str | None = None`) on a cdef class declared in a pxd, and the one spelling it accepts silently drops the default. It stays a cdef class with the same attributes, constructor signature and defaults, but `dataclasses.replace`, `fields`, `astuple` and the generated `__eq__`/`__repr__` no longer work on it. The tests used `replace`; each fixture now builds its own params and sets the attribute directly. Keeping the dataclass and dropping the two defaults instead would also build, but `timezone=None` and `provide_time=True` are part of the public constructor, so that was rejected.

Verified by generating the Cython annotated HTML and C for 3.2.9 on main and 3.3.0 on this branch. On the same Cython version every `APIConnection`, `APIClientBase` and frame helper function is byte for byte identical, including the packet builders and `write_packets`; the only functions that differ are the `ConnectionParams` ones that changed on purpose. The per line annotation scores show no source line getting worse from this change; the remaining cross version deltas are Cython 3.3.0's own codegen. Full test suite passes on both the compiled and `SKIP_CYTHON` paths, mypy is clean.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
