### PR TITLE
Add EntityState.with_device_id

### DIFF
--- a/aioesphomeapi/model.py
+++ b/aioesphomeapi/model.py
@@ -415,6 +415,12 @@ class EntityState(APIModelBase):
     key: int = 0
     device_id: int = 0
 
+    def with_device_id(self, device_id: int) -> Self:
+        """Return a copy of this state that belongs to another device."""
+        values = {f.name: getattr(self, f.name) for f in cached_fields(type(self))}  # type: ignore[arg-type]
+        values["device_id"] = device_id
+        return type(self)(**values)
+
 
 @_frozen_dataclass_decorator
 class CommandProtoMessage(APIModelBase):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -304,6 +304,14 @@ def test_api_model_base_from_dict():
     assert ListAPIModel.from_dict({"val": []}) == ListAPIModel()
 
 
+def test_entity_state_with_device_id() -> None:
+    """Test with_device_id returns a copy with only the device id changed."""
+    state = SensorState(key=1, state=4.5, device_id=1)
+    moved = state.with_device_id(2)
+    assert moved == SensorState(key=1, state=4.5, device_id=2)
+    assert state.device_id == 1
+
+
 def test_api_model_base_from_dict_null_float_becomes_nan() -> None:
     """Test a null float field (how JSON encodes NaN) is restored as NaN."""
     restored = SensorState.from_dict({"key": 1, "state": None})


### PR DESCRIPTION
# What does this implement/fix?

Adds `EntityState.with_device_id(device_id)`, which returns a copy of a state that belongs to another device. Home Assistant needs this when an entity moves between sub devices and its cached state has to follow it to the new slot; the models are built with `partial(dataclass, ...)` so mypy does not accept `dataclasses.replace` on them, and a typed helper here avoids a type ignore in every consumer.

## Types of changes

<!--
If the change relies on change in the main esphome repo
(https://github.com/esphome/esphome), please be sure to link
to the pull request in that repo.

If you change api.proto, the change must be done first in the main esphome repo.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] If api.proto was modified, a linked pull request has been made to [esphome](https://github.com/esphome/esphome) with the same changes.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
