### PR TITLE
Restore null float fields as NaN in from_dict

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -4,6 +4,7 @@ import contextlib
 from dataclasses import asdict, dataclass, field, fields
 import enum
 from functools import cache, lru_cache, partial
+import math
 from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from .util import fix_float_single_double_conversion
@@ -55,6 +56,11 @@ class APIIntEnum(enum.IntEnum):
 cached_fields = cache(fields)
 
 
+@cache
+def _float_field_names(cls: type[Any]) -> frozenset[str]:
+    return frozenset(f.name for f in cached_fields(cls) if f.type == "float")  # type: ignore[arg-type]
+
+
 @_frozen_dataclass_decorator
 class APIModelBase:
     def __post_init__(self) -> None:
@@ -71,9 +77,16 @@ class APIModelBase:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], *, ignore_missing: bool = True) -> Self:
+        # JSON has no representation for NaN or inf, so serializers such as
+        # orjson emit null; map it back to NaN for float fields.
+        float_fields = _float_field_names(cls)  # type: ignore[arg-type]
         return cls(
             **{
-                f.name: data[f.name]
+                f.name: (
+                    math.nan
+                    if f.name in float_fields and data[f.name] is None
+                    else data[f.name]
+                )
                 for f in cached_fields(cls)  # type: ignore[arg-type]
                 if f.name in data or (not ignore_missing)
             }

--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -58,7 +58,7 @@ cached_fields = cache(fields)
 
 @cache
 def _float_field_names(cls: type[Any]) -> frozenset[str]:
-    return frozenset(f.name for f in cached_fields(cls) if f.type == "float")  # type: ignore[arg-type]
+    return frozenset(f.name for f in cached_fields(cls) if f.type in ("float", float))  # type: ignore[arg-type]
 
 
 @_frozen_dataclass_decorator

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 from typing import TYPE_CHECKING
 
 import pytest
@@ -299,6 +300,15 @@ def test_api_model_base_from_dict():
     ) == DummyAPIModel(val1=-1)
     assert ListAPIModel.from_dict({}) == ListAPIModel()
     assert ListAPIModel.from_dict({"val": []}) == ListAPIModel()
+
+
+def test_api_model_base_from_dict_null_float_becomes_nan() -> None:
+    """Test a null float field (how JSON encodes NaN) is restored as NaN."""
+    restored = SensorState.from_dict({"key": 1, "state": None})
+    assert math.isnan(restored.state)
+    assert restored.key == 1
+    assert SensorState.from_dict({"key": 1, "state": 4.5}).state == 4.5
+    assert DummyAPIModel.from_dict({"val1": None}).val1 is None
 
 
 def test_api_model_base_from_pb():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -306,6 +306,11 @@ def test_api_model_base_from_dict_null_float_becomes_nan() -> None:
     """Test a null float field (how JSON encodes NaN) is restored as NaN."""
     restored = SensorState.from_dict({"key": 1, "state": None})
     assert math.isnan(restored.state)
+    assert math.isnan(
+        ClimateState.from_dict(
+            {"key": 1, "target_temperature": None}
+        ).target_temperature
+    )
     assert restored.key == 1
     assert SensorState.from_dict({"key": 1, "state": 4.5}).state == 4.5
     assert DummyAPIModel.from_dict({"val1": None}).val1 is None


### PR DESCRIPTION
# What does this implement/fix?

JSON has no way to represent NaN or inf, so serializers like orjson write null for those floats. When a model that was serialized with `to_dict` is loaded back with `from_dict`, a float field that was NaN comes back as None instead of a float, which breaks callers that expect a float there. This maps null back to NaN for float fields in `from_dict` so a state cached to JSON restores with the same type it was saved with; Home Assistant needs this to persist deep sleep device states across restarts.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
